### PR TITLE
Bug fix: Avoid generic handlers in subgraph.yaml

### DIFF
--- a/src/minter-suite-mapping.ts
+++ b/src/minter-suite-mapping.ts
@@ -419,6 +419,30 @@ export function handleHoldersOfProjectsGeneric<T>(event: T): void {
   }
 }
 
+export function handleAllowHoldersOfProjectsV0(
+  event: MinterHolderV0AllowedHoldersOfProjects
+): void {
+  handleHoldersOfProjectsGeneric(event);
+}
+
+export function handleRemoveHoldersOfProjectsV0(
+  event: MinterHolderV0RemovedHoldersOfProjects
+): void {
+  handleHoldersOfProjectsGeneric(event);
+}
+
+export function handleAllowHoldersOfProjectsV1(
+  event: MinterHolderV1AllowedHoldersOfProjects
+): void {
+  handleHoldersOfProjectsGeneric(event);
+}
+
+export function handleRemoveHoldersOfProjectsV1(
+  event: MinterHolderV1RemovedHoldersOfProjects
+): void {
+  handleHoldersOfProjectsGeneric(event);
+}
+
 export function handleRegistrationNFTAddresses<T>(event: T): void {
   if (
     !(

--- a/src/minter-suite-mapping.ts
+++ b/src/minter-suite-mapping.ts
@@ -170,7 +170,18 @@ export function handlePurchaseToDisabledUpdated(
 }
 
 // MinterDALin events
-export function handleMinimumAuctionLengthSecondsUpdated<T>(event: T): void {
+
+// This is meant to handle all `MinimumAuctionLengthSecondsUpdated` events from all
+// versions of the DALin contract because they have the same signature
+export function handleMinimumAuctionLengthSecondsUpdated(
+  event: MinimumAuctionLengthSecondsUpdatedV0
+): void {
+  handleMinimumAuctionLengthSecondsUpdatedGeneric(event);
+}
+
+export function handleMinimumAuctionLengthSecondsUpdatedGeneric<T>(
+  event: T
+): void {
   if (
     !(
       event instanceof MinimumAuctionLengthSecondsUpdatedV0 ||
@@ -189,7 +200,15 @@ export function handleMinimumAuctionLengthSecondsUpdated<T>(event: T): void {
   minter.save();
 }
 
-export function handleDALinSetAuctionDetails<T>(event: T): void {
+// This is meant to handle all `SetAuctionDetails` events from all
+// versions of the DALin contract because they have the same signature
+export function handleDALinSetAuctionDetails(
+  event: DALinV0SetAuctionDetails
+): void {
+  handleDALinSetAuctionDetailsGeneric(event);
+}
+
+export function handleDALinSetAuctionDetailsGeneric<T>(event: T): void {
   if (
     !(
       event instanceof DALinV0SetAuctionDetails ||
@@ -223,7 +242,15 @@ export function handleDALinSetAuctionDetails<T>(event: T): void {
   }
 }
 
-export function handleDALinResetAuctionDetails<T>(event: T): void {
+// This is meant to handle all `ResetAuctionDetails` events from all
+// versions of the DALin contract because they have the same signature
+export function handleDALinResetAuctionDetails(
+  event: DALinV0ResetAuctionDetails
+): void {
+  handleDALinResetAuctionDetailsGeneric(event);
+}
+
+export function handleDALinResetAuctionDetailsGeneric<T>(event: T): void {
   if (
     !(
       event instanceof DALinV0ResetAuctionDetails ||
@@ -257,8 +284,18 @@ export function handleDALinResetAuctionDetails<T>(event: T): void {
   }
 }
 
+// This is meant to handle all `AuctionHalfLifeRangeSecondsUpdated` events from all
+// versions of the DAExp contract because they have the same signature
+export function handleAuctionHalfLifeRangeSecondsUpdated(
+  event: DAExpV0SetAuctionDetails
+): void {
+  handleAuctionHalfLifeRangeSecondsUpdatedGeneric(event);
+}
+
 // MinterDAExp events
-export function handleAuctionHalfLifeRangeSecondsUpdated<T>(event: T): void {
+export function handleAuctionHalfLifeRangeSecondsUpdatedGeneric<T>(
+  event: T
+): void {
   if (
     !(
       event instanceof AuctionHalfLifeRangeSecondsUpdatedV0 ||
@@ -280,7 +317,15 @@ export function handleAuctionHalfLifeRangeSecondsUpdated<T>(event: T): void {
   minter.save();
 }
 
-export function handleDAExpSetAuctionDetails<T>(event: T): void {
+// This is meant to handle all `SetAuctionDetails` events from all
+// versions of the DAExp contract because they have the same signature
+export function handleDAExpSetAuctionDetails(
+  event: DAExpV0SetAuctionDetails
+): void {
+  handleDAExpSetAuctionDetailsGeneric(event);
+}
+
+export function handleDAExpSetAuctionDetailsGeneric<T>(event: T): void {
   if (
     !(
       event instanceof DAExpV0SetAuctionDetails ||
@@ -315,7 +360,15 @@ export function handleDAExpSetAuctionDetails<T>(event: T): void {
   }
 }
 
-export function handleDAExpResetAuctionDetails<T>(event: T): void {
+// This is meant to handle all `ResetAuctionDetails` events from all
+// versions of the DAExp contract because they have the same signature
+export function handleDAExpResetAuctionDetails(
+  event: DAExpV0ResetAuctionDetails
+): void {
+  handleDAExpResetAuctionDetailsGeneric(event);
+}
+
+export function handleDAExpResetAuctionDetailsGeneric<T>(event: T): void {
   if (
     !(
       event instanceof DAExpV0ResetAuctionDetails ||

--- a/src/minter-suite-mapping.ts
+++ b/src/minter-suite-mapping.ts
@@ -419,26 +419,18 @@ export function handleHoldersOfProjectsGeneric<T>(event: T): void {
   }
 }
 
-export function handleAllowHoldersOfProjectsV0(
+// This is meant to handle all `AllowedHoldersOfProjects` events from all
+// versions of the MinterHolder contract because they have the same signature
+export function handleAllowHoldersOfProjects(
   event: MinterHolderV0AllowedHoldersOfProjects
 ): void {
   handleHoldersOfProjectsGeneric(event);
 }
 
-export function handleRemoveHoldersOfProjectsV0(
+// This is meant to handle all `RemovedHoldersOfProjects` events from all
+// versions of the MinterHolder contract because they have the same signature
+export function handleRemoveHoldersOfProjects(
   event: MinterHolderV0RemovedHoldersOfProjects
-): void {
-  handleHoldersOfProjectsGeneric(event);
-}
-
-export function handleAllowHoldersOfProjectsV1(
-  event: MinterHolderV1AllowedHoldersOfProjects
-): void {
-  handleHoldersOfProjectsGeneric(event);
-}
-
-export function handleRemoveHoldersOfProjectsV1(
-  event: MinterHolderV1RemovedHoldersOfProjects
 ): void {
   handleHoldersOfProjectsGeneric(event);
 }
@@ -482,26 +474,18 @@ export function handleRegistrationNFTAddresses<T>(event: T): void {
   }
 }
 
-export function handleRegisteredNFTAddressV0(
+// This is meant to handle all `RegisteredNFTAddress` events from all
+// versions of the MinterHolder contract because they have the same signature
+export function handleRegisteredNFTAddress(
   event: MinterHolderV0RegisteredNFTAddress
 ): void {
   handleRegistrationNFTAddresses(event);
 }
 
-export function handleUnregisteredNFTAddressV0(
+// This is meant to handle all `UnregisteredNFTAddress` events from all
+// versions of the MinterHolder contract because they have the same signature
+export function handleUnregisteredNFTAddress(
   event: MinterHolderV0UnregisteredNFTAddress
-): void {
-  handleRegistrationNFTAddresses(event);
-}
-
-export function handleRegisteredNFTAddressV1(
-  event: MinterHolderV1RegisteredNFTAddress
-): void {
-  handleRegistrationNFTAddresses(event);
-}
-
-export function handleUnregisteredNFTAddressV1(
-  event: MinterHolderV1UnregisteredNFTAddress
 ): void {
   handleRegistrationNFTAddresses(event);
 }

--- a/src/minter-suite-mapping.ts
+++ b/src/minter-suite-mapping.ts
@@ -309,17 +309,17 @@ export function handleDALinResetAuctionDetailsGeneric<T>(event: T): void {
 }
 
 export function handleAuctionHalfLifeRangeSecondsUpdatedV0(
-  event: DAExpV0SetAuctionDetails
+  event: AuctionHalfLifeRangeSecondsUpdatedV0
 ): void {
   handleAuctionHalfLifeRangeSecondsUpdatedGeneric(event);
 }
 export function handleAuctionHalfLifeRangeSecondsUpdatedV1(
-  event: DAExpV1SetAuctionDetails
+  event: AuctionHalfLifeRangeSecondsUpdatedV1
 ): void {
   handleAuctionHalfLifeRangeSecondsUpdatedGeneric(event);
 }
 export function handleAuctionHalfLifeRangeSecondsUpdatedV2(
-  event: DAExpV2SetAuctionDetails
+  event: AuctionHalfLifeRangeSecondsUpdatedV2
 ): void {
   handleAuctionHalfLifeRangeSecondsUpdatedGeneric(event);
 }

--- a/src/minter-suite-mapping.ts
+++ b/src/minter-suite-mapping.ts
@@ -171,10 +171,18 @@ export function handlePurchaseToDisabledUpdated(
 
 // MinterDALin events
 
-// This is meant to handle all `MinimumAuctionLengthSecondsUpdated` events from all
-// versions of the DALin contract because they have the same signature
-export function handleMinimumAuctionLengthSecondsUpdated(
+export function handleMinimumAuctionLengthSecondsUpdatedV0(
   event: MinimumAuctionLengthSecondsUpdatedV0
+): void {
+  handleMinimumAuctionLengthSecondsUpdatedGeneric(event);
+}
+export function handleMinimumAuctionLengthSecondsUpdatedV1(
+  event: MinimumAuctionLengthSecondsUpdatedV1
+): void {
+  handleMinimumAuctionLengthSecondsUpdatedGeneric(event);
+}
+export function handleMinimumAuctionLengthSecondsUpdatedV2(
+  event: MinimumAuctionLengthSecondsUpdatedV2
 ): void {
   handleMinimumAuctionLengthSecondsUpdatedGeneric(event);
 }
@@ -200,10 +208,18 @@ export function handleMinimumAuctionLengthSecondsUpdatedGeneric<T>(
   minter.save();
 }
 
-// This is meant to handle all `SetAuctionDetails` events from all
-// versions of the DALin contract because they have the same signature
-export function handleDALinSetAuctionDetails(
+export function handleDALinSetAuctionDetailsV0(
   event: DALinV0SetAuctionDetails
+): void {
+  handleDALinSetAuctionDetailsGeneric(event);
+}
+export function handleDALinSetAuctionDetailsV1(
+  event: DALinV1SetAuctionDetails
+): void {
+  handleDALinSetAuctionDetailsGeneric(event);
+}
+export function handleDALinSetAuctionDetailsV2(
+  event: DALinV2SetAuctionDetails
 ): void {
   handleDALinSetAuctionDetailsGeneric(event);
 }
@@ -242,10 +258,18 @@ export function handleDALinSetAuctionDetailsGeneric<T>(event: T): void {
   }
 }
 
-// This is meant to handle all `ResetAuctionDetails` events from all
-// versions of the DALin contract because they have the same signature
-export function handleDALinResetAuctionDetails(
+export function handleDALinResetAuctionDetailsV0(
   event: DALinV0ResetAuctionDetails
+): void {
+  handleDALinResetAuctionDetailsGeneric(event);
+}
+export function handleDALinResetAuctionDetailsV1(
+  event: DALinV1ResetAuctionDetails
+): void {
+  handleDALinResetAuctionDetailsGeneric(event);
+}
+export function handleDALinResetAuctionDetailsV2(
+  event: DALinV2ResetAuctionDetails
 ): void {
   handleDALinResetAuctionDetailsGeneric(event);
 }
@@ -284,10 +308,18 @@ export function handleDALinResetAuctionDetailsGeneric<T>(event: T): void {
   }
 }
 
-// This is meant to handle all `AuctionHalfLifeRangeSecondsUpdated` events from all
-// versions of the DAExp contract because they have the same signature
-export function handleAuctionHalfLifeRangeSecondsUpdated(
+export function handleAuctionHalfLifeRangeSecondsUpdatedV0(
   event: DAExpV0SetAuctionDetails
+): void {
+  handleAuctionHalfLifeRangeSecondsUpdatedGeneric(event);
+}
+export function handleAuctionHalfLifeRangeSecondsUpdatedV1(
+  event: DAExpV1SetAuctionDetails
+): void {
+  handleAuctionHalfLifeRangeSecondsUpdatedGeneric(event);
+}
+export function handleAuctionHalfLifeRangeSecondsUpdatedV2(
+  event: DAExpV2SetAuctionDetails
 ): void {
   handleAuctionHalfLifeRangeSecondsUpdatedGeneric(event);
 }
@@ -317,10 +349,18 @@ export function handleAuctionHalfLifeRangeSecondsUpdatedGeneric<T>(
   minter.save();
 }
 
-// This is meant to handle all `SetAuctionDetails` events from all
-// versions of the DAExp contract because they have the same signature
-export function handleDAExpSetAuctionDetails(
+export function handleDAExpSetAuctionDetailsV0(
   event: DAExpV0SetAuctionDetails
+): void {
+  handleDAExpSetAuctionDetailsGeneric(event);
+}
+export function handleDAExpSetAuctionDetailsV1(
+  event: DAExpV1SetAuctionDetails
+): void {
+  handleDAExpSetAuctionDetailsGeneric(event);
+}
+export function handleDAExpSetAuctionDetailsV2(
+  event: DAExpV2SetAuctionDetails
 ): void {
   handleDAExpSetAuctionDetailsGeneric(event);
 }
@@ -360,10 +400,18 @@ export function handleDAExpSetAuctionDetailsGeneric<T>(event: T): void {
   }
 }
 
-// This is meant to handle all `ResetAuctionDetails` events from all
-// versions of the DAExp contract because they have the same signature
-export function handleDAExpResetAuctionDetails(
+export function handleDAExpResetAuctionDetailsV0(
   event: DAExpV0ResetAuctionDetails
+): void {
+  handleDAExpResetAuctionDetailsGeneric(event);
+}
+export function handleDAExpResetAuctionDetailsV1(
+  event: DAExpV1ResetAuctionDetails
+): void {
+  handleDAExpResetAuctionDetailsGeneric(event);
+}
+export function handleDAExpResetAuctionDetailsV2(
+  event: DAExpV2ResetAuctionDetails
 ): void {
   handleDAExpResetAuctionDetailsGeneric(event);
 }
@@ -472,18 +520,24 @@ export function handleHoldersOfProjectsGeneric<T>(event: T): void {
   }
 }
 
-// This is meant to handle all `AllowedHoldersOfProjects` events from all
-// versions of the MinterHolder contract because they have the same signature
-export function handleAllowHoldersOfProjects(
+export function handleAllowHoldersOfProjectsV0(
+  event: MinterHolderV0AllowedHoldersOfProjects
+): void {
+  handleHoldersOfProjectsGeneric(event);
+}
+export function handleAllowHoldersOfProjectsV1(
   event: MinterHolderV0AllowedHoldersOfProjects
 ): void {
   handleHoldersOfProjectsGeneric(event);
 }
 
-// This is meant to handle all `RemovedHoldersOfProjects` events from all
-// versions of the MinterHolder contract because they have the same signature
-export function handleRemoveHoldersOfProjects(
+export function handleRemoveHoldersOfProjectsV0(
   event: MinterHolderV0RemovedHoldersOfProjects
+): void {
+  handleHoldersOfProjectsGeneric(event);
+}
+export function handleRemoveHoldersOfProjectsV1(
+  event: MinterHolderV1RemovedHoldersOfProjects
 ): void {
   handleHoldersOfProjectsGeneric(event);
 }
@@ -527,18 +581,24 @@ export function handleRegistrationNFTAddresses<T>(event: T): void {
   }
 }
 
-// This is meant to handle all `RegisteredNFTAddress` events from all
-// versions of the MinterHolder contract because they have the same signature
-export function handleRegisteredNFTAddress(
+export function handleRegisteredNFTAddressV0(
   event: MinterHolderV0RegisteredNFTAddress
 ): void {
   handleRegistrationNFTAddresses(event);
 }
+export function handleRegisteredNFTAddressV1(
+  event: MinterHolderV1RegisteredNFTAddress
+): void {
+  handleRegistrationNFTAddresses(event);
+}
 
-// This is meant to handle all `UnregisteredNFTAddress` events from all
-// versions of the MinterHolder contract because they have the same signature
-export function handleUnregisteredNFTAddress(
+export function handleUnregisteredNFTAddressV0(
   event: MinterHolderV0UnregisteredNFTAddress
+): void {
+  handleRegistrationNFTAddresses(event);
+}
+export function handleUnregisteredNFTAddressV1(
+  event: MinterHolderV1UnregisteredNFTAddress
 ): void {
   handleRegistrationNFTAddresses(event);
 }

--- a/src/minter-suite-mapping.ts
+++ b/src/minter-suite-mapping.ts
@@ -452,6 +452,28 @@ export function handleDAExpResetAuctionDetailsGeneric<T>(event: T): void {
 
 // MinterHolder Specific Handlers
 
+export function handleAllowHoldersOfProjectsV0(
+  event: MinterHolderV0AllowedHoldersOfProjects
+): void {
+  handleHoldersOfProjectsGeneric(event);
+}
+export function handleAllowHoldersOfProjectsV1(
+  event: MinterHolderV1AllowedHoldersOfProjects
+): void {
+  handleHoldersOfProjectsGeneric(event);
+}
+
+export function handleRemoveHoldersOfProjectsV0(
+  event: MinterHolderV0RemovedHoldersOfProjects
+): void {
+  handleHoldersOfProjectsGeneric(event);
+}
+export function handleRemoveHoldersOfProjectsV1(
+  event: MinterHolderV1RemovedHoldersOfProjects
+): void {
+  handleHoldersOfProjectsGeneric(event);
+}
+
 export function handleHoldersOfProjectsGeneric<T>(event: T): void {
   if (
     !(
@@ -518,28 +540,6 @@ export function handleHoldersOfProjectsGeneric<T>(event: T): void {
       handleRemoveBytesManyValueProjectConfig(newRemoveEvent);
     }
   }
-}
-
-export function handleAllowHoldersOfProjectsV0(
-  event: MinterHolderV0AllowedHoldersOfProjects
-): void {
-  handleHoldersOfProjectsGeneric(event);
-}
-export function handleAllowHoldersOfProjectsV1(
-  event: MinterHolderV0AllowedHoldersOfProjects
-): void {
-  handleHoldersOfProjectsGeneric(event);
-}
-
-export function handleRemoveHoldersOfProjectsV0(
-  event: MinterHolderV0RemovedHoldersOfProjects
-): void {
-  handleHoldersOfProjectsGeneric(event);
-}
-export function handleRemoveHoldersOfProjectsV1(
-  event: MinterHolderV1RemovedHoldersOfProjects
-): void {
-  handleHoldersOfProjectsGeneric(event);
 }
 
 export function handleRegistrationNFTAddresses<T>(event: T): void {

--- a/src/minter-suite-mapping.ts
+++ b/src/minter-suite-mapping.ts
@@ -458,6 +458,30 @@ export function handleRegistrationNFTAddresses<T>(event: T): void {
   }
 }
 
+export function handleRegisteredNFTAddressV0(
+  event: MinterHolderV0RegisteredNFTAddress
+): void {
+  handleRegistrationNFTAddresses(event);
+}
+
+export function handleUnregisteredNFTAddressV0(
+  event: MinterHolderV0UnregisteredNFTAddress
+): void {
+  handleRegistrationNFTAddresses(event);
+}
+
+export function handleRegisteredNFTAddressV1(
+  event: MinterHolderV1RegisteredNFTAddress
+): void {
+  handleRegistrationNFTAddresses(event);
+}
+
+export function handleUnregisteredNFTAddressV1(
+  event: MinterHolderV1UnregisteredNFTAddress
+): void {
+  handleRegistrationNFTAddresses(event);
+}
+
 // Generic Handlers
 // Below is all logic pertaining to generic handlers used for maintaining JSON config stores on both the ProjectMinterConfiguration and Minter entities.
 // Most logic is shared and bubbled up each respective handler for each action. We utilize ducktype to allow these to work on either a Minter or ProjectMinterConfiguration

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -997,9 +997,9 @@ dataSources:
         - event: ProjectCurrencyInfoUpdated(indexed uint256,indexed address,string)
           handler: handleProjectCurrencyInfoUpdated
         - event: RegisteredNFTAddress(indexed address)
-          handler: handleRegistrationNFTAddresses
+          handler: handleRegistrationNFTAddressesV0
         - event: UnregisteredNFTAddress(indexed address)
-          handler: handleRegistrationNFTAddresses
+          handler: handleRegistrationNFTAddressesV0
         - event: AllowedHoldersOfProjects(indexed uint256,address[],uint256[])
           handler: handleHoldersOfProjectsGeneric
         - event: RemovedHoldersOfProjects(indexed uint256,address[],uint256[])
@@ -1206,9 +1206,9 @@ dataSources:
         - event: ProjectCurrencyInfoUpdated(indexed uint256,indexed address,string)
           handler: handleProjectCurrencyInfoUpdated
         - event: RegisteredNFTAddress(indexed address)
-          handler: handleRegistrationNFTAddresses
+          handler: handleRegistrationNFTAddressesV1
         - event: UnregisteredNFTAddress(indexed address)
-          handler: handleRegistrationNFTAddresses
+          handler: handleRegistrationNFTAddressesV1
         - event: AllowedHoldersOfProjects(indexed uint256,address[],uint256[])
           handler: handleHoldersOfProjectsGeneric
         - event: RemovedHoldersOfProjects(indexed uint256,address[],uint256[])

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -997,9 +997,9 @@ dataSources:
         - event: ProjectCurrencyInfoUpdated(indexed uint256,indexed address,string)
           handler: handleProjectCurrencyInfoUpdated
         - event: RegisteredNFTAddress(indexed address)
-          handler: handleRegistrationNFTAddressesV0
+          handler: handleRegisteredNFTAddress
         - event: UnregisteredNFTAddress(indexed address)
-          handler: handleRegistrationNFTAddressesV0
+          handler: handleUnregisteredNFTAddress
         - event: AllowedHoldersOfProjects(indexed uint256,address[],uint256[])
           handler: handleHoldersOfProjectsGenericV0
         - event: RemovedHoldersOfProjects(indexed uint256,address[],uint256[])
@@ -1206,9 +1206,9 @@ dataSources:
         - event: ProjectCurrencyInfoUpdated(indexed uint256,indexed address,string)
           handler: handleProjectCurrencyInfoUpdated
         - event: RegisteredNFTAddress(indexed address)
-          handler: handleRegistrationNFTAddressesV1
+          handler: handleRegisteredNFTAddress
         - event: UnregisteredNFTAddress(indexed address)
-          handler: handleRegistrationNFTAddressesV1
+          handler: handleUnregisteredNFTAddress
         - event: AllowedHoldersOfProjects(indexed uint256,address[],uint256[])
           handler: handleHoldersOfProjectsGenericV1
         - event: RemovedHoldersOfProjects(indexed uint256,address[],uint256[])

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -1001,9 +1001,9 @@ dataSources:
         - event: UnregisteredNFTAddress(indexed address)
           handler: handleRegistrationNFTAddressesV0
         - event: AllowedHoldersOfProjects(indexed uint256,address[],uint256[])
-          handler: handleHoldersOfProjectsGeneric
+          handler: handleHoldersOfProjectsGenericV0
         - event: RemovedHoldersOfProjects(indexed uint256,address[],uint256[])
-          handler: handleHoldersOfProjectsGeneric
+          handler: handleHoldersOfProjectsGenericV0
       file: ./src/minter-suite-mapping.ts
   {{/minterHolderV0Contracts}}
   {{#minterMerkleV0Contracts}}
@@ -1210,9 +1210,9 @@ dataSources:
         - event: UnregisteredNFTAddress(indexed address)
           handler: handleRegistrationNFTAddressesV1
         - event: AllowedHoldersOfProjects(indexed uint256,address[],uint256[])
-          handler: handleHoldersOfProjectsGeneric
+          handler: handleHoldersOfProjectsGenericV1
         - event: RemovedHoldersOfProjects(indexed uint256,address[],uint256[])
-          handler: handleHoldersOfProjectsGeneric
+          handler: handleHoldersOfProjectsGenericV1
       file: ./src/minter-suite-mapping.ts
   {{/minterHolderV1Contracts}}
   {{#minterMerkleV1Contracts}}

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -780,7 +780,7 @@ dataSources:
           file: ./abis/IFilteredMinterV0.json
       eventHandlers:
         - event: MinimumAuctionLengthSecondsUpdated(uint256)
-          handler: handleMinimumAuctionLengthSecondsUpdated
+          handler: handleMinimumAuctionLengthSecondsUpdatedV0
         - event: PricePerTokenInWeiUpdated(indexed uint256,indexed uint256)
           handler: handlePricePerTokenInWeiUpdated
         - event: ProjectCurrencyInfoUpdated(indexed uint256,indexed address,string)
@@ -788,9 +788,9 @@ dataSources:
         - event: PurchaseToDisabledUpdated(indexed uint256,bool)
           handler: handlePurchaseToDisabledUpdated
         - event: ResetAuctionDetails(indexed uint256)
-          handler: handleDALinResetAuctionDetails
+          handler: handleDALinResetAuctionDetailsV0
         - event: SetAuctionDetails(indexed uint256,uint256,uint256,uint256,uint256)
-          handler: handleDALinSetAuctionDetails
+          handler: handleDALinSetAuctionDetailsV0
       file: ./src/minter-suite-mapping.ts
   {{/minterDALinV0Contracts}}
   {{#minterDAExpV0Contracts}}
@@ -818,7 +818,7 @@ dataSources:
           file: ./abis/IFilteredMinterV0.json
       eventHandlers:
         - event: AuctionHalfLifeRangeSecondsUpdated(uint256,uint256)
-          handler: handleAuctionHalfLifeRangeSecondsUpdated
+          handler: handleAuctionHalfLifeRangeSecondsUpdatedV0
         - event: PricePerTokenInWeiUpdated(indexed uint256,indexed uint256)
           handler: handlePricePerTokenInWeiUpdated
         - event: ProjectCurrencyInfoUpdated(indexed uint256,indexed address,string)
@@ -826,9 +826,9 @@ dataSources:
         - event: PurchaseToDisabledUpdated(indexed uint256,bool)
           handler: handlePurchaseToDisabledUpdated
         - event: ResetAuctionDetails(indexed uint256)
-          handler: handleDAExpResetAuctionDetails
+          handler: handleDAExpResetAuctionDetailsV0
         - event: SetAuctionDetails(indexed uint256,uint256,uint256,uint256,uint256)
-          handler: handleDAExpSetAuctionDetails
+          handler: handleDAExpSetAuctionDetailsV0
       file: ./src/minter-suite-mapping.ts
   {{/minterDAExpV0Contracts}}
   {{#minterSetPriceERC20V1Contracts}}
@@ -921,15 +921,15 @@ dataSources:
           file: ./abis/IFilteredMinterV0.json
       eventHandlers:
         - event: MinimumAuctionLengthSecondsUpdated(uint256)
-          handler: handleMinimumAuctionLengthSecondsUpdated
+          handler: handleMinimumAuctionLengthSecondsUpdatedV1
         - event: PricePerTokenInWeiUpdated(indexed uint256,indexed uint256)
           handler: handlePricePerTokenInWeiUpdated
         - event: ProjectCurrencyInfoUpdated(indexed uint256,indexed address,string)
           handler: handleProjectCurrencyInfoUpdated
         - event: ResetAuctionDetails(indexed uint256)
-          handler: handleDALinResetAuctionDetails
+          handler: handleDALinResetAuctionDetailsV1
         - event: SetAuctionDetails(indexed uint256,uint256,uint256,uint256,uint256)
-          handler: handleDALinSetAuctionDetails
+          handler: handleDALinSetAuctionDetailsV1
       file: ./src/minter-suite-mapping.ts
   {{/minterDALinV1Contracts}}
   {{#minterDAExpV1Contracts}}
@@ -957,15 +957,15 @@ dataSources:
           file: ./abis/IFilteredMinterV0.json
       eventHandlers:
         - event: AuctionHalfLifeRangeSecondsUpdated(uint256,uint256)
-          handler: handleAuctionHalfLifeRangeSecondsUpdated
+          handler: handleAuctionHalfLifeRangeSecondsUpdatedV1
         - event: PricePerTokenInWeiUpdated(indexed uint256,indexed uint256)
           handler: handlePricePerTokenInWeiUpdated
         - event: ProjectCurrencyInfoUpdated(indexed uint256,indexed address,string)
           handler: handleProjectCurrencyInfoUpdated
         - event: ResetAuctionDetails(indexed uint256)
-          handler: handleDAExpResetAuctionDetails
+          handler: handleDAExpResetAuctionDetailsV1
         - event: SetAuctionDetails(indexed uint256,uint256,uint256,uint256,uint256)
-          handler: handleDAExpSetAuctionDetails
+          handler: handleDAExpSetAuctionDetailsV1
       file: ./src/minter-suite-mapping.ts
   {{/minterDAExpV1Contracts}}
   {{#minterHolderV0Contracts}}
@@ -997,13 +997,13 @@ dataSources:
         - event: ProjectCurrencyInfoUpdated(indexed uint256,indexed address,string)
           handler: handleProjectCurrencyInfoUpdated
         - event: RegisteredNFTAddress(indexed address)
-          handler: handleRegisteredNFTAddress
+          handler: handleRegisteredNFTAddressV0
         - event: UnregisteredNFTAddress(indexed address)
-          handler: handleUnregisteredNFTAddress
+          handler: handleUnregisteredNFTAddressV0
         - event: AllowedHoldersOfProjects(indexed uint256,address[],uint256[])
-          handler: handleHoldersOfProjectsGenericV0
+          handler: handleAllowHoldersOfProjectsV0
         - event: RemovedHoldersOfProjects(indexed uint256,address[],uint256[])
-          handler: handleHoldersOfProjectsGenericV0
+          handler: handleRemoveHoldersOfProjectsV0
       file: ./src/minter-suite-mapping.ts
   {{/minterHolderV0Contracts}}
   {{#minterMerkleV0Contracts}}
@@ -1130,15 +1130,15 @@ dataSources:
           file: ./abis/IFilteredMinterV0.json
       eventHandlers:
         - event: MinimumAuctionLengthSecondsUpdated(uint256)
-          handler: handleMinimumAuctionLengthSecondsUpdated
+          handler: handleMinimumAuctionLengthSecondsUpdatedV2
         - event: PricePerTokenInWeiUpdated(indexed uint256,indexed uint256)
           handler: handlePricePerTokenInWeiUpdated
         - event: ProjectCurrencyInfoUpdated(indexed uint256,indexed address,string)
           handler: handleProjectCurrencyInfoUpdated
         - event: ResetAuctionDetails(indexed uint256)
-          handler: handleDALinResetAuctionDetails
+          handler: handleDALinResetAuctionDetailsV2
         - event: SetAuctionDetails(indexed uint256,uint256,uint256,uint256,uint256)
-          handler: handleDALinSetAuctionDetails
+          handler: handleDALinSetAuctionDetailsV2
       file: ./src/minter-suite-mapping.ts
   {{/minterDALinV2Contracts}}
   {{#minterDAExpV2Contracts}}
@@ -1166,15 +1166,15 @@ dataSources:
           file: ./abis/IFilteredMinterV0.json
       eventHandlers:
         - event: AuctionHalfLifeRangeSecondsUpdated(uint256,uint256)
-          handler: handleAuctionHalfLifeRangeSecondsUpdated
+          handler: handleAuctionHalfLifeRangeSecondsUpdatedV2
         - event: PricePerTokenInWeiUpdated(indexed uint256,indexed uint256)
           handler: handlePricePerTokenInWeiUpdated
         - event: ProjectCurrencyInfoUpdated(indexed uint256,indexed address,string)
           handler: handleProjectCurrencyInfoUpdated
         - event: ResetAuctionDetails(indexed uint256)
-          handler: handleDAExpResetAuctionDetails
+          handler: handleDAExpResetAuctionDetailsV2
         - event: SetAuctionDetails(indexed uint256,uint256,uint256,uint256,uint256)
-          handler: handleDAExpSetAuctionDetails
+          handler: handleDAExpSetAuctionDetailsV2
       file: ./src/minter-suite-mapping.ts
   {{/minterDAExpV2Contracts}}
   {{#minterHolderV1Contracts}}
@@ -1206,13 +1206,13 @@ dataSources:
         - event: ProjectCurrencyInfoUpdated(indexed uint256,indexed address,string)
           handler: handleProjectCurrencyInfoUpdated
         - event: RegisteredNFTAddress(indexed address)
-          handler: handleRegisteredNFTAddress
+          handler: handleRegisteredNFTAddressV1
         - event: UnregisteredNFTAddress(indexed address)
-          handler: handleUnregisteredNFTAddress
+          handler: handleUnregisteredNFTAddressV1
         - event: AllowedHoldersOfProjects(indexed uint256,address[],uint256[])
-          handler: handleHoldersOfProjectsGenericV1
+          handler: handleAllowHoldersOfProjectsV1
         - event: RemovedHoldersOfProjects(indexed uint256,address[],uint256[])
-          handler: handleHoldersOfProjectsGenericV1
+          handler: handleRemoveHoldersOfProjectsV1
       file: ./src/minter-suite-mapping.ts
   {{/minterHolderV1Contracts}}
   {{#minterMerkleV1Contracts}}

--- a/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
+++ b/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
@@ -60,7 +60,7 @@ import {
   MinimumAuctionLengthSecondsUpdated as DALinV2MinimumAuctionLengthSecondsUpdated
 } from "../../../generated/MinterDALinV2/MinterDALinV2";
 import {
-  AuctionHalfLifeRangeSecondsUpdated,
+  AuctionHalfLifeRangeSecondsUpdated as AuctionHalfLifeRangeSecondsUpdatedV0,
   SetAuctionDetails as DAExpV0SetAuctionDetails,
   ResetAuctionDetails as DAExpV0ResetAuctionDetails
 } from "../../../generated/MinterDAExpV0/MinterDAExpV0";
@@ -92,12 +92,24 @@ import {
   handleAddManyBigIntValueProjectConfig as handleAddManyBigIntValue,
   handleAddManyBytesValueProjectConfig as handleAddManyBytesValue,
   handleHoldersOfProjectsGeneric,
-  handleAuctionHalfLifeRangeSecondsUpdated,
-  handleDAExpResetAuctionDetails,
-  handleDAExpSetAuctionDetails,
-  handleDALinResetAuctionDetails,
-  handleDALinSetAuctionDetails,
-  handleMinimumAuctionLengthSecondsUpdated,
+  handleAuctionHalfLifeRangeSecondsUpdatedV0,
+  handleAuctionHalfLifeRangeSecondsUpdatedV1,
+  handleAuctionHalfLifeRangeSecondsUpdatedV2,
+  handleDAExpResetAuctionDetailsV0,
+  handleDAExpResetAuctionDetailsV1,
+  handleDAExpResetAuctionDetailsV2,
+  handleDAExpSetAuctionDetailsV0,
+  handleDAExpSetAuctionDetailsV1,
+  handleDAExpSetAuctionDetailsV2,
+  handleDALinResetAuctionDetailsV0,
+  handleDALinResetAuctionDetailsV1,
+  handleDALinResetAuctionDetailsV2,
+  handleDALinSetAuctionDetailsV0,
+  handleDALinSetAuctionDetailsV1,
+  handleDALinSetAuctionDetailsV2,
+  handleMinimumAuctionLengthSecondsUpdatedV0,
+  handleMinimumAuctionLengthSecondsUpdatedV1,
+  handleMinimumAuctionLengthSecondsUpdatedV2,
   handlePricePerTokenInWeiUpdated,
   handleProjectCurrencyInfoUpdated,
   handlePurchaseToDisabledUpdated,
@@ -483,15 +495,15 @@ describe("MinterDALin-related tests", () => {
         event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
 
         if (minterType == "MinterDALinV0") {
-          handleMinimumAuctionLengthSecondsUpdated(
+          handleMinimumAuctionLengthSecondsUpdatedV0(
             changetype<DALinV0MinimumAuctionLengthSecondsUpdated>(event)
           );
         } else if (minterType == "MinterDALinV1") {
-          handleMinimumAuctionLengthSecondsUpdated(
+          handleMinimumAuctionLengthSecondsUpdatedV1(
             changetype<DALinV1MinimumAuctionLengthSecondsUpdated>(event)
           );
         } else {
-          handleMinimumAuctionLengthSecondsUpdated(
+          handleMinimumAuctionLengthSecondsUpdatedV2(
             changetype<DALinV2MinimumAuctionLengthSecondsUpdated>(event)
           );
         }
@@ -545,15 +557,15 @@ describe("MinterDALin-related tests", () => {
         assert.notInStore(PROJECT_ENTITY_TYPE, fullProjectId);
 
         if (minterType == "MinterDALinV0") {
-          handleDALinSetAuctionDetails(
+          handleDALinSetAuctionDetailsV0(
             changetype<DALinV0SetAuctionDetails>(event)
           );
         } else if (minterType == "MinterDALinV1") {
-          handleDALinSetAuctionDetails(
+          handleDALinSetAuctionDetailsV1(
             changetype<DALinV1SetAuctionDetails>(event)
           );
         } else {
-          handleDALinSetAuctionDetails(
+          handleDALinSetAuctionDetailsV2(
             changetype<DALinV2SetAuctionDetails>(event)
           );
         }
@@ -629,15 +641,15 @@ describe("MinterDALin-related tests", () => {
         event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
 
         if (minterType == "MinterDALinV0") {
-          handleDALinSetAuctionDetails(
+          handleDALinSetAuctionDetailsV0(
             changetype<DALinV0SetAuctionDetails>(event)
           );
         } else if (minterType == "MinterDALinV1") {
-          handleDALinSetAuctionDetails(
+          handleDALinSetAuctionDetailsV1(
             changetype<DALinV1SetAuctionDetails>(event)
           );
         } else {
-          handleDALinSetAuctionDetails(
+          handleDALinSetAuctionDetailsV2(
             changetype<DALinV2SetAuctionDetails>(event)
           );
         }
@@ -711,15 +723,15 @@ describe("MinterDALin-related tests", () => {
           assert.notInStore(PROJECT_ENTITY_TYPE, fullProjectId);
 
           if (minterType == "MinterDALinV0") {
-            handleDALinResetAuctionDetails(
+            handleDALinResetAuctionDetailsV0(
               changetype<DALinV0ResetAuctionDetails>(event)
             );
           } else if (minterType == "MinterDALinV1") {
-            handleDALinResetAuctionDetails(
+            handleDALinResetAuctionDetailsV1(
               changetype<DALinV1ResetAuctionDetails>(event)
             );
           } else {
-            handleDALinResetAuctionDetails(
+            handleDALinResetAuctionDetailsV2(
               changetype<DALinV2ResetAuctionDetails>(event)
             );
           }
@@ -784,15 +796,15 @@ describe("MinterDALin-related tests", () => {
           event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
 
           if (minterType == "MinterDALinV0") {
-            handleDALinResetAuctionDetails(
+            handleDALinResetAuctionDetailsV0(
               changetype<DALinV0ResetAuctionDetails>(event)
             );
           } else if (minterType == "MinterDALinV1") {
-            handleDALinResetAuctionDetails(
+            handleDALinResetAuctionDetailsV1(
               changetype<DALinV1ResetAuctionDetails>(event)
             );
           } else {
-            handleDALinResetAuctionDetails(
+            handleDALinResetAuctionDetailsV2(
               changetype<DALinV2ResetAuctionDetails>(event)
             );
           }
@@ -854,9 +866,6 @@ describe("MinterDAExp-related tests", () => {
         const newMinimumHalfLifeInSeconds = BigInt.fromI32(600);
         const newMaximumHalfLifeInSeconds = BigInt.fromI32(1200);
         let event = newMockEvent();
-        const auctionHalfLifeRangeSecondsUpdatedEvent: AuctionHalfLifeRangeSecondsUpdated = changetype<
-          AuctionHalfLifeRangeSecondsUpdated
-        >(newMockEvent());
         event.address = minterAddress;
         event.parameters = [
           new ethereum.EventParam(
@@ -871,15 +880,15 @@ describe("MinterDAExp-related tests", () => {
         event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
 
         if (minterType === "MinterDAExpV0") {
-          handleAuctionHalfLifeRangeSecondsUpdated(
-            changetype<AuctionHalfLifeRangeSecondsUpdated>(event)
+          handleAuctionHalfLifeRangeSecondsUpdatedV0(
+            changetype<AuctionHalfLifeRangeSecondsUpdatedV0>(event)
           );
         } else if (minterType === "MinterDAExpV1") {
-          handleAuctionHalfLifeRangeSecondsUpdated(
+          handleAuctionHalfLifeRangeSecondsUpdatedV1(
             changetype<AuctionHalfLifeRangeSecondsUpdatedV1>(event)
           );
         } else {
-          handleAuctionHalfLifeRangeSecondsUpdated(
+          handleAuctionHalfLifeRangeSecondsUpdatedV2(
             changetype<AuctionHalfLifeRangeSecondsUpdatedV2>(event)
           );
         }
@@ -936,15 +945,15 @@ describe("MinterDAExp-related tests", () => {
         assert.notInStore(PROJECT_ENTITY_TYPE, fullProjectId);
 
         if (minterType === "MinterDAExpV0") {
-          handleDAExpSetAuctionDetails(
+          handleDAExpSetAuctionDetailsV0(
             changetype<DAExpV0SetAuctionDetails>(event)
           );
         } else if (minterType === "MinterDAExpV1") {
-          handleDAExpSetAuctionDetails(
+          handleDAExpSetAuctionDetailsV1(
             changetype<DAExpV1SetAuctionDetails>(event)
           );
         } else {
-          handleDAExpSetAuctionDetails(
+          handleDAExpSetAuctionDetailsV2(
             changetype<DAExpV2SetAuctionDetails>(event)
           );
         }
@@ -1020,15 +1029,15 @@ describe("MinterDAExp-related tests", () => {
         event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
 
         if (minterType === "MinterDAExpV0") {
-          handleDAExpSetAuctionDetails(
+          handleDAExpSetAuctionDetailsV0(
             changetype<DAExpV0SetAuctionDetails>(event)
           );
         } else if (minterType === "MinterDAExpV1") {
-          handleDAExpSetAuctionDetails(
+          handleDAExpSetAuctionDetailsV1(
             changetype<DAExpV1SetAuctionDetails>(event)
           );
         } else {
-          handleDAExpSetAuctionDetails(
+          handleDAExpSetAuctionDetailsV2(
             changetype<DAExpV2SetAuctionDetails>(event)
           );
         }
@@ -1137,15 +1146,15 @@ describe("MinterDAExp-related tests", () => {
         event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
 
         if (minterType === "MinterDAExpV0") {
-          handleDAExpSetAuctionDetails(
+          handleDAExpSetAuctionDetailsV0(
             changetype<DAExpV0SetAuctionDetails>(event)
           );
         } else if (minterType === "MinterDAExpV1") {
-          handleDAExpSetAuctionDetails(
+          handleDAExpSetAuctionDetailsV1(
             changetype<DAExpV1SetAuctionDetails>(event)
           );
         } else {
-          handleDAExpSetAuctionDetails(
+          handleDAExpSetAuctionDetailsV2(
             changetype<DAExpV2SetAuctionDetails>(event)
           );
         }
@@ -1221,15 +1230,15 @@ describe("MinterDAExp-related tests", () => {
         assert.notInStore(PROJECT_ENTITY_TYPE, fullProjectId);
 
         if (minterType == "MinterDAExpV0") {
-          handleDAExpResetAuctionDetails(
+          handleDAExpResetAuctionDetailsV0(
             changetype<DAExpV0ResetAuctionDetails>(event)
           );
         } else if (minterType == "MinterDAExpV1") {
-          handleDAExpResetAuctionDetails(
+          handleDAExpResetAuctionDetailsV1(
             changetype<DAExpV1ResetAuctionDetails>(event)
           );
         } else {
-          handleDAExpResetAuctionDetails(
+          handleDAExpResetAuctionDetailsV2(
             changetype<DAExpV2ResetAuctionDetails>(event)
           );
         }
@@ -1292,15 +1301,15 @@ describe("MinterDAExp-related tests", () => {
         event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
 
         if (minterType == "MinterDAExpV0") {
-          handleDAExpResetAuctionDetails(
+          handleDAExpResetAuctionDetailsV0(
             changetype<DAExpV0ResetAuctionDetails>(event)
           );
         } else if (minterType == "MinterDAExpV1") {
-          handleDAExpResetAuctionDetails(
+          handleDAExpResetAuctionDetailsV1(
             changetype<DAExpV1ResetAuctionDetails>(event)
           );
         } else {
-          handleDAExpResetAuctionDetails(
+          handleDAExpResetAuctionDetailsV2(
             changetype<DAExpV2ResetAuctionDetails>(event)
           );
         }
@@ -1393,15 +1402,15 @@ describe("MinterDAExp-related tests", () => {
         event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
 
         if (minterType == "MinterDAExpV0") {
-          handleDAExpResetAuctionDetails(
+          handleDAExpResetAuctionDetailsV0(
             changetype<DAExpV0ResetAuctionDetails>(event)
           );
         } else if (minterType == "MinterDAExpV1") {
-          handleDAExpResetAuctionDetails(
+          handleDAExpResetAuctionDetailsV1(
             changetype<DAExpV1ResetAuctionDetails>(event)
           );
         } else {
-          handleDAExpResetAuctionDetails(
+          handleDAExpResetAuctionDetailsV2(
             changetype<DAExpV2ResetAuctionDetails>(event)
           );
         }
@@ -1678,7 +1687,7 @@ describe("Generic minter details", () => {
       )
     ];
     configValueSetEvent.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
-    
+
     handleAddManyBigIntValue(configValueSetEvent);
 
     assert.fieldEquals(
@@ -1687,7 +1696,7 @@ describe("Generic minter details", () => {
       "extraMinterDetails",
       '{"array":[100]}'
     );
-    
+
     configValueSetEvent.parameters[2] = new ethereum.EventParam(
       "_value",
       ethereum.Value.fromSignedBigInt(BigInt.fromI32(200))
@@ -1701,7 +1710,7 @@ describe("Generic minter details", () => {
       '{"array":[100,200]}'
     );
   });
-  
+
   test("handleAddManyBigIntValue should add a single value to an array at a designated key extraMinterDetails, when duplicate of same value is added", () => {
     clearStore();
     const minter = addNewMinterToStore("MinterHolderV0");

--- a/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
+++ b/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
@@ -91,7 +91,14 @@ import {
   handleAddManyAddressValueProjectConfig as handleAddManyAddressValue,
   handleAddManyBigIntValueProjectConfig as handleAddManyBigIntValue,
   handleAddManyBytesValueProjectConfig as handleAddManyBytesValue,
-  handleHoldersOfProjectsGeneric,
+  handleAllowHoldersOfProjectsV0,
+  handleAllowHoldersOfProjectsV1,
+  handleRemoveHoldersOfProjectsV0,
+  handleRemoveHoldersOfProjectsV1,
+  handleRegisteredNFTAddressV0,
+  handleRegisteredNFTAddressV1,
+  handleUnregisteredNFTAddressV0,
+  handleUnregisteredNFTAddressV1,
   handleAuctionHalfLifeRangeSecondsUpdatedV0,
   handleAuctionHalfLifeRangeSecondsUpdatedV1,
   handleAuctionHalfLifeRangeSecondsUpdatedV2,
@@ -113,7 +120,6 @@ import {
   handlePricePerTokenInWeiUpdated,
   handleProjectCurrencyInfoUpdated,
   handlePurchaseToDisabledUpdated,
-  handleRegistrationNFTAddresses,
   handleRemoveBigIntManyValueProjectConfig as handleRemoveBigIntManyValue,
   handleRemoveBytesManyValueProjectConfig as handleRemoveBytesManyValue,
   handleRemoveValueProjectConfig as handleRemoveValue,
@@ -2098,11 +2104,11 @@ describe("MinterHolder-specific tests", () => {
       event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
 
       if (minterType == "MinterHolderV0") {
-        handleHoldersOfProjectsGeneric(
+        handleAllowHoldersOfProjectsV0(
           changetype<HolderV0AllowedHoldersOfProjects>(event)
         );
       } else {
-        handleHoldersOfProjectsGeneric(
+        handleAllowHoldersOfProjectsV1(
           changetype<HolderV1AllowedHoldersOfProjects>(event)
         );
       }
@@ -2173,11 +2179,11 @@ describe("MinterHolder-specific tests", () => {
       event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
 
       if (minterType == "MinterHolderV0") {
-        handleHoldersOfProjectsGeneric(
+        handleAllowHoldersOfProjectsV0(
           changetype<HolderV0AllowedHoldersOfProjects>(event)
         );
       } else {
-        handleHoldersOfProjectsGeneric(
+        handleAllowHoldersOfProjectsV1(
           changetype<HolderV1AllowedHoldersOfProjects>(event)
         );
       }
@@ -2245,11 +2251,11 @@ describe("MinterHolder-specific tests", () => {
       event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
 
       if (minterType == "MinterHolderV0") {
-        handleHoldersOfProjectsGeneric(
+        handleRemoveHoldersOfProjectsV0(
           changetype<HolderV0RemovedHoldersOfProjects>(event)
         );
       } else {
-        handleHoldersOfProjectsGeneric(
+        handleRemoveHoldersOfProjectsV1(
           changetype<HolderV1RemovedHoldersOfProjects>(event)
         );
       }
@@ -2321,11 +2327,11 @@ describe("MinterHolder-specific tests", () => {
       event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
 
       if (minterType == "MinterHolderV0") {
-        handleHoldersOfProjectsGeneric(
+        handleRemoveHoldersOfProjectsV0(
           changetype<HolderV0RemovedHoldersOfProjects>(event)
         );
       } else {
-        handleHoldersOfProjectsGeneric(
+        handleRemoveHoldersOfProjectsV1(
           changetype<HolderV1RemovedHoldersOfProjects>(event)
         );
       }
@@ -2362,11 +2368,11 @@ describe("MinterHolder-specific tests", () => {
       event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
 
       if (minterType == "MinterHolderV0") {
-        handleRegistrationNFTAddresses(
+        handleRegisteredNFTAddressV0(
           changetype<HolderV0RegisteredNFTAddress>(event)
         );
       } else {
-        handleRegistrationNFTAddresses(
+        handleRegisteredNFTAddressV1(
           changetype<HolderV1RegisteredNFTAddress>(event)
         );
       }
@@ -2419,11 +2425,11 @@ describe("MinterHolder-specific tests", () => {
       event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
 
       if (minterType == "MinterHolderV0") {
-        handleRegistrationNFTAddresses(
+        handleUnregisteredNFTAddressV0(
           changetype<HolderV0UnregisteredNFTAddress>(event)
         );
       } else {
-        handleRegistrationNFTAddresses(
+        handleUnregisteredNFTAddressV1(
           changetype<HolderV1UnregisteredNFTAddress>(event)
         );
       }


### PR DESCRIPTION
Update subgraph.yaml to never use generic handlers.

This reinforces the lesson learned that events should be in the interface of all indexed contracts.

This bug showed up when running a local version of the subgraph. It does not surface when running tests via our `yarn test` script. This is because the subgraph config yaml is not used when we run our tests in this repo - instead we send events directly to handlers (which doesn't test the subgraph yaml's routing from event to appropriate handler function).