### PR TITLE
fix bug where minterAllowlist not being updated, add tests to catch in future

### DIFF
--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -1300,13 +1300,13 @@ export class MinterFilter extends Entity {
     this.set("minterAllowlist", Value.fromStringArray(value));
   }
 
-  get minters(): Array<string> {
-    let value = this.get("minters");
+  get associatedMinters(): Array<string> {
+    let value = this.get("associatedMinters");
     return value!.toStringArray();
   }
 
-  set minters(value: Array<string>) {
-    this.set("minters", Value.fromStringArray(value));
+  set associatedMinters(value: Array<string>) {
+    this.set("associatedMinters", Value.fromStringArray(value));
   }
 
   get updatedAt(): BigInt {

--- a/src/minter-filter-mapping.ts
+++ b/src/minter-filter-mapping.ts
@@ -111,7 +111,9 @@ export function handleMinterApproved(event: MinterApproved): void {
 
   // add minter to the list of allowlisted minters if it's not already there
   if (!minterFilter.minterAllowlist.includes(minter.id)) {
-    minterFilter.minterAllowlist.push(minter.id);
+    minterFilter.minterAllowlist = minterFilter.minterAllowlist.concat([
+      minter.id
+    ]);
     minterFilter.updatedAt = event.block.timestamp;
     minterFilter.save();
   }


### PR DESCRIPTION
This fixes a bug where `array.push` did not actually update the MinterFilter entity's `minterAllowlist` array.

Also added tests to catch this in the future.

I think the generated/schema updates are just catching up to main (didn't expect them to be updated with this PR)