### PR TITLE
guardedArrayReplace fix

### DIFF
--- a/src/os-helper.ts
+++ b/src/os-helper.ts
@@ -133,6 +133,9 @@ export function guardedArrayReplace(
 ): Bytes {
   // Sometime the replacementPattern is empty, meaning that both arrays (buyCallData and sellCallData) are identicall and
   // no merging is necessary. In such a case randomly return the first array (buyCallData)
+  // Also note, that outside of the case that mask length is zero, a require on the contract
+  // will revert the transaction if all arrays are not the same length so there's no need
+  // to check for that here.
   if (mask.length == 0) {
     return array;
   }


### PR DESCRIPTION
This fixes a bug in guardedArrayReplace that was cause certain OS sales to no be indexed. The logic is pulled from https://github.com/ArtBlocks/artblocks-subgraph/pull/48 with some minor updates.