### PR TITLE
Add updated V3 core Admin ACL to goerli dev config

### DIFF
--- a/config/goerli-dev.json
+++ b/config/goerli-dev.json
@@ -148,7 +148,12 @@
     {
       "address": "0x4Cbf3805011f0f4d4daeDa710b2215fBF37288Ad",
       "name": "Initial Admin ACL V0 for V3 core (deprecated)",
-      "startBlock": 7105457
+      "startBlock": 7594604
+    },
+    {
+      "address": "0x0D277C3d488CdABD86DB37E743765835e273101E",
+      "name": "Updated Admin ACL V0 for V3 core (with event for indexing)",
+      "startBlock": 7625379
     }
   ]
 }


### PR DESCRIPTION
Add updated V3 core Admin ACL contract to Goerli dev config.

The updated Admin ACL includes an event that is emitted when the Admin ACL's superAdmin is changed, enabling indexing of a V3 core contract's admin and [whitelisted] address. 

>Note: this commit should be included in our initial goerli dev subgraph deployment