### PR TITLE
add goerli dev minters to config

### DIFF
--- a/config/goerli-dev.json
+++ b/config/goerli-dev.json
@@ -73,5 +73,17 @@
       "name": "Art Blocks x Pace Minter",
       "startBlock": 7010933
     }
+  ],
+  "minterHolderV0Contracts": [
+    {
+      "address": "0xA9a7974d92eCD49C4E3F19937eDb9e3173dF1fd6",
+      "startBlock": 7105455
+    }
+  ],
+  "minterMerkleV0Contracts": [
+    {
+      "address": "0xE14757AC0075898Ad3343e22D828FAaeF2bb7595",
+      "startBlock": 7105457
+    }
   ]
 }


### PR DESCRIPTION
deployed new minters on goerli dev.

deployment logs:
```
Using MinterFilterV0 deployed at 0x7c4FB14F0c020109cB95A9B92BC4c8267C421Cc4
MinterHolderV0 deployed at 0xA9a7974d92eCD49C4E3F19937eDb9e3173dF1fd6
MinterMerkleV0 deployed at 0xE14757AC0075898Ad3343e22D828FAaeF2bb7595
REMINDER: Allowlist the Minters on your MinterFilter located at: 0x7c4FB14F0c020109cB95A9B92BC4c8267C421Cc4,ONLY after you have added the new subgraph types to the enum in the subgraph schema's enum MinterType!
```