### PR TITLE
Fix bug in matching price.

### DIFF
--- a/src/os-mapping.ts
+++ b/src/os-mapping.ts
@@ -493,15 +493,8 @@ function _calculateMatchPrice(
   sellExprirationTime: BigInt,
   sellFeeRecipient: Address
 ): BigInt {
-  let buyPrice = _calculateFinalPrice(
-    buySide,
-    buySaleKind,
-    buyBasePrice,
-    buyExtra,
-    buyLinstingTime,
-    buyExprirationTime
-  );
-  let sellPrice = _calculateFinalPrice(
+
+   let sellPrice = _calculateFinalPrice(
     sellSide,
     sellSaleKind,
     sellBasePrice,
@@ -510,5 +503,14 @@ function _calculateMatchPrice(
     sellExprirationTime
   );
 
-  return sellFeeRecipient.toHexString() == NULL_ADDRESS ? sellPrice : buyPrice;
+  let buyPrice = _calculateFinalPrice(
+    buySide,
+    buySaleKind,
+    buyBasePrice,
+    buyExtra,
+    buyLinstingTime,
+    buyExprirationTime
+  );
+
+  return sellFeeRecipient.toHexString() != NULL_ADDRESS ? sellPrice : buyPrice;
 }


### PR DESCRIPTION
Quick fix on the OpenSea matching price function. A wrong comparaison was causing the graph to index a wrong price for the sale.