### PR TITLE
Emulate Set instead of Array for generic "many values"

### DIFF
--- a/src/minter-suite-mapping.ts
+++ b/src/minter-suite-mapping.ts
@@ -707,7 +707,10 @@ export function handleAddManyValueGeneric<T, C>(
     if (val) {
       arr = val.toArray().map<BigInt>((v: JSONValue) => v.toBigInt());
     }
-    arr.push(event.params._value);
+    // only add if it doesn't exist, so we act like a Set
+    if (!arr.includes(event.params._value)) {
+      arr.push(event.params._value);
+    }
     newValue = arrayToJSONValue(arr.toString());
   } else if (
     event instanceof ConfigValueAddedToSetAddress ||
@@ -730,7 +733,10 @@ export function handleAddManyValueGeneric<T, C>(
       // for Bytes, use method to determine if string or hexString
       stringVal = bytesToJSONValue(event.params._value).toString();
     }
-    arr.push(stringToJSONString(stringVal));
+    // only add if it doesn't exist, so we act like a Set
+    if (!arr.includes(stringVal)) {
+      arr.push(stringToJSONString(stringVal));
+    }
     newValue = arrayToJSONValue(arr.toString());
   }
 

--- a/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
+++ b/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
@@ -1711,6 +1711,61 @@ test("handleAddManyBigIntValue should add a value to an array at a designated ke
     "extraMinterDetails",
     '{"array":[100]}'
   );
+  configValueSetEvent.parameters[2] = new ethereum.EventParam(
+    "_value",
+    ethereum.Value.fromSignedBigInt(BigInt.fromI32(200))
+  );
+  handleAddManyBigIntValue(configValueSetEvent);
+
+  assert.fieldEquals(
+    PROJECT_MINTER_CONFIGURATION_ENTITY_TYPE,
+    getProjectMinterConfigId(minterAddress.toHexString(), project.id),
+    "extraMinterDetails",
+    '{"array":[100,200]}'
+  );
+});
+test("handleAddManyBigIntValue should add a single value to an array at a designated key extraMinterDetails, when duplicate of same value is added", () => {
+  clearStore();
+  const minter = addNewMinterToStore("MinterHolderV0");
+  const minterAddress: Address = changetype<Address>(
+    Address.fromHexString(minter.id)
+  );
+  const minterType = minter.type;
+
+  const projectId = BigInt.fromI32(0);
+  const project = addNewProjectToStore(
+    TEST_CONTRACT_ADDRESS,
+    projectId,
+    "project 0",
+    randomAddressGenerator.generateRandomAddress(),
+    BigInt.fromI32(0),
+    CURRENT_BLOCK_TIMESTAMP.minus(BigInt.fromI32(10))
+  );
+
+  const projectMinterConfig = addNewProjectMinterConfigToStore(
+    project.id,
+    minterAddress
+  );
+
+  const configValueSetEvent: ConfigValueAddedToSetBigInt = changetype<
+    ConfigValueAddedToSetBigInt
+  >(newMockEvent());
+  configValueSetEvent.address = minterAddress;
+  configValueSetEvent.parameters = [
+    new ethereum.EventParam(
+      "_projectId",
+      ethereum.Value.fromUnsignedBigInt(projectId)
+    ),
+    new ethereum.EventParam(
+      "_key",
+      ethereum.Value.fromBytes(Bytes.fromUTF8("array"))
+    ),
+    new ethereum.EventParam(
+      "_value",
+      ethereum.Value.fromSignedBigInt(BigInt.fromI32(100))
+    )
+  ];
+  configValueSetEvent.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
 
   handleAddManyBigIntValue(configValueSetEvent);
 
@@ -1718,7 +1773,16 @@ test("handleAddManyBigIntValue should add a value to an array at a designated ke
     PROJECT_MINTER_CONFIGURATION_ENTITY_TYPE,
     getProjectMinterConfigId(minterAddress.toHexString(), project.id),
     "extraMinterDetails",
-    '{"array":[100,100]}'
+    '{"array":[100]}'
+  );
+
+  handleAddManyBigIntValue(configValueSetEvent);
+
+  assert.fieldEquals(
+    PROJECT_MINTER_CONFIGURATION_ENTITY_TYPE,
+    getProjectMinterConfigId(minterAddress.toHexString(), project.id),
+    "extraMinterDetails",
+    '{"array":[100]}'
   );
 });
 test("handleAddManyAddressValue should add a value to an array at a designated key extraMinterDetails", () => {


### PR DESCRIPTION
Update `handleAddManyValueGeneric` handler to treat "many values" as a Set instead of an Array.

I _think_ this is desired behavior, but would love input from others on this.

Current behavior:
- Behave like Array:
  - e.g. If `100` is added twice, generic json would be `{<key>: [100, 100]}`
Updated behavior:
- Behave like Set:
  - e.g. if `100` is added twice, generic json would be: `{<key>: [100]}`

A Set is typically preferable because how Solidity works so well with mappings, which act more like Sets than Arrays. Emulating a Set in our subgraph eliminates on-chain validation to protect against adding something more than once (reducing gas cost and on-chain complexity). Most relevant current example is [this line in our MinterHolder](https://github.com/ArtBlocks/artblocks-contracts/blob/ed09f1c352916d0736b06ac7eb913b157aef7b51/contracts/minter-suite/Minters/MinterHolder/MinterHolderV0.sol#L197)
With this update, smart contract doesn't have to validate if the project is already allowlisted, it simply sets the mapping value to true, and emits an event indicating the project is allowlisted. It is up to the frontend to intelligently avoid duplicate allow/deny requests when queueing up txs.

Cc @mchrupcala since this was based on convo from today 🙏 