### PR TITLE
Bug fix: JSON Bytes string validity check

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -177,10 +177,21 @@ export function arrayToJSONValue(value: string): JSONValue {
 // If byte data is parseable to a valid unicode string then do so
 // otherwise parse the byte data to a hex string
 export function bytesToJSONValue(value: Bytes): JSONValue {
-  // If the bytes cannot be
-  let result = json.try_fromString('["' + value.toString() + '"]');
-  if (result.isError) {
-    result = json.try_fromString('["' + value.toHexString() + '"]');
+  // fallback - assume the data is a hex string (always valid)
+  let result = json.try_fromString('["' + value.toHexString() + '"]');
+  // If the bytes can be parsed as a string, then losslessly re-encoded into
+  // UTF-8 bytes, then consider a valid UTF-8 encoded string and store
+  // string value in json.
+  // note: Bytes.toString() uses WTF-8 encoding as opposed to UTF-8.  Solidity
+  // encodes UTF-8 strings, so safe assume any string data are UTF-8 encoded.
+  let stringValue: string = value.toString();
+  let reEncodedBytesValue: Bytes = Bytes.fromUTF8(stringValue);
+  if (reEncodedBytesValue.toHexString() == value.toHexString()) {
+    // if the bytes are the same then the string was valid UTF-8
+    let potentialResult = json.try_fromString('["' + stringValue + '"]');
+    if (potentialResult.isOk) {
+      result = potentialResult;
+    }
   }
   return result.value.toArray()[0];
 }

--- a/src/minter-suite-mapping.ts
+++ b/src/minter-suite-mapping.ts
@@ -727,7 +727,8 @@ export function handleAddManyValueGeneric<T, C>(
     ) {
       stringVal = event.params._value.toHexString();
     } else {
-      stringVal = event.params._value.toString();
+      // for Bytes, use method to determine if string or hexString
+      stringVal = bytesToJSONValue(event.params._value).toString();
     }
     arr.push(stringToJSONString(stringVal));
     newValue = arrayToJSONValue(arr.toString());

--- a/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
+++ b/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
@@ -1620,7 +1620,11 @@ test("handleSetValue should set all values to a designated key in extraMinterDet
 
   // If the bytes are not intended to be a human readable string
   // we should instead convert to their hex string representation
-  const eventValue = randomAddressGenerator.generateRandomAddress();
+  // Always use the following hex string because valid WTF-8 but not valid
+  // UTF-8, which is a somewhat common edge-case when dealing with bytes
+  let eventValue = Bytes.fromHexString(
+    "0x57e32bd396b7c3337dd6b4a672e6d99b47865e56"
+  );
   const configValueSetEvent4: ConfigValueSetBytes = changetype<
     ConfigValueSetBytes
   >(newMockEvent());

--- a/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
+++ b/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
@@ -1824,13 +1824,36 @@ test("handleAddManyBytesValue should add a value to an array at a designated key
     '{"array":["im bytes"]}'
   );
 
-  handleAddManyBytesValue(configValueSetEvent);
+  // add another value, this time with bytes that should format to hex string
+  const configValueSetEvent2: ConfigValueAddedToSetBytes = changetype<
+    ConfigValueAddedToSetBytes
+  >(newMockEvent());
+  // Always use the following hex string because valid WTF-8 but not valid
+  // UTF-8, which is a somewhat common edge-case when dealing with bytes
+  let eventValue = Bytes.fromHexString(
+    "0x57e32bd396b7c3337dd6b4a672e6d99b47865e56"
+  );
+  configValueSetEvent2.address = minterAddress;
+  configValueSetEvent2.parameters = [
+    new ethereum.EventParam(
+      "_projectId",
+      ethereum.Value.fromUnsignedBigInt(projectId)
+    ),
+    new ethereum.EventParam(
+      "_key",
+      ethereum.Value.fromBytes(Bytes.fromUTF8("array"))
+    ),
+    new ethereum.EventParam("_value", ethereum.Value.fromBytes(eventValue))
+  ];
+  configValueSetEvent2.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
+
+  handleAddManyBytesValue(configValueSetEvent2);
 
   assert.fieldEquals(
     PROJECT_MINTER_CONFIGURATION_ENTITY_TYPE,
     getProjectMinterConfigId(minterAddress.toHexString(), project.id),
     "extraMinterDetails",
-    '{"array":["im bytes","im bytes"]}'
+    '{"array":["im bytes","0x57e32bd396b7c3337dd6b4a672e6d99b47865e56"]}'
   );
 });
 test("handleRemoveValue should remove the key/value from extraMinterDetails", () => {


### PR DESCRIPTION
Fix bug in `bytesToJSONValue` generic handler logic used to determine if bytes value is an encoded UTF-8 string vs. raw bytes.

A false-positive "UTF-8 encoded string" was detected in our test suite in some unrelated work. Specifically, the randomly generated address `0x57e32bd396b7c3337dd6b4a672e6d99b47865e56` was tested and found to be a valid "WTF-8 encoded string", which is used internally by AssemblyScript, but not a valid "UTF-8 encoded string". Upon further investigation, the likelihood of of us attempting to upload a bytes32 not intended to be an encoded string (e.g. Merkle root) is pretty high (Based on testing a few random addresses, I would estimate anywhere from 10% to 50%, not completely sure without spending more time).

This updates our handler logic to convert from `Bytes` to string via `Bytes.toString()` method, then from string to Bytes via `string.toHexString()` method. The starting `Bytes` and the decoded/re-encoded `Bytes` will only be the same if the original `Bytes` was a valid `UTF-8` encoded string.

Note that it is possible for this to detect false-positives and improperly assume bytes are an encoded string. The likelihood of that occurring goes up with shorter bytes values being stored. When using a Bytes32, it seems negligibly likely that we would encounter a false positive, If we want to prove that we should do some more work to quantify.

## Deployment Impacts
This bug fix should be included for any work with the new Merkle minter (currently in Goerli-dev deployment) Cc @mchrupcala 