### PR TITLE
add missing handlers for merkle and holder minters

### DIFF
--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -760,6 +760,10 @@ dataSources:
         - name: IFilteredMinterV0
           file: ./abis/IFilteredMinterV0.json
       eventHandlers:
+        - event: PricePerTokenInWeiUpdated(indexed uint256,indexed uint256)
+          handler: handlePricePerTokenInWeiUpdated
+        - event: ProjectCurrencyInfoUpdated(indexed uint256,indexed address,string)
+          handler: handleProjectCurrencyInfoUpdated
         - event: RegisteredNFTAddress(indexed address)
           handler: handleRegisteredNFTAddress
         - event: UnregisteredNFTAddress(indexed address)
@@ -794,6 +798,10 @@ dataSources:
         - name: IFilteredMinterV0
           file: ./abis/IFilteredMinterV0.json
       eventHandlers:
+        - event: PricePerTokenInWeiUpdated(indexed uint256,indexed uint256)
+          handler: handlePricePerTokenInWeiUpdated
+        - event: ProjectCurrencyInfoUpdated(indexed uint256,indexed address,string)
+          handler: handleProjectCurrencyInfoUpdated
         - event: ConfigValueSet(indexed uint256,bytes32,bytes32)
           handler: handleSetBytesValueProjectConfig
         - event: ConfigValueSet(indexed uint256,bytes32,bool)


### PR DESCRIPTION
add missing handlers to subgraph template yaml file for the new Merkle and Holder minters.

please double check my work here. I'll also deploy the fix. We should probably also refactor our Minter tests to prevent this from happening in the future.