### PR TITLE
Handle non-unicode bytes data in handleSetValueGeneric

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,7 +2,6 @@ import {
   Address,
   BigInt,
   Bytes,
-  ethereum,
   json,
   JSONValue,
   JSONValueKind,
@@ -75,6 +74,7 @@ export function loadOrCreateMinter(
   minter.coreContract = filteredMinterContract
     .genArt721CoreAddress()
     .toHexString();
+  minter.extraMinterDetails = "{}";
 
   // values assigned during contract deployments
   let minterType = filteredMinterContract.minterType();
@@ -172,6 +172,17 @@ export function stringToJSONValue(value: string): JSONValue {
 }
 export function arrayToJSONValue(value: string): JSONValue {
   return json.fromString("[" + value + "]");
+}
+
+// If byte data is parseable to a valid unicode string then do so
+// otherwise parse the byte data to a hex string
+export function bytesToJSONValue(value: Bytes): JSONValue {
+  // If the bytes cannot be
+  let result = json.try_fromString('["' + value.toString() + '"]');
+  if (result.isError) {
+    result = json.try_fromString('["' + value.toHexString() + '"]');
+  }
+  return result.value.toArray()[0];
 }
 
 export function stringToJSONString(value: string): string {

--- a/src/minter-filter-mapping.ts
+++ b/src/minter-filter-mapping.ts
@@ -237,6 +237,10 @@ function loadOrCreateAndSetProjectMinterConfiguration(
     projectMinterConfig.project = project.id;
     projectMinterConfig.minter = minterAddress.toHexString();
     projectMinterConfig.priceIsConfigured = false;
+    projectMinterConfig.currencySymbol = "ETH";
+    projectMinterConfig.currencyAddress = Address.zero();
+    projectMinterConfig.purchaseToDisabled = false;
+    projectMinterConfig.extraMinterDetails = "{}";
     projectMinterConfig.save();
   }
 

--- a/src/minter-suite-mapping.ts
+++ b/src/minter-suite-mapping.ts
@@ -49,6 +49,7 @@ import {
 import {
   arrayToJSONValue,
   booleanToString,
+  bytesToJSONValue,
   generateContractSpecificId,
   getMinterDetails,
   getProjectMinterConfigId,
@@ -553,7 +554,7 @@ export function handleSetValueGeneric<T, C>(
   } else if (event instanceof ConfigValueSetAddress) {
     jsonValue = stringToJSONValue(event.params._value.toHexString());
   } else if (event instanceof ConfigValueSetBytes) {
-    jsonValue = stringToJSONValue(event.params._value.toString());
+    jsonValue = bytesToJSONValue(event.params._value);
   }
 
   minterDetails.set(jsonKey, jsonValue);
@@ -966,15 +967,17 @@ function loadMinterProjectAndConfig(
   let projectMinterConfig = ProjectMinterConfiguration.load(
     getProjectMinterConfigId(minter.id, project.id)
   );
-  if (
-    !projectMinterConfig ||
-    projectMinterConfig.minter != minterAddress.toHexString()
-  ) {
+  if (!projectMinterConfig) {
     projectMinterConfig = new ProjectMinterConfiguration(
       getProjectMinterConfigId(minter.id, project.id)
     );
     projectMinterConfig.project = project.id;
     projectMinterConfig.minter = minterAddress.toHexString();
+    projectMinterConfig.priceIsConfigured = false;
+    projectMinterConfig.currencySymbol = "ETH";
+    projectMinterConfig.currencyAddress = Address.zero();
+    projectMinterConfig.purchaseToDisabled = false;
+    projectMinterConfig.extraMinterDetails = "{}";
     projectMinterConfig.save();
   }
 

--- a/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
+++ b/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
@@ -1631,6 +1631,44 @@ test("handleSetValue should set all values to a designated key in extraMinterDet
       "," +
       '"bigInt":100,"boolean":true,"bytes":"im bytes"}'
   );
+
+  // If the bytes are not intended to be a human readable string
+  // we should instead convert to their hex string representation
+  const eventValue = randomAddressGenerator.generateRandomAddress();
+  const configValueSetEvent4: ConfigValueSetBytes = changetype<
+    ConfigValueSetBytes
+  >(newMockEvent());
+  configValueSetEvent4.address = minterAddress;
+  configValueSetEvent4.parameters = [
+    new ethereum.EventParam(
+      "_projectId",
+      ethereum.Value.fromUnsignedBigInt(projectId)
+    ),
+    new ethereum.EventParam(
+      "_key",
+      ethereum.Value.fromBytes(Bytes.fromUTF8("bytes"))
+    ),
+    new ethereum.EventParam("_value", ethereum.Value.fromBytes(eventValue))
+  ];
+  configValueSetEvent4.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
+
+  handleSetBytesValue(configValueSetEvent4);
+
+  assert.fieldEquals(
+    PROJECT_MINTER_CONFIGURATION_ENTITY_TYPE,
+    getProjectMinterConfigId(minterAddress.toHexString(), project.id),
+    "extraMinterDetails",
+    '{"address":' +
+      '"' +
+      addressString +
+      '"' +
+      "," +
+      '"bigInt":100,"boolean":true,"bytes":' +
+      '"' +
+      eventValue.toHexString() +
+      '"' +
+      "}"
+  );
 });
 test("handleAddManyBigIntValue should add a value to an array at a designated key extraMinterDetails", () => {
   clearStore();


### PR DESCRIPTION
Our ConfigValueSet handler for bytes values was previously set up to treat all values as encoded unicode strings.  However, we've realized that this is not always the correct assumption. For example, the Merkle tree roots that we store in MinterMerkleV0 are hex-encoded raw binary data that cannot be parsed into a valid string. In attempting to do so, we hit an error while creating a JSON object that brought down our dev subgraph. This PR fixes that issue by checking if the bytes data can successfully be parsed to a unicode string, and if not we instead store the data as the hex representation of the bytes.

Additionally this PR makes sure that new Minter and ProjectMinterConfig objects are always saved with all required fields.  This was necessary after updating the graph-ts library.