### PR TITLE
V3/Ownership transferred

### DIFF
--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -23,7 +23,8 @@ import {
   AccountProject,
   ProjectScript,
   Contract,
-  MinterFilter
+  MinterFilter,
+  ProposedArtistAddressesAndSplits
 } from "../generated/schema";
 
 import {

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -17,7 +17,8 @@ import {
   PlatformUpdated,
   MinterUpdated,
   ProposedArtistAddressesAndSplits as ProposedArtistAddressesAndSplitsEvent,
-  AcceptedArtistAddressesAndSplits
+  AcceptedArtistAddressesAndSplits,
+  OwnershipTransferred
 } from "../generated/GenArt721CoreV3/GenArt721CoreV3";
 
 import { MinterFilterV0 } from "../generated/MinterFilterV0/MinterFilterV0";
@@ -344,6 +345,18 @@ export function handleAcceptedArtistAddressesAndSplits(
   project.save();
   // remove the existing proposed artist addresses and splits entity from store
   store.remove("ProposedArtistAddressesAndSplits", entityId);
+}
+
+// Handle OwnershipTransferred event, emitted by the Ownable contract.
+// This event is updated whenever an admin address is changed.
+export function handleOwnershipTransferred(event: OwnershipTransferred): void {
+  let contractEntity = Contract.load(event.address.toHexString());
+  if (!contractEntity) {
+    return;
+  }
+  contractEntity.admin = event.params.newOwner;
+  contractEntity.updatedAt = event.block.timestamp;
+  contractEntity.save();
 }
 
 /*** END EVENT HANDLERS ***/

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -350,10 +350,11 @@ export function handleAcceptedArtistAddressesAndSplits(
 // Handle OwnershipTransferred event, emitted by the Ownable contract.
 // This event is updated whenever an admin address is changed.
 export function handleOwnershipTransferred(event: OwnershipTransferred): void {
-  let contractEntity = Contract.load(event.address.toHexString());
-  if (!contractEntity) {
-    return;
-  }
+  let contract = GenArt721CoreV3.bind(event.address);
+  let contractEntity = loadOrCreateContract(contract, event.block.timestamp);
+  // update the contract entity with the new admin address from the event, as
+  // opposed to the value at the end of the block, which could be the current
+  // value if we just created a new contract entity and synced it.
   contractEntity.admin = event.params.newOwner;
   contractEntity.updatedAt = event.block.timestamp;
   contractEntity.save();

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -352,9 +352,7 @@ export function handleAcceptedArtistAddressesAndSplits(
 export function handleOwnershipTransferred(event: OwnershipTransferred): void {
   let contract = GenArt721CoreV3.bind(event.address);
   let contractEntity = loadOrCreateContract(contract, event.block.timestamp);
-  // update the contract entity with the new admin address from the event, as
-  // opposed to the value at the end of the block, which could be the current
-  // value if we just created a new contract entity and synced it.
+  // update the contract entity with the new admin address from the event
   contractEntity.admin = event.params.newOwner;
   contractEntity.updatedAt = event.block.timestamp;
   contractEntity.save();

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -42,6 +42,8 @@ dataSources:
           handler: handleProposedArtistAddressesAndSplits
         - event: AcceptedArtistAddressesAndSplits(indexed uint256)
           handler: handleAcceptedArtistAddressesAndSplits
+        - event: OwnershipTransferred(indexed address,indexed address)
+          handler: handleOwnershipTransferred
       file: ./src/mapping-v3-core.ts
   {{/genArt721CoreV3Contracts}}
   {{#genArt721CoreContracts}}

--- a/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
@@ -200,6 +200,9 @@ test("GenArt721CoreV3: Handles OwnershipTransferred to new address and zero addr
     const projectId = BigInt.fromI32(i);
     addTestContractToStore(projectId);
 
+    const updatedEventBlockTimestamp = CURRENT_BLOCK_TIMESTAMP.plus(
+      BigInt.fromI32(10)
+    );
     const event: OwnershipTransferred = changetype<OwnershipTransferred>(
       newMockEvent()
     );
@@ -216,6 +219,7 @@ test("GenArt721CoreV3: Handles OwnershipTransferred to new address and zero addr
         ethereum.Value.fromAddress(newOwnerAddress)
       )
     ];
+    event.block.timestamp = updatedEventBlockTimestamp;
     // handle event
     handleOwnershipTransferred(event);
     // assertions
@@ -224,6 +228,12 @@ test("GenArt721CoreV3: Handles OwnershipTransferred to new address and zero addr
       TEST_CONTRACT_ADDRESS.toHexString(),
       "admin",
       newOwnerAddress.toHexString()
+    );
+    assert.fieldEquals(
+      CONTRACT_ENTITY_TYPE,
+      TEST_CONTRACT_ADDRESS.toHexString(),
+      "updatedAt",
+      updatedEventBlockTimestamp.toString()
     );
   }
 });

--- a/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
@@ -74,7 +74,7 @@ import {
   handleMint,
   handleTransfer,
   handlePlatformUpdated,
-  handleOwnershipTransferred
+  handleOwnershipTransferred,
   handleProjectUpdated
 } from "../../../src/mapping-v3-core";
 import {

--- a/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
@@ -187,7 +187,7 @@ test("GenArt721CoreV3: Can handle transfer", () => {
   );
 });
 
-test("GenArt721CoreV3: Handles OwnershipTransferred to new address and zero address", () => {
+test("GenArt721CoreV3: Handles OwnershipTransferred to new address and zero address, when Contract not in store", () => {
   const newOwners = [
     randomAddressGenerator.generateRandomAddress(),
     Address.zero()
@@ -197,8 +197,87 @@ test("GenArt721CoreV3: Handles OwnershipTransferred to new address and zero addr
     clearStore();
     const newOwnerAddress = newOwners[i];
     // add new contract to store
-    const projectId = BigInt.fromI32(i);
+    const projectId = BigInt.fromI32(101);
+    // specifically do not add new contract to store, because this event is
+    // emitted by the V3 constructor, and we expect item may not be in store.
+    // DO add mock contract calls, because we expect the contract to be called
+    // during initial contract setup.
+    mockRefreshContractCalls(projectId, null);
+
+    const updatedEventBlockTimestamp = CURRENT_BLOCK_TIMESTAMP.plus(
+      BigInt.fromI32(10)
+    );
+    const event: OwnershipTransferred = changetype<OwnershipTransferred>(
+      newMockEvent()
+    );
+    event.address = TEST_CONTRACT_ADDRESS;
+    event.transaction.hash = TEST_TX_HASH;
+    event.logIndex = BigInt.fromI32(0);
+    event.parameters = [
+      new ethereum.EventParam(
+        "previousOwner",
+        ethereum.Value.fromAddress(TEST_CONTRACT_ADDRESS)
+      ),
+      new ethereum.EventParam(
+        "newOwner",
+        ethereum.Value.fromAddress(newOwnerAddress)
+      )
+    ];
+    event.block.timestamp = updatedEventBlockTimestamp;
+    // handle event
+    handleOwnershipTransferred(event);
+    // assertions
+    assert.fieldEquals(
+      CONTRACT_ENTITY_TYPE,
+      TEST_CONTRACT_ADDRESS.toHexString(),
+      "admin",
+      newOwnerAddress.toHexString()
+    );
+    assert.fieldEquals(
+      CONTRACT_ENTITY_TYPE,
+      TEST_CONTRACT_ADDRESS.toHexString(),
+      "updatedAt",
+      updatedEventBlockTimestamp.toString()
+    );
+    // should also initialize the Contract entity with expected values from
+    // mock functions. spot check a few here
+    assert.fieldEquals(
+      CONTRACT_ENTITY_TYPE,
+      TEST_CONTRACT_ADDRESS.toHexString(),
+      "renderProviderAddress",
+      TEST_CONTRACT.renderProviderAddress.toHexString()
+    );
+    assert.fieldEquals(
+      CONTRACT_ENTITY_TYPE,
+      TEST_CONTRACT_ADDRESS.toHexString(),
+      "randomizerContract",
+      TEST_CONTRACT.randomizerContract.toHexString()
+    );
+    assert.fieldEquals(
+      CONTRACT_ENTITY_TYPE,
+      TEST_CONTRACT_ADDRESS.toHexString(),
+      "nextProjectId",
+      projectId.toString()
+    );
+  }
+});
+
+test("GenArt721CoreV3: Handles OwnershipTransferred to new address and zero address, when already in store", () => {
+  const newOwners = [
+    randomAddressGenerator.generateRandomAddress(),
+    Address.zero()
+  ];
+  // test for nextProjectId of 0 and 1
+  for (let i = 0; i < newOwners.length; i++) {
+    clearStore();
+    const newOwnerAddress = newOwners[i];
+    // add new contract to store
+    const projectId = BigInt.fromI32(101);
+    // specifically do add new contract to store, because sometimes we do
+    // expect contract entity to be in store.
     addTestContractToStore(projectId);
+    // also add mock contract calls, because that will always be available.
+    mockRefreshContractCalls(projectId, null);
 
     const updatedEventBlockTimestamp = CURRENT_BLOCK_TIMESTAMP.plus(
       BigInt.fromI32(10)


### PR DESCRIPTION
Add V3 core event handlers for OpenZeppelin's OwnershipTransferred event

This PR:
- Adds V3 `handleOwnershipTransferred` event handler when V3 core emits `OwnershipTransferred` event
  
## Tests
- Tests are added for coverage of new handler