### PR TITLE
V3/Handle propose/accept artist addresses and splits

### DIFF
--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -859,6 +859,15 @@ export class ProposedArtistAddressesAndSplits extends Entity {
   set project(value: string) {
     this.set("project", Value.fromString(value));
   }
+
+  get createdAt(): BigInt {
+    let value = this.get("createdAt");
+    return value!.toBigInt();
+  }
+
+  set createdAt(value: BigInt) {
+    this.set("createdAt", Value.fromBigInt(value));
+  }
 }
 
 export class Contract extends Entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -160,6 +160,8 @@ type ProposedArtistAddressesAndSplits @entity {
 
   "Project associated with this proposed artist addresses and splits"
   project: Project!
+  
+  createdAt: BigInt!
 }
 
 enum CoreType {

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -22,7 +22,8 @@ import {
   AccountProject,
   ProjectScript,
   Contract,
-  MinterFilter
+  MinterFilter,
+  ProposedArtistAddressesAndSplits
 } from "../generated/schema";
 
 import {

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -570,17 +570,9 @@ export function handleProposedArtistAddressesAndSplits(
   if (!project) {
     return;
   }
-  // remove any existing proposed artist addresses and splits
-  const existingProposedArtistAddressesAndSplitsId =
-    project.proposedArtistAddressesAndSplits;
-  if (existingProposedArtistAddressesAndSplitsId !== null) {
-    project.proposedArtistAddressesAndSplits = null;
-    store.remove(
-      "ProposedArtistAddressesAndSplits",
-      existingProposedArtistAddressesAndSplitsId
-    );
-  }
   // create new proposed artist addresses and splits entity
+  // note: any existing proposal entity will be overwritten, which is intended
+  // all fields will be populated.
   const proposedArtistAddressesAndSplits = new ProposedArtistAddressesAndSplits(
     newEntityId
   );

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -288,11 +288,11 @@ export function handleAcceptedArtistAddressesAndSplits(
   event: AcceptedArtistAddressesAndSplits
 ): void {
   // load associated project entity
-  const newEntityId = generateContractSpecificId(
+  const entityId = generateContractSpecificId(
     event.address,
     event.params._projectId
   );
-  const project = Project.load(newEntityId);
+  const project = Project.load(entityId);
   if (!project) {
     return;
   }
@@ -303,18 +303,18 @@ export function handleAcceptedArtistAddressesAndSplits(
     // we don't expect this state to be possible, so we should log a warning
     log.warning(
       "[WARN] No proposed artist addresses and splits found on project {}.",
-      [newEntityId]
+      [entityId]
     );
     return;
   }
   const proposedArtistAddressesAndSplits = ProposedArtistAddressesAndSplits.load(
-    newEntityId
+    entityId
   );
   if (!proposedArtistAddressesAndSplits) {
     // we dont expect this state to be possible, so we should log a warning
     log.warning(
       "[WARN] No proposed artist addresses and splits found with id {}.",
-      [newEntityId]
+      [entityId]
     );
     return;
   }
@@ -328,11 +328,12 @@ export function handleAcceptedArtistAddressesAndSplits(
     proposedArtistAddressesAndSplits.additionalPayeeSecondarySalesAddress;
   project.additionalPayeeSecondarySalesPercentage =
     proposedArtistAddressesAndSplits.additionalPayeeSecondarySalesPercentage;
-  // keep the proposed artist addresses and splits entity because it still
-  // exists on the blockchain, and admin could still "accept" it again (even
-  // though it wouldn't change anything)
+  // clear the existing proposed artist addresses and splits
+  project.proposedArtistAddressesAndSplits = null;
   project.updatedAt = event.block.timestamp;
   project.save();
+  // remove the existing proposed artist addresses and splits entity from store
+  store.remove("ProposedArtistAddressesAndSplits", entityId);
 }
 
 /*** END EVENT HANDLERS ***/

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -594,7 +594,6 @@ export function handleProposedArtistAddressesAndSplits(
     event.params._additionalPayeeSecondarySales;
   proposedArtistAddressesAndSplits.additionalPayeeSecondarySalesPercentage =
     event.params._additionalPayeeSecondarySalesPercentage;
-  proposedArtistAddressesAndSplits.createdAt = event.block.timestamp;
   proposedArtistAddressesAndSplits.project = project.id;
   // save new entity to store
   proposedArtistAddressesAndSplits.createdAt = event.block.timestamp;

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -38,6 +38,10 @@ dataSources:
           handler: handlePlatformUpdated
         - event: MinterUpdated(indexed address)
           handler: handleMinterUpdated
+        - event: ProposedArtistAddressesAndSplits(indexed uint256,address,address,uint256,address,uint256)
+          handler: handleProposedArtistAddressesAndSplits
+        - event: AcceptedArtistAddressesAndSplits(indexed uint256)
+          handler: handleAcceptedArtistAddressesAndSplits
       file: ./src/mapping-v3-core.ts
   {{/genArt721CoreV3Contracts}}
   {{#genArt721CoreContracts}}

--- a/tests/subgraph/mapping-v3-core/helpers.ts
+++ b/tests/subgraph/mapping-v3-core/helpers.ts
@@ -92,10 +92,28 @@ export function mockRefreshContractCalls(
     "artblocksPrimarySalesAddress():(address)"
   ).returns([ethereum.Value.fromAddress(TEST_CONTRACT.renderProviderAddress)]);
 
+  // Note: not used in V3 sync, but good to add backwards-compatible mock here
+  //for the backwards-compatible V3 external function
+  createMockedFunction(
+    TEST_CONTRACT_ADDRESS,
+    "artblocksAddress",
+    "artblocksAddress():(address)"
+  ).returns([ethereum.Value.fromAddress(TEST_CONTRACT.renderProviderAddress)]);
+
   createMockedFunction(
     TEST_CONTRACT_ADDRESS,
     "artblocksPrimarySalesPercentage",
     "artblocksPrimarySalesPercentage():(uint256)"
+  ).returns([
+    ethereum.Value.fromUnsignedBigInt(TEST_CONTRACT.renderProviderPercentage)
+  ]);
+
+  // Note: not used in V3 sync, but good to add backwards-compatible mock here
+  //for the backwards-compatible V3 external function
+  createMockedFunction(
+    TEST_CONTRACT_ADDRESS,
+    "artblocksPercentage",
+    "artblocksPercentage():(uint256)"
   ).returns([
     ethereum.Value.fromUnsignedBigInt(TEST_CONTRACT.renderProviderPercentage)
   ]);

--- a/tests/subgraph/mapping-v3-core/mapping-v3-core-proposed-addresses-splits.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-core-proposed-addresses-splits.test.ts
@@ -37,13 +37,14 @@ import {
   assertNewProjectFields,
   assertTestContractFields,
   addTestContractToStore,
+  addNewProjectToStore,
   addNewTokenToStore,
   addNewContractToStore,
   TRANSFER_ENTITY_TYPE,
   DEFAULT_COLLECTION
 } from "../shared-helpers";
 
-import { mockRefreshContractCalls, addNewProjectToStore } from "./helpers";
+import { mockRefreshContractCalls } from "./helpers";
 
 import {
   Account,
@@ -81,11 +82,11 @@ test("GenArt721CoreV3/ProposedAddressesAndSplits: should handle new artist propo
   mockRefreshContractCalls(BigInt.fromI32(2), null);
 
   addNewProjectToStore(
+    TEST_CONTRACT_ADDRESS,
     projectId,
     projectName,
     artistAddress,
     pricePerTokenInWei,
-    true,
     CURRENT_BLOCK_TIMESTAMP
   );
 
@@ -202,11 +203,11 @@ test("GenArt721CoreV3/ProposedAddressesAndSplits: should overwrite new artist pr
   mockRefreshContractCalls(BigInt.fromI32(2), null);
 
   addNewProjectToStore(
+    TEST_CONTRACT_ADDRESS,
     projectId,
     projectName,
     artistAddress,
     pricePerTokenInWei,
-    true,
     CURRENT_BLOCK_TIMESTAMP
   );
 
@@ -379,11 +380,11 @@ test("GenArt721CoreV3/AcceptedArtistAddressesAndSplits: should update Project, a
   mockRefreshContractCalls(BigInt.fromI32(2), null);
 
   addNewProjectToStore(
+    TEST_CONTRACT_ADDRESS,
     projectId,
     projectName,
     artistAddress,
     pricePerTokenInWei,
-    true,
     CURRENT_BLOCK_TIMESTAMP
   );
 

--- a/tests/subgraph/mapping-v3-core/mapping-v3-core-proposed-addresses-splits.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-core-proposed-addresses-splits.test.ts
@@ -1,0 +1,191 @@
+import {
+  assert,
+  clearStore,
+  test,
+  newMockCall,
+  log,
+  logStore,
+  createMockedFunction,
+  newMockEvent
+} from "matchstick-as/assembly/index";
+import { BigInt, Bytes, ethereum, store, Value } from "@graphprotocol/graph-ts";
+import {
+  ACCOUNT_ENTITY_TYPE,
+  PROJECT_ENTITY_TYPE,
+  CONTRACT_ENTITY_TYPE,
+  WHITELISTING_ENTITY_TYPE,
+  PROJECT_SCRIPT_ENTITY_TYPE,
+  TOKEN_ENTITY_TYPE,
+  DEFAULT_PROJECT_VALUES,
+  CURRENT_BLOCK_TIMESTAMP,
+  RandomAddressGenerator,
+  mockProjectScriptByIndex,
+  mockTokenIdToHash,
+  PROJECT_MINTER_CONFIGURATION_ENTITY_TYPE,
+  TEST_CONTRACT_ADDRESS,
+  TEST_CONTRACT_CREATED_AT,
+  TEST_CONTRACT,
+  TEST_TOKEN_HASH,
+  TEST_TX_HASH,
+  assertNewProjectFields,
+  assertTestContractFields,
+  addTestContractToStore,
+  addNewTokenToStore,
+  addNewContractToStore,
+  TRANSFER_ENTITY_TYPE,
+  DEFAULT_COLLECTION
+} from "../shared-helpers";
+
+import { mockRefreshContractCalls, addNewProjectToStore } from "./helpers";
+
+import {
+  Account,
+  Contract,
+  MinterFilter,
+  Project,
+  ProjectMinterConfiguration,
+  ProjectScript,
+  Token,
+  Whitelisting
+} from "../../../generated/schema";
+import {
+  Mint,
+  Transfer,
+  PlatformUpdated,
+  ProposedArtistAddressesAndSplits,
+  AcceptedArtistAddressesAndSplits
+} from "../../../generated/GenArt721CoreV3/GenArt721CoreV3";
+import {
+  handleProposedArtistAddressesAndSplits,
+  handleAcceptedArtistAddressesAndSplits
+} from "../../../src/mapping-v3-core";
+import { generateContractSpecificId } from "../../../src/helpers";
+
+const randomAddressGenerator = new RandomAddressGenerator();
+
+test("GenArt721CoreV3/ProposedAddressesAndSplits: should handle new artist proposal", () => {
+  clearStore();
+  // add project to store
+  const projectId = BigInt.fromI32(1);
+  const artistAddress = randomAddressGenerator.generateRandomAddress();
+  const projectName = "Test Project";
+  const pricePerTokenInWei = BigInt.fromI64(i64(1e18));
+
+  mockRefreshContractCalls(BigInt.fromI32(2), null);
+
+  addNewProjectToStore(
+    projectId,
+    projectName,
+    artistAddress,
+    pricePerTokenInWei,
+    true,
+    CURRENT_BLOCK_TIMESTAMP
+  );
+
+  const fullProjectId = generateContractSpecificId(
+    TEST_CONTRACT_ADDRESS,
+    projectId
+  );
+
+  // handle artist proposal
+  const newArtistAddress = randomAddressGenerator.generateRandomAddress();
+  const additionalPayeePrimarySalesAddress = randomAddressGenerator.generateRandomAddress();
+  const additionalPayeePrimarySalesPercentage = BigInt.fromI32(10);
+  const additionalPayeeSecondarySalesAddress = randomAddressGenerator.generateRandomAddress();
+  const additionalPayeeSecondarySalesPercentage = BigInt.fromI32(49);
+
+  const updatedEventBlockTimestamp = CURRENT_BLOCK_TIMESTAMP.plus(
+    BigInt.fromI32(10)
+  );
+
+  const event: ProposedArtistAddressesAndSplits = changetype<
+    ProposedArtistAddressesAndSplits
+  >(newMockEvent());
+  event.address = TEST_CONTRACT_ADDRESS;
+  event.transaction.hash = TEST_TX_HASH;
+  event.logIndex = BigInt.fromI32(0);
+  event.parameters = [
+    new ethereum.EventParam(
+      "_projectId",
+      ethereum.Value.fromUnsignedBigInt(projectId)
+    ),
+    new ethereum.EventParam(
+      "_artistAddress",
+      ethereum.Value.fromAddress(newArtistAddress)
+    ),
+    new ethereum.EventParam(
+      "_additionalPayeePrimarySales",
+      ethereum.Value.fromAddress(additionalPayeePrimarySalesAddress)
+    ),
+    new ethereum.EventParam(
+      "_additionalPayeePrimarySalesPercentage",
+      ethereum.Value.fromUnsignedBigInt(additionalPayeePrimarySalesPercentage)
+    ),
+    new ethereum.EventParam(
+      "_additionalPayeeSecondarySales",
+      ethereum.Value.fromAddress(additionalPayeeSecondarySalesAddress)
+    ),
+    new ethereum.EventParam(
+      "_additionalPayeeSecondarySalesPercentage",
+      ethereum.Value.fromUnsignedBigInt(additionalPayeeSecondarySalesPercentage)
+    )
+  ];
+  event.block.timestamp = updatedEventBlockTimestamp;
+
+  handleProposedArtistAddressesAndSplits(event);
+
+  assert.fieldEquals(
+    "ProposedArtistAddressesAndSplits",
+    fullProjectId,
+    "id",
+    fullProjectId
+  );
+  assert.fieldEquals(
+    "ProposedArtistAddressesAndSplits",
+    fullProjectId,
+    "project",
+    fullProjectId
+  );
+  assert.fieldEquals(
+    "ProposedArtistAddressesAndSplits",
+    fullProjectId,
+    "artistAddress",
+    newArtistAddress.toHexString()
+  );
+  assert.fieldEquals(
+    "ProposedArtistAddressesAndSplits",
+    fullProjectId,
+    "additionalPayeePrimarySalesAddress",
+    additionalPayeePrimarySalesAddress.toHexString()
+  );
+  assert.fieldEquals(
+    "ProposedArtistAddressesAndSplits",
+    fullProjectId,
+    "additionalPayeePrimarySalesPercentage",
+    additionalPayeePrimarySalesPercentage.toString()
+  );
+  assert.fieldEquals(
+    "ProposedArtistAddressesAndSplits",
+    fullProjectId,
+    "additionalPayeeSecondarySalesAddress",
+    additionalPayeeSecondarySalesAddress.toHexString()
+  );
+  assert.fieldEquals(
+    "ProposedArtistAddressesAndSplits",
+    fullProjectId,
+    "additionalPayeeSecondarySalesPercentage",
+    additionalPayeeSecondarySalesPercentage.toString()
+  );
+  assert.fieldEquals(
+    "ProposedArtistAddressesAndSplits",
+    fullProjectId,
+    "createdAt",
+    updatedEventBlockTimestamp.toString()
+  );
+});
+
+// export handlers for test coverage https://github.com/LimeChain/demo-subgraph#test-coverage
+export {
+  handleProposedArtistAddressesAndSplits,
+  handleAcceptedArtistAddressesAndSplits
+};

--- a/tests/subgraph/mapping-v3-core/mapping-v3-core-proposed-addresses-splits.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-core-proposed-addresses-splits.test.ts
@@ -56,7 +56,8 @@ import {
   ProjectMinterConfiguration,
   ProjectScript,
   Token,
-  Whitelisting
+  Whitelisting,
+  ProposedArtistAddressesAndSplits as ProposedArtistAddressesAndSplitsEntity
 } from "../../../generated/schema";
 import {
   Mint,
@@ -72,13 +73,13 @@ import {
 import { generateContractSpecificId } from "../../../src/helpers";
 
 const randomAddressGenerator = new RandomAddressGenerator();
+const artistAddress = randomAddressGenerator.generateRandomAddress();
 
 describe("GenArt721CoreV3, artist propose/admin accept new payments", () => {
   beforeEach(() => {
     clearStore();
     // add project to store
     const projectId = BigInt.fromI32(1);
-    const artistAddress = randomAddressGenerator.generateRandomAddress();
     const projectName = "Test Project";
     const pricePerTokenInWei = BigInt.fromI64(i64(1e18));
 
@@ -95,6 +96,69 @@ describe("GenArt721CoreV3, artist propose/admin accept new payments", () => {
   });
 
   describe("ProposedAddressesAndSplits", () => {
+    test("should do nothing if project not in store", () => {
+      clearStore();
+      const projectId = BigInt.fromI32(1);
+      const fullProjectId = generateContractSpecificId(
+        TEST_CONTRACT_ADDRESS,
+        projectId
+      );
+
+      // handle artist proposal
+      const newArtistAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeePrimarySalesAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeePrimarySalesPercentage = BigInt.fromI32(10);
+      const additionalPayeeSecondarySalesAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeeSecondarySalesPercentage = BigInt.fromI32(49);
+
+      const updatedEventBlockTimestamp = CURRENT_BLOCK_TIMESTAMP.plus(
+        BigInt.fromI32(10)
+      );
+
+      const event: ProposedArtistAddressesAndSplits = changetype<
+        ProposedArtistAddressesAndSplits
+      >(newMockEvent());
+      event.address = TEST_CONTRACT_ADDRESS;
+      event.transaction.hash = TEST_TX_HASH;
+      event.logIndex = BigInt.fromI32(0);
+      event.parameters = [
+        new ethereum.EventParam(
+          "_projectId",
+          ethereum.Value.fromUnsignedBigInt(projectId)
+        ),
+        new ethereum.EventParam(
+          "_artistAddress",
+          ethereum.Value.fromAddress(newArtistAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeePrimarySales",
+          ethereum.Value.fromAddress(additionalPayeePrimarySalesAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeePrimarySalesPercentage",
+          ethereum.Value.fromUnsignedBigInt(
+            additionalPayeePrimarySalesPercentage
+          )
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeeSecondarySales",
+          ethereum.Value.fromAddress(additionalPayeeSecondarySalesAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeeSecondarySalesPercentage",
+          ethereum.Value.fromUnsignedBigInt(
+            additionalPayeeSecondarySalesPercentage
+          )
+        )
+      ];
+      event.block.timestamp = updatedEventBlockTimestamp;
+
+      handleProposedArtistAddressesAndSplits(event);
+
+      assert.entityCount(PROJECT_ENTITY_TYPE, 0);
+      assert.entityCount("ProposedArtistAddressesAndSplits", 0);
+    });
+
     test("should handle new artist proposal", () => {
       const projectId = BigInt.fromI32(1);
       const fullProjectId = generateContractSpecificId(
@@ -369,6 +433,343 @@ describe("GenArt721CoreV3, artist propose/admin accept new payments", () => {
   });
 
   describe("AcceptedArtistAddressesAndSplits", () => {
+    test("should do nothing if project not in store", () => {
+      // remove project from store
+      clearStore();
+      // add dummy proposal to store
+      const projectId = BigInt.fromI32(1);
+      const fullProjectId = generateContractSpecificId(
+        TEST_CONTRACT_ADDRESS,
+        projectId
+      );
+      // add dummy proposal to store for non-existent project
+      const updatedBlockTimestamp = CURRENT_BLOCK_TIMESTAMP.plus(
+        BigInt.fromI32(10)
+      );
+      const dummyProposalId = randomAddressGenerator
+        .generateRandomAddress()
+        .toHexString();
+      const dummyProposal = new ProposedArtistAddressesAndSplitsEntity(
+        dummyProposalId
+      );
+      dummyProposal.project = fullProjectId;
+      dummyProposal.artistAddress = randomAddressGenerator.generateRandomAddress();
+      dummyProposal.additionalPayeePrimarySalesAddress = randomAddressGenerator.generateRandomAddress();
+      dummyProposal.additionalPayeePrimarySalesPercentage = BigInt.fromI32(10);
+      dummyProposal.additionalPayeeSecondarySalesAddress = randomAddressGenerator.generateRandomAddress();
+      dummyProposal.additionalPayeeSecondarySalesPercentage = BigInt.fromI32(
+        49
+      );
+      dummyProposal.createdAt = updatedBlockTimestamp;
+      dummyProposal.save();
+
+      // handle admin acceptance with non-existent project
+      const acceptedEventBlockTimestamp = updatedBlockTimestamp.plus(
+        BigInt.fromI32(10)
+      );
+
+      const acceptedEvent: AcceptedArtistAddressesAndSplits = changetype<
+        AcceptedArtistAddressesAndSplits
+      >(newMockEvent());
+      acceptedEvent.address = TEST_CONTRACT_ADDRESS;
+      acceptedEvent.transaction.hash = Bytes.fromByteArray(
+        crypto.keccak256(Bytes.fromUTF8("accept tx hash"))
+      );
+      acceptedEvent.logIndex = BigInt.fromI32(0);
+      acceptedEvent.parameters = [
+        new ethereum.EventParam(
+          "_projectId",
+          ethereum.Value.fromUnsignedBigInt(projectId)
+        )
+      ];
+      acceptedEvent.block.timestamp = acceptedEventBlockTimestamp;
+
+      handleAcceptedArtistAddressesAndSplits(acceptedEvent);
+
+      // assert that the dummy proposal is still in store (i.e. was not removed)
+      assert.entityCount("ProposedArtistAddressesAndSplits", 1);
+    });
+
+    test("should not accept proposal when no proposal found on project", () => {
+      const projectId = BigInt.fromI32(1);
+      const fullProjectId = generateContractSpecificId(
+        TEST_CONTRACT_ADDRESS,
+        projectId
+      );
+
+      // handle artist proposal
+      const newArtistAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeePrimarySalesAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeePrimarySalesPercentage = BigInt.fromI32(10);
+      const additionalPayeeSecondarySalesAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeeSecondarySalesPercentage = BigInt.fromI32(49);
+
+      const updatedEventBlockTimestamp = CURRENT_BLOCK_TIMESTAMP.plus(
+        BigInt.fromI32(10)
+      );
+
+      const event: ProposedArtistAddressesAndSplits = changetype<
+        ProposedArtistAddressesAndSplits
+      >(newMockEvent());
+      event.address = TEST_CONTRACT_ADDRESS;
+      event.transaction.hash = TEST_TX_HASH;
+      event.logIndex = BigInt.fromI32(0);
+      event.parameters = [
+        new ethereum.EventParam(
+          "_projectId",
+          ethereum.Value.fromUnsignedBigInt(projectId)
+        ),
+        new ethereum.EventParam(
+          "_artistAddress",
+          ethereum.Value.fromAddress(newArtistAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeePrimarySales",
+          ethereum.Value.fromAddress(additionalPayeePrimarySalesAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeePrimarySalesPercentage",
+          ethereum.Value.fromUnsignedBigInt(
+            additionalPayeePrimarySalesPercentage
+          )
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeeSecondarySales",
+          ethereum.Value.fromAddress(additionalPayeeSecondarySalesAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeeSecondarySalesPercentage",
+          ethereum.Value.fromUnsignedBigInt(
+            additionalPayeeSecondarySalesPercentage
+          )
+        )
+      ];
+      event.block.timestamp = updatedEventBlockTimestamp;
+
+      handleProposedArtistAddressesAndSplits(event);
+
+      // assert that the proposal is stored
+      assert.entityCount("ProposedArtistAddressesAndSplits", 1);
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "id",
+        fullProjectId
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "project",
+        fullProjectId
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "artistAddress",
+        newArtistAddress.toHexString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "createdAt",
+        updatedEventBlockTimestamp.toString()
+      );
+
+      // remove the proposal from Project entity
+      // note: this is expected to be an impossible state due to smart contract logic
+      const project = Project.load(fullProjectId);
+      if (project) {
+        project.proposedArtistAddressesAndSplits = null;
+        project.save();
+      }
+
+      // handle admin acceptance
+      const acceptedEventBlockTimestamp = updatedEventBlockTimestamp.plus(
+        BigInt.fromI32(10)
+      );
+
+      const acceptedEvent: AcceptedArtistAddressesAndSplits = changetype<
+        AcceptedArtistAddressesAndSplits
+      >(newMockEvent());
+      acceptedEvent.address = TEST_CONTRACT_ADDRESS;
+      acceptedEvent.transaction.hash = Bytes.fromByteArray(
+        crypto.keccak256(Bytes.fromUTF8("accept tx hash"))
+      );
+      acceptedEvent.logIndex = BigInt.fromI32(0);
+      acceptedEvent.parameters = [
+        new ethereum.EventParam(
+          "_projectId",
+          ethereum.Value.fromUnsignedBigInt(projectId)
+        )
+      ];
+      acceptedEvent.block.timestamp = acceptedEventBlockTimestamp;
+
+      handleAcceptedArtistAddressesAndSplits(acceptedEvent);
+
+      // assert that the proposal is not removed
+      assert.entityCount("ProposedArtistAddressesAndSplits", 1);
+      // assert that the project is not updated
+      assert.fieldEquals(
+        PROJECT_ENTITY_TYPE,
+        fullProjectId,
+        "artistAddress",
+        artistAddress.toHexString()
+      );
+    });
+
+    test("should do nothing if proposal not in store", () => {
+      const projectId = BigInt.fromI32(1);
+      const fullProjectId = generateContractSpecificId(
+        TEST_CONTRACT_ADDRESS,
+        projectId
+      );
+
+      // handle artist proposal
+      const newArtistAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeePrimarySalesAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeePrimarySalesPercentage = BigInt.fromI32(10);
+      const additionalPayeeSecondarySalesAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeeSecondarySalesPercentage = BigInt.fromI32(49);
+
+      const updatedEventBlockTimestamp = CURRENT_BLOCK_TIMESTAMP.plus(
+        BigInt.fromI32(10)
+      );
+
+      const event: ProposedArtistAddressesAndSplits = changetype<
+        ProposedArtistAddressesAndSplits
+      >(newMockEvent());
+      event.address = TEST_CONTRACT_ADDRESS;
+      event.transaction.hash = TEST_TX_HASH;
+      event.logIndex = BigInt.fromI32(0);
+      event.parameters = [
+        new ethereum.EventParam(
+          "_projectId",
+          ethereum.Value.fromUnsignedBigInt(projectId)
+        ),
+        new ethereum.EventParam(
+          "_artistAddress",
+          ethereum.Value.fromAddress(newArtistAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeePrimarySales",
+          ethereum.Value.fromAddress(additionalPayeePrimarySalesAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeePrimarySalesPercentage",
+          ethereum.Value.fromUnsignedBigInt(
+            additionalPayeePrimarySalesPercentage
+          )
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeeSecondarySales",
+          ethereum.Value.fromAddress(additionalPayeeSecondarySalesAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeeSecondarySalesPercentage",
+          ethereum.Value.fromUnsignedBigInt(
+            additionalPayeeSecondarySalesPercentage
+          )
+        )
+      ];
+      event.block.timestamp = updatedEventBlockTimestamp;
+
+      handleProposedArtistAddressesAndSplits(event);
+
+      // assert that the proposal is stored
+      assert.entityCount("ProposedArtistAddressesAndSplits", 1);
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "id",
+        fullProjectId
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "project",
+        fullProjectId
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "artistAddress",
+        newArtistAddress.toHexString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "additionalPayeePrimarySalesAddress",
+        additionalPayeePrimarySalesAddress.toHexString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "additionalPayeePrimarySalesPercentage",
+        additionalPayeePrimarySalesPercentage.toString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "additionalPayeeSecondarySalesAddress",
+        additionalPayeeSecondarySalesAddress.toHexString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "additionalPayeeSecondarySalesPercentage",
+        additionalPayeeSecondarySalesPercentage.toString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "createdAt",
+        updatedEventBlockTimestamp.toString()
+      );
+
+      // handle admin acceptance
+      const acceptedEventBlockTimestamp = updatedEventBlockTimestamp.plus(
+        BigInt.fromI32(10)
+      );
+
+      const acceptedEvent: AcceptedArtistAddressesAndSplits = changetype<
+        AcceptedArtistAddressesAndSplits
+      >(newMockEvent());
+      acceptedEvent.address = TEST_CONTRACT_ADDRESS;
+      acceptedEvent.transaction.hash = Bytes.fromByteArray(
+        crypto.keccak256(Bytes.fromUTF8("accept tx hash"))
+      );
+      acceptedEvent.logIndex = BigInt.fromI32(0);
+      acceptedEvent.parameters = [
+        new ethereum.EventParam(
+          "_projectId",
+          ethereum.Value.fromUnsignedBigInt(projectId)
+        )
+      ];
+      acceptedEvent.block.timestamp = acceptedEventBlockTimestamp;
+
+      // remove the proposal from store
+      // note: this is expected to be an impossible state due to smart contract logic
+      store.remove("ProposedArtistAddressesAndSplits", fullProjectId);
+      assert.entityCount("ProposedArtistAddressesAndSplits", 0);
+
+      handleAcceptedArtistAddressesAndSplits(acceptedEvent);
+
+      // assert that the project was not updated
+      assert.fieldEquals(
+        PROJECT_ENTITY_TYPE,
+        fullProjectId,
+        "artistAddress",
+        artistAddress.toHexString()
+      );
+      // last updated at should not be updated to the accepted event timestamp
+      assert.fieldEquals(
+        PROJECT_ENTITY_TYPE,
+        fullProjectId,
+        "updatedAt",
+        updatedEventBlockTimestamp.toString()
+      );
+    });
+
     test("should update Project, and remove ProposedArtistAddressesAndSplits from store", () => {
       const projectId = BigInt.fromI32(1);
       const fullProjectId = generateContractSpecificId(

--- a/tests/subgraph/mapping-v3-core/mapping-v3-core-proposed-addresses-splits.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-core-proposed-addresses-splits.test.ts
@@ -6,7 +6,9 @@ import {
   log,
   logStore,
   createMockedFunction,
-  newMockEvent
+  newMockEvent,
+  describe,
+  beforeEach
 } from "matchstick-as/assembly/index";
 import {
   BigInt,
@@ -71,488 +73,475 @@ import { generateContractSpecificId } from "../../../src/helpers";
 
 const randomAddressGenerator = new RandomAddressGenerator();
 
-test("GenArt721CoreV3/ProposedAddressesAndSplits: should handle new artist proposal", () => {
-  clearStore();
-  // add project to store
-  const projectId = BigInt.fromI32(1);
-  const artistAddress = randomAddressGenerator.generateRandomAddress();
-  const projectName = "Test Project";
-  const pricePerTokenInWei = BigInt.fromI64(i64(1e18));
+describe("GenArt721CoreV3, artist propose/admin accept new payments", () => {
+  beforeEach(() => {
+    clearStore();
+    // add project to store
+    const projectId = BigInt.fromI32(1);
+    const artistAddress = randomAddressGenerator.generateRandomAddress();
+    const projectName = "Test Project";
+    const pricePerTokenInWei = BigInt.fromI64(i64(1e18));
 
-  mockRefreshContractCalls(BigInt.fromI32(2), null);
+    mockRefreshContractCalls(BigInt.fromI32(2), null);
 
-  addNewProjectToStore(
-    TEST_CONTRACT_ADDRESS,
-    projectId,
-    projectName,
-    artistAddress,
-    pricePerTokenInWei,
-    CURRENT_BLOCK_TIMESTAMP
-  );
+    addNewProjectToStore(
+      TEST_CONTRACT_ADDRESS,
+      projectId,
+      projectName,
+      artistAddress,
+      pricePerTokenInWei,
+      CURRENT_BLOCK_TIMESTAMP
+    );
+  });
 
-  const fullProjectId = generateContractSpecificId(
-    TEST_CONTRACT_ADDRESS,
-    projectId
-  );
+  describe("ProposedAddressesAndSplits", () => {
+    test("should handle new artist proposal", () => {
+      const projectId = BigInt.fromI32(1);
+      const fullProjectId = generateContractSpecificId(
+        TEST_CONTRACT_ADDRESS,
+        projectId
+      );
 
-  // handle artist proposal
-  const newArtistAddress = randomAddressGenerator.generateRandomAddress();
-  const additionalPayeePrimarySalesAddress = randomAddressGenerator.generateRandomAddress();
-  const additionalPayeePrimarySalesPercentage = BigInt.fromI32(10);
-  const additionalPayeeSecondarySalesAddress = randomAddressGenerator.generateRandomAddress();
-  const additionalPayeeSecondarySalesPercentage = BigInt.fromI32(49);
+      // handle artist proposal
+      const newArtistAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeePrimarySalesAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeePrimarySalesPercentage = BigInt.fromI32(10);
+      const additionalPayeeSecondarySalesAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeeSecondarySalesPercentage = BigInt.fromI32(49);
 
-  const updatedEventBlockTimestamp = CURRENT_BLOCK_TIMESTAMP.plus(
-    BigInt.fromI32(10)
-  );
+      const updatedEventBlockTimestamp = CURRENT_BLOCK_TIMESTAMP.plus(
+        BigInt.fromI32(10)
+      );
 
-  const event: ProposedArtistAddressesAndSplits = changetype<
-    ProposedArtistAddressesAndSplits
-  >(newMockEvent());
-  event.address = TEST_CONTRACT_ADDRESS;
-  event.transaction.hash = TEST_TX_HASH;
-  event.logIndex = BigInt.fromI32(0);
-  event.parameters = [
-    new ethereum.EventParam(
-      "_projectId",
-      ethereum.Value.fromUnsignedBigInt(projectId)
-    ),
-    new ethereum.EventParam(
-      "_artistAddress",
-      ethereum.Value.fromAddress(newArtistAddress)
-    ),
-    new ethereum.EventParam(
-      "_additionalPayeePrimarySales",
-      ethereum.Value.fromAddress(additionalPayeePrimarySalesAddress)
-    ),
-    new ethereum.EventParam(
-      "_additionalPayeePrimarySalesPercentage",
-      ethereum.Value.fromUnsignedBigInt(additionalPayeePrimarySalesPercentage)
-    ),
-    new ethereum.EventParam(
-      "_additionalPayeeSecondarySales",
-      ethereum.Value.fromAddress(additionalPayeeSecondarySalesAddress)
-    ),
-    new ethereum.EventParam(
-      "_additionalPayeeSecondarySalesPercentage",
-      ethereum.Value.fromUnsignedBigInt(additionalPayeeSecondarySalesPercentage)
-    )
-  ];
-  event.block.timestamp = updatedEventBlockTimestamp;
+      const event: ProposedArtistAddressesAndSplits = changetype<
+        ProposedArtistAddressesAndSplits
+      >(newMockEvent());
+      event.address = TEST_CONTRACT_ADDRESS;
+      event.transaction.hash = TEST_TX_HASH;
+      event.logIndex = BigInt.fromI32(0);
+      event.parameters = [
+        new ethereum.EventParam(
+          "_projectId",
+          ethereum.Value.fromUnsignedBigInt(projectId)
+        ),
+        new ethereum.EventParam(
+          "_artistAddress",
+          ethereum.Value.fromAddress(newArtistAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeePrimarySales",
+          ethereum.Value.fromAddress(additionalPayeePrimarySalesAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeePrimarySalesPercentage",
+          ethereum.Value.fromUnsignedBigInt(
+            additionalPayeePrimarySalesPercentage
+          )
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeeSecondarySales",
+          ethereum.Value.fromAddress(additionalPayeeSecondarySalesAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeeSecondarySalesPercentage",
+          ethereum.Value.fromUnsignedBigInt(
+            additionalPayeeSecondarySalesPercentage
+          )
+        )
+      ];
+      event.block.timestamp = updatedEventBlockTimestamp;
 
-  handleProposedArtistAddressesAndSplits(event);
+      handleProposedArtistAddressesAndSplits(event);
 
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "id",
-    fullProjectId
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "project",
-    fullProjectId
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "artistAddress",
-    newArtistAddress.toHexString()
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "additionalPayeePrimarySalesAddress",
-    additionalPayeePrimarySalesAddress.toHexString()
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "additionalPayeePrimarySalesPercentage",
-    additionalPayeePrimarySalesPercentage.toString()
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "additionalPayeeSecondarySalesAddress",
-    additionalPayeeSecondarySalesAddress.toHexString()
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "additionalPayeeSecondarySalesPercentage",
-    additionalPayeeSecondarySalesPercentage.toString()
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "createdAt",
-    updatedEventBlockTimestamp.toString()
-  );
-});
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "id",
+        fullProjectId
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "project",
+        fullProjectId
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "artistAddress",
+        newArtistAddress.toHexString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "additionalPayeePrimarySalesAddress",
+        additionalPayeePrimarySalesAddress.toHexString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "additionalPayeePrimarySalesPercentage",
+        additionalPayeePrimarySalesPercentage.toString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "additionalPayeeSecondarySalesAddress",
+        additionalPayeeSecondarySalesAddress.toHexString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "additionalPayeeSecondarySalesPercentage",
+        additionalPayeeSecondarySalesPercentage.toString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "createdAt",
+        updatedEventBlockTimestamp.toString()
+      );
+    });
 
-test("GenArt721CoreV3/ProposedAddressesAndSplits: should overwrite new artist proposals", () => {
-  clearStore();
-  // add project to store
-  const projectId = BigInt.fromI32(1);
-  const artistAddress = randomAddressGenerator.generateRandomAddress();
-  const projectName = "Test Project";
-  const pricePerTokenInWei = BigInt.fromI64(i64(1e18));
+    test("should overwrite new artist proposals", () => {
+      const projectId = BigInt.fromI32(1);
+      const fullProjectId = generateContractSpecificId(
+        TEST_CONTRACT_ADDRESS,
+        projectId
+      );
 
-  mockRefreshContractCalls(BigInt.fromI32(2), null);
+      // handle artist proposal
+      const newArtistAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeePrimarySalesAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeePrimarySalesPercentage = BigInt.fromI32(10);
+      const additionalPayeeSecondarySalesAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeeSecondarySalesPercentage = BigInt.fromI32(49);
 
-  addNewProjectToStore(
-    TEST_CONTRACT_ADDRESS,
-    projectId,
-    projectName,
-    artistAddress,
-    pricePerTokenInWei,
-    CURRENT_BLOCK_TIMESTAMP
-  );
+      const updatedEventBlockTimestamp = CURRENT_BLOCK_TIMESTAMP.plus(
+        BigInt.fromI32(10)
+      );
 
-  const fullProjectId = generateContractSpecificId(
-    TEST_CONTRACT_ADDRESS,
-    projectId
-  );
+      const event: ProposedArtistAddressesAndSplits = changetype<
+        ProposedArtistAddressesAndSplits
+      >(newMockEvent());
+      event.address = TEST_CONTRACT_ADDRESS;
+      event.transaction.hash = TEST_TX_HASH;
+      event.logIndex = BigInt.fromI32(0);
+      event.parameters = [
+        new ethereum.EventParam(
+          "_projectId",
+          ethereum.Value.fromUnsignedBigInt(projectId)
+        ),
+        new ethereum.EventParam(
+          "_artistAddress",
+          ethereum.Value.fromAddress(newArtistAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeePrimarySales",
+          ethereum.Value.fromAddress(additionalPayeePrimarySalesAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeePrimarySalesPercentage",
+          ethereum.Value.fromUnsignedBigInt(
+            additionalPayeePrimarySalesPercentage
+          )
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeeSecondarySales",
+          ethereum.Value.fromAddress(additionalPayeeSecondarySalesAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeeSecondarySalesPercentage",
+          ethereum.Value.fromUnsignedBigInt(
+            additionalPayeeSecondarySalesPercentage
+          )
+        )
+      ];
+      event.block.timestamp = updatedEventBlockTimestamp;
 
-  // handle artist proposal
-  const newArtistAddress = randomAddressGenerator.generateRandomAddress();
-  const additionalPayeePrimarySalesAddress = randomAddressGenerator.generateRandomAddress();
-  const additionalPayeePrimarySalesPercentage = BigInt.fromI32(10);
-  const additionalPayeeSecondarySalesAddress = randomAddressGenerator.generateRandomAddress();
-  const additionalPayeeSecondarySalesPercentage = BigInt.fromI32(49);
+      handleProposedArtistAddressesAndSplits(event);
 
-  const updatedEventBlockTimestamp = CURRENT_BLOCK_TIMESTAMP.plus(
-    BigInt.fromI32(10)
-  );
+      // handle another artist proposal, overwriting previous one
+      const newNewArtistAddress = randomAddressGenerator.generateRandomAddress();
+      const newAdditionalPayeePrimarySalesAddress = randomAddressGenerator.generateRandomAddress();
+      const newAdditionalPayeePrimarySalesPercentage = BigInt.fromI32(10);
+      const newAdditionalPayeeSecondarySalesAddress = randomAddressGenerator.generateRandomAddress();
+      const newAdditionalPayeeSecondarySalesPercentage = BigInt.fromI32(49);
 
-  const event: ProposedArtistAddressesAndSplits = changetype<
-    ProposedArtistAddressesAndSplits
-  >(newMockEvent());
-  event.address = TEST_CONTRACT_ADDRESS;
-  event.transaction.hash = TEST_TX_HASH;
-  event.logIndex = BigInt.fromI32(0);
-  event.parameters = [
-    new ethereum.EventParam(
-      "_projectId",
-      ethereum.Value.fromUnsignedBigInt(projectId)
-    ),
-    new ethereum.EventParam(
-      "_artistAddress",
-      ethereum.Value.fromAddress(newArtistAddress)
-    ),
-    new ethereum.EventParam(
-      "_additionalPayeePrimarySales",
-      ethereum.Value.fromAddress(additionalPayeePrimarySalesAddress)
-    ),
-    new ethereum.EventParam(
-      "_additionalPayeePrimarySalesPercentage",
-      ethereum.Value.fromUnsignedBigInt(additionalPayeePrimarySalesPercentage)
-    ),
-    new ethereum.EventParam(
-      "_additionalPayeeSecondarySales",
-      ethereum.Value.fromAddress(additionalPayeeSecondarySalesAddress)
-    ),
-    new ethereum.EventParam(
-      "_additionalPayeeSecondarySalesPercentage",
-      ethereum.Value.fromUnsignedBigInt(additionalPayeeSecondarySalesPercentage)
-    )
-  ];
-  event.block.timestamp = updatedEventBlockTimestamp;
+      const newUpdatedEventBlockTimestamp = updatedEventBlockTimestamp.plus(
+        BigInt.fromI32(10)
+      );
 
-  handleProposedArtistAddressesAndSplits(event);
+      const newEvent: ProposedArtistAddressesAndSplits = changetype<
+        ProposedArtistAddressesAndSplits
+      >(newMockEvent());
+      newEvent.address = TEST_CONTRACT_ADDRESS;
+      newEvent.transaction.hash = Bytes.fromByteArray(
+        crypto.keccak256(Bytes.fromUTF8("new tx hash"))
+      );
+      newEvent.logIndex = BigInt.fromI32(0);
+      newEvent.parameters = [
+        new ethereum.EventParam(
+          "_projectId",
+          ethereum.Value.fromUnsignedBigInt(projectId)
+        ),
+        new ethereum.EventParam(
+          "_artistAddress",
+          ethereum.Value.fromAddress(newNewArtistAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeePrimarySales",
+          ethereum.Value.fromAddress(newAdditionalPayeePrimarySalesAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeePrimarySalesPercentage",
+          ethereum.Value.fromUnsignedBigInt(
+            newAdditionalPayeePrimarySalesPercentage
+          )
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeeSecondarySales",
+          ethereum.Value.fromAddress(newAdditionalPayeeSecondarySalesAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeeSecondarySalesPercentage",
+          ethereum.Value.fromUnsignedBigInt(
+            newAdditionalPayeeSecondarySalesPercentage
+          )
+        )
+      ];
+      newEvent.block.timestamp = newUpdatedEventBlockTimestamp;
 
-  // handle another artist proposal, overwriting previous one
-  const newNewArtistAddress = randomAddressGenerator.generateRandomAddress();
-  const newAdditionalPayeePrimarySalesAddress = randomAddressGenerator.generateRandomAddress();
-  const newAdditionalPayeePrimarySalesPercentage = BigInt.fromI32(10);
-  const newAdditionalPayeeSecondarySalesAddress = randomAddressGenerator.generateRandomAddress();
-  const newAdditionalPayeeSecondarySalesPercentage = BigInt.fromI32(49);
+      handleProposedArtistAddressesAndSplits(newEvent);
 
-  const newUpdatedEventBlockTimestamp = updatedEventBlockTimestamp.plus(
-    BigInt.fromI32(10)
-  );
+      // assert that the previous proposal is not in store
+      assert.entityCount("ProposedArtistAddressesAndSplits", 1);
+      // assert that the new proposal is stored
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "id",
+        fullProjectId
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "project",
+        fullProjectId
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "artistAddress",
+        newNewArtistAddress.toHexString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "additionalPayeePrimarySalesAddress",
+        newAdditionalPayeePrimarySalesAddress.toHexString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "additionalPayeePrimarySalesPercentage",
+        newAdditionalPayeePrimarySalesPercentage.toString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "additionalPayeeSecondarySalesAddress",
+        newAdditionalPayeeSecondarySalesAddress.toHexString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "additionalPayeeSecondarySalesPercentage",
+        newAdditionalPayeeSecondarySalesPercentage.toString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "createdAt",
+        newUpdatedEventBlockTimestamp.toString()
+      );
+    });
+  });
 
-  const newEvent: ProposedArtistAddressesAndSplits = changetype<
-    ProposedArtistAddressesAndSplits
-  >(newMockEvent());
-  newEvent.address = TEST_CONTRACT_ADDRESS;
-  newEvent.transaction.hash = Bytes.fromByteArray(
-    crypto.keccak256(Bytes.fromUTF8("new tx hash"))
-  );
-  newEvent.logIndex = BigInt.fromI32(0);
-  newEvent.parameters = [
-    new ethereum.EventParam(
-      "_projectId",
-      ethereum.Value.fromUnsignedBigInt(projectId)
-    ),
-    new ethereum.EventParam(
-      "_artistAddress",
-      ethereum.Value.fromAddress(newNewArtistAddress)
-    ),
-    new ethereum.EventParam(
-      "_additionalPayeePrimarySales",
-      ethereum.Value.fromAddress(newAdditionalPayeePrimarySalesAddress)
-    ),
-    new ethereum.EventParam(
-      "_additionalPayeePrimarySalesPercentage",
-      ethereum.Value.fromUnsignedBigInt(
-        newAdditionalPayeePrimarySalesPercentage
-      )
-    ),
-    new ethereum.EventParam(
-      "_additionalPayeeSecondarySales",
-      ethereum.Value.fromAddress(newAdditionalPayeeSecondarySalesAddress)
-    ),
-    new ethereum.EventParam(
-      "_additionalPayeeSecondarySalesPercentage",
-      ethereum.Value.fromUnsignedBigInt(
-        newAdditionalPayeeSecondarySalesPercentage
-      )
-    )
-  ];
-  newEvent.block.timestamp = newUpdatedEventBlockTimestamp;
+  describe("AcceptedArtistAddressesAndSplits", () => {
+    test("should update Project, and remove ProposedArtistAddressesAndSplits from store", () => {
+      const projectId = BigInt.fromI32(1);
+      const fullProjectId = generateContractSpecificId(
+        TEST_CONTRACT_ADDRESS,
+        projectId
+      );
 
-  handleProposedArtistAddressesAndSplits(newEvent);
+      // handle artist proposal
+      const newArtistAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeePrimarySalesAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeePrimarySalesPercentage = BigInt.fromI32(10);
+      const additionalPayeeSecondarySalesAddress = randomAddressGenerator.generateRandomAddress();
+      const additionalPayeeSecondarySalesPercentage = BigInt.fromI32(49);
 
-  // assert that the previous proposal is not in store
-  assert.entityCount("ProposedArtistAddressesAndSplits", 1);
-  // assert that the new proposal is stored
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "id",
-    fullProjectId
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "project",
-    fullProjectId
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "artistAddress",
-    newNewArtistAddress.toHexString()
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "additionalPayeePrimarySalesAddress",
-    newAdditionalPayeePrimarySalesAddress.toHexString()
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "additionalPayeePrimarySalesPercentage",
-    newAdditionalPayeePrimarySalesPercentage.toString()
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "additionalPayeeSecondarySalesAddress",
-    newAdditionalPayeeSecondarySalesAddress.toHexString()
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "additionalPayeeSecondarySalesPercentage",
-    newAdditionalPayeeSecondarySalesPercentage.toString()
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "createdAt",
-    newUpdatedEventBlockTimestamp.toString()
-  );
-});
+      const updatedEventBlockTimestamp = CURRENT_BLOCK_TIMESTAMP.plus(
+        BigInt.fromI32(10)
+      );
 
-test("GenArt721CoreV3/AcceptedArtistAddressesAndSplits: should update Project, and remove ProposedArtistAddressesAndSplits from store", () => {
-  clearStore();
-  // add project to store
-  const projectId = BigInt.fromI32(1);
-  const artistAddress = randomAddressGenerator.generateRandomAddress();
-  const projectName = "Test Project";
-  const pricePerTokenInWei = BigInt.fromI64(i64(1e18));
+      const event: ProposedArtistAddressesAndSplits = changetype<
+        ProposedArtistAddressesAndSplits
+      >(newMockEvent());
+      event.address = TEST_CONTRACT_ADDRESS;
+      event.transaction.hash = TEST_TX_HASH;
+      event.logIndex = BigInt.fromI32(0);
+      event.parameters = [
+        new ethereum.EventParam(
+          "_projectId",
+          ethereum.Value.fromUnsignedBigInt(projectId)
+        ),
+        new ethereum.EventParam(
+          "_artistAddress",
+          ethereum.Value.fromAddress(newArtistAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeePrimarySales",
+          ethereum.Value.fromAddress(additionalPayeePrimarySalesAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeePrimarySalesPercentage",
+          ethereum.Value.fromUnsignedBigInt(
+            additionalPayeePrimarySalesPercentage
+          )
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeeSecondarySales",
+          ethereum.Value.fromAddress(additionalPayeeSecondarySalesAddress)
+        ),
+        new ethereum.EventParam(
+          "_additionalPayeeSecondarySalesPercentage",
+          ethereum.Value.fromUnsignedBigInt(
+            additionalPayeeSecondarySalesPercentage
+          )
+        )
+      ];
+      event.block.timestamp = updatedEventBlockTimestamp;
 
-  mockRefreshContractCalls(BigInt.fromI32(2), null);
+      handleProposedArtistAddressesAndSplits(event);
 
-  addNewProjectToStore(
-    TEST_CONTRACT_ADDRESS,
-    projectId,
-    projectName,
-    artistAddress,
-    pricePerTokenInWei,
-    CURRENT_BLOCK_TIMESTAMP
-  );
+      // assert that the proposal is stored
+      assert.entityCount("ProposedArtistAddressesAndSplits", 1);
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "id",
+        fullProjectId
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "project",
+        fullProjectId
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "artistAddress",
+        newArtistAddress.toHexString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "additionalPayeePrimarySalesAddress",
+        additionalPayeePrimarySalesAddress.toHexString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "additionalPayeePrimarySalesPercentage",
+        additionalPayeePrimarySalesPercentage.toString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "additionalPayeeSecondarySalesAddress",
+        additionalPayeeSecondarySalesAddress.toHexString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "additionalPayeeSecondarySalesPercentage",
+        additionalPayeeSecondarySalesPercentage.toString()
+      );
+      assert.fieldEquals(
+        "ProposedArtistAddressesAndSplits",
+        fullProjectId,
+        "createdAt",
+        updatedEventBlockTimestamp.toString()
+      );
 
-  const fullProjectId = generateContractSpecificId(
-    TEST_CONTRACT_ADDRESS,
-    projectId
-  );
+      // handle admin acceptance
+      const acceptedEventBlockTimestamp = updatedEventBlockTimestamp.plus(
+        BigInt.fromI32(10)
+      );
 
-  // handle artist proposal
-  const newArtistAddress = randomAddressGenerator.generateRandomAddress();
-  const additionalPayeePrimarySalesAddress = randomAddressGenerator.generateRandomAddress();
-  const additionalPayeePrimarySalesPercentage = BigInt.fromI32(10);
-  const additionalPayeeSecondarySalesAddress = randomAddressGenerator.generateRandomAddress();
-  const additionalPayeeSecondarySalesPercentage = BigInt.fromI32(49);
+      const acceptedEvent: AcceptedArtistAddressesAndSplits = changetype<
+        AcceptedArtistAddressesAndSplits
+      >(newMockEvent());
+      acceptedEvent.address = TEST_CONTRACT_ADDRESS;
+      acceptedEvent.transaction.hash = Bytes.fromByteArray(
+        crypto.keccak256(Bytes.fromUTF8("accept tx hash"))
+      );
+      acceptedEvent.logIndex = BigInt.fromI32(0);
+      acceptedEvent.parameters = [
+        new ethereum.EventParam(
+          "_projectId",
+          ethereum.Value.fromUnsignedBigInt(projectId)
+        )
+      ];
+      acceptedEvent.block.timestamp = acceptedEventBlockTimestamp;
 
-  const updatedEventBlockTimestamp = CURRENT_BLOCK_TIMESTAMP.plus(
-    BigInt.fromI32(10)
-  );
+      handleAcceptedArtistAddressesAndSplits(acceptedEvent);
 
-  const event: ProposedArtistAddressesAndSplits = changetype<
-    ProposedArtistAddressesAndSplits
-  >(newMockEvent());
-  event.address = TEST_CONTRACT_ADDRESS;
-  event.transaction.hash = TEST_TX_HASH;
-  event.logIndex = BigInt.fromI32(0);
-  event.parameters = [
-    new ethereum.EventParam(
-      "_projectId",
-      ethereum.Value.fromUnsignedBigInt(projectId)
-    ),
-    new ethereum.EventParam(
-      "_artistAddress",
-      ethereum.Value.fromAddress(newArtistAddress)
-    ),
-    new ethereum.EventParam(
-      "_additionalPayeePrimarySales",
-      ethereum.Value.fromAddress(additionalPayeePrimarySalesAddress)
-    ),
-    new ethereum.EventParam(
-      "_additionalPayeePrimarySalesPercentage",
-      ethereum.Value.fromUnsignedBigInt(additionalPayeePrimarySalesPercentage)
-    ),
-    new ethereum.EventParam(
-      "_additionalPayeeSecondarySales",
-      ethereum.Value.fromAddress(additionalPayeeSecondarySalesAddress)
-    ),
-    new ethereum.EventParam(
-      "_additionalPayeeSecondarySalesPercentage",
-      ethereum.Value.fromUnsignedBigInt(additionalPayeeSecondarySalesPercentage)
-    )
-  ];
-  event.block.timestamp = updatedEventBlockTimestamp;
-
-  handleProposedArtistAddressesAndSplits(event);
-
-  // assert that the proposal is stored
-  assert.entityCount("ProposedArtistAddressesAndSplits", 1);
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "id",
-    fullProjectId
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "project",
-    fullProjectId
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "artistAddress",
-    newArtistAddress.toHexString()
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "additionalPayeePrimarySalesAddress",
-    additionalPayeePrimarySalesAddress.toHexString()
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "additionalPayeePrimarySalesPercentage",
-    additionalPayeePrimarySalesPercentage.toString()
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "additionalPayeeSecondarySalesAddress",
-    additionalPayeeSecondarySalesAddress.toHexString()
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "additionalPayeeSecondarySalesPercentage",
-    additionalPayeeSecondarySalesPercentage.toString()
-  );
-  assert.fieldEquals(
-    "ProposedArtistAddressesAndSplits",
-    fullProjectId,
-    "createdAt",
-    updatedEventBlockTimestamp.toString()
-  );
-
-  // handle admin acceptance
-  const acceptedEventBlockTimestamp = updatedEventBlockTimestamp.plus(
-    BigInt.fromI32(10)
-  );
-
-  const acceptedEvent: AcceptedArtistAddressesAndSplits = changetype<
-    AcceptedArtistAddressesAndSplits
-  >(newMockEvent());
-  acceptedEvent.address = TEST_CONTRACT_ADDRESS;
-  acceptedEvent.transaction.hash = Bytes.fromByteArray(
-    crypto.keccak256(Bytes.fromUTF8("accept tx hash"))
-  );
-  acceptedEvent.logIndex = BigInt.fromI32(0);
-  acceptedEvent.parameters = [
-    new ethereum.EventParam(
-      "_projectId",
-      ethereum.Value.fromUnsignedBigInt(projectId)
-    )
-  ];
-  acceptedEvent.block.timestamp = acceptedEventBlockTimestamp;
-
-  handleAcceptedArtistAddressesAndSplits(acceptedEvent);
-
-  // assert that the proposal is removed
-  assert.entityCount("ProposedArtistAddressesAndSplits", 0);
-  // assert that the project is updated
-  assert.fieldEquals(
-    PROJECT_ENTITY_TYPE,
-    fullProjectId,
-    "artistAddress",
-    newArtistAddress.toHexString()
-  );
-  assert.fieldEquals(
-    PROJECT_ENTITY_TYPE,
-    fullProjectId,
-    "additionalPayee",
-    additionalPayeePrimarySalesAddress.toHexString()
-  );
-  assert.fieldEquals(
-    PROJECT_ENTITY_TYPE,
-    fullProjectId,
-    "additionalPayeePercentage",
-    additionalPayeePrimarySalesPercentage.toString()
-  );
-  assert.fieldEquals(
-    PROJECT_ENTITY_TYPE,
-    fullProjectId,
-    "additionalPayeeSecondarySalesAddress",
-    additionalPayeeSecondarySalesAddress.toHexString()
-  );
-  assert.fieldEquals(
-    PROJECT_ENTITY_TYPE,
-    fullProjectId,
-    "additionalPayeeSecondarySalesPercentage",
-    additionalPayeeSecondarySalesPercentage.toString()
-  );
-  assert.fieldEquals(
-    PROJECT_ENTITY_TYPE,
-    fullProjectId,
-    "updatedAt",
-    acceptedEventBlockTimestamp.toString()
-  );
+      // assert that the proposal is removed
+      assert.entityCount("ProposedArtistAddressesAndSplits", 0);
+      // assert that the project is updated
+      assert.fieldEquals(
+        PROJECT_ENTITY_TYPE,
+        fullProjectId,
+        "artistAddress",
+        newArtistAddress.toHexString()
+      );
+      assert.fieldEquals(
+        PROJECT_ENTITY_TYPE,
+        fullProjectId,
+        "additionalPayee",
+        additionalPayeePrimarySalesAddress.toHexString()
+      );
+      assert.fieldEquals(
+        PROJECT_ENTITY_TYPE,
+        fullProjectId,
+        "additionalPayeePercentage",
+        additionalPayeePrimarySalesPercentage.toString()
+      );
+      assert.fieldEquals(
+        PROJECT_ENTITY_TYPE,
+        fullProjectId,
+        "additionalPayeeSecondarySalesAddress",
+        additionalPayeeSecondarySalesAddress.toHexString()
+      );
+      assert.fieldEquals(
+        PROJECT_ENTITY_TYPE,
+        fullProjectId,
+        "additionalPayeeSecondarySalesPercentage",
+        additionalPayeeSecondarySalesPercentage.toString()
+      );
+      assert.fieldEquals(
+        PROJECT_ENTITY_TYPE,
+        fullProjectId,
+        "updatedAt",
+        acceptedEventBlockTimestamp.toString()
+      );
+    });
+  });
 });
 
 // export handlers for test coverage https://github.com/LimeChain/demo-subgraph#test-coverage


### PR DESCRIPTION
Add V3 core event handlers for proposing and accepting new artist addresses and splits.

This PR:
- Creates a new `ProposedArtistAddressesAndSplits` entity when V3 core emits `ProposedArtistAddressesAndSplits` event
  - also removes any existing `ProposedArtistAddressesAndSplits` entity at the same ID, since this process works by overwriting any existing proposals on the blockchain
- Sets project addresses and splits to current proposed values when V3 core emits `AcceptedArtistAddressesAndSplits`
  - also clears existing proposed addresses and splits, aligning with the logic in this PR: https://github.com/ArtBlocks/artblocks-contracts/pull/279
- Adds a `createdAt` field to the `ProposedArtistAddressesAndSplits` entity in our schema
  - just something I forgot to add previously
  
## Tests
- Tests are added for coverage of new handlers