### PR TITLE
bug fix V3 whitelisting entities, update tests

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,7 +5,8 @@ import {
   json,
   JSONValue,
   JSONValueKind,
-  TypedMap
+  TypedMap,
+  store
 } from "@graphprotocol/graph-ts";
 import { MinterDAExpV0 } from "../generated/MinterDAExpV0/MinterDAExpV0";
 import { MinterDAExpV1 } from "../generated/MinterDAExpV1/MinterDAExpV1";
@@ -54,10 +55,7 @@ export function generateContractSpecificId(
 }
 
 // returns new whitelisting id
-export function addWhitelisting(
-  contractId: string,
-  accountId: string
-): Whitelisting {
+export function addWhitelisting(contractId: string, accountId: string): void {
   let account = new Account(accountId);
   account.save();
 
@@ -68,7 +66,20 @@ export function addWhitelisting(
   whitelisting.contract = contractId;
 
   whitelisting.save();
-  return whitelisting;
+}
+
+export function removeWhitelisting(
+  contractId: string,
+  accountId: string
+): void {
+  let account = new Account(accountId);
+
+  let whitelistingId = generateWhitelistingId(contractId, account.id);
+  let whitelisting = Whitelisting.load(whitelistingId);
+
+  if (whitelisting) {
+    store.remove("Whitelisting", whitelistingId);
+  }
 }
 
 export function generateProjectScriptId(

--- a/src/mapping-v1-core.ts
+++ b/src/mapping-v1-core.ts
@@ -73,7 +73,8 @@ import {
   generateWhitelistingId,
   generateContractSpecificId,
   generateProjectScriptId,
-  addWhitelisting
+  addWhitelisting,
+  removeWhitelisting
 } from "./helpers";
 import { GEN_ART_721_CORE_V1 } from "./constants";
 
@@ -291,17 +292,6 @@ export function handleRemoveWhitelisted(call: RemoveWhitelistedCall): void {
 
   if (contractEntity) {
     removeWhitelisting(contractEntity.id, call.inputs._address.toHexString());
-  }
-}
-
-function removeWhitelisting(contractId: string, accountId: string): void {
-  let account = new Account(accountId);
-
-  let whitelistingId = generateWhitelistingId(contractId, account.id);
-  let whitelisting = Whitelisting.load(whitelistingId);
-
-  if (whitelisting) {
-    store.remove("Whitelisting", whitelistingId);
   }
 }
 

--- a/src/mapping-v2-core.ts
+++ b/src/mapping-v2-core.ts
@@ -70,7 +70,8 @@ import {
   generateContractSpecificId,
   generateProjectScriptId,
   generateProjectExternalAssetDependencyId,
-  addWhitelisting
+  addWhitelisting,
+  removeWhitelisting
 } from "./helpers";
 import {
   FLEX_CONTRACT_EXTERNAL_ASSET_DEP_TYPES,
@@ -201,7 +202,10 @@ export function handleExternalAssetDependencyUpdated(
   );
 
   if (!project) {
-    log.warning("Project not found for ExternalAssetDependencyUpdated event", []);
+    log.warning(
+      "Project not found for ExternalAssetDependencyUpdated event",
+      []
+    );
     return;
   }
 
@@ -236,7 +240,10 @@ export function handleExternalAssetDependencyRemoved(
   );
 
   if (!project) {
-    log.warning("Project not found for ExternalAssetDependencyRemoved event", []);
+    log.warning(
+      "Project not found for ExternalAssetDependencyRemoved event",
+      []
+    );
     return;
   }
 
@@ -288,12 +295,13 @@ export function handleExternalAssetDependencyRemoved(
 
 export function handleGatewayUpdated(event: GatewayUpdated): void {
   let contractEntity = Contract.load(event.address.toHexString());
-  
+
   if (!contractEntity) {
     log.warning("Contract not found for GatewayUpdated event", []);
     return;
   }
-  const dependencyType = FLEX_CONTRACT_EXTERNAL_ASSET_DEP_TYPES[event.params._dependencyType];
+  const dependencyType =
+    FLEX_CONTRACT_EXTERNAL_ASSET_DEP_TYPES[event.params._dependencyType];
   if (dependencyType === "IPFS") {
     contractEntity.preferredIPFSGateway = event.params._gatewayAddress;
   } else {
@@ -303,17 +311,22 @@ export function handleGatewayUpdated(event: GatewayUpdated): void {
   contractEntity.save();
 }
 
-export function handleProjectExternalAssetDependenciesLocked(event: ProjectExternalAssetDependenciesLocked): void {
+export function handleProjectExternalAssetDependenciesLocked(
+  event: ProjectExternalAssetDependenciesLocked
+): void {
   let project = Project.load(
     generateContractSpecificId(event.address, event.params._projectId)
   );
 
   if (!project) {
-    log.warning("Project not found for ProjectExternalAssetDependenciesLocked event", []);
+    log.warning(
+      "Project not found for ProjectExternalAssetDependenciesLocked event",
+      []
+    );
     return;
   }
 
-  project.externalAssetDependenciesLocked = true; 
+  project.externalAssetDependenciesLocked = true;
   project.updatedAt = event.block.timestamp;
   project.save();
 }
@@ -411,17 +424,6 @@ export function handleRemoveWhitelisted(call: RemoveWhitelistedCall): void {
   let contractEntity = refreshContract(contract, call.block.timestamp);
 
   removeWhitelisting(contractEntity.id, call.inputs._address.toHexString());
-}
-
-function removeWhitelisting(contractId: string, accountId: string): void {
-  let account = new Account(accountId);
-
-  let whitelistingId = generateWhitelistingId(contractId, account.id);
-  let whitelisting = Whitelisting.load(whitelistingId);
-
-  if (whitelisting) {
-    store.remove("Whitelisting", whitelistingId);
-  }
 }
 
 export function handleAddMintWhitelisted(call: AddMintWhitelistedCall): void {

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -37,7 +37,8 @@ import {
   generateProjectIdNumberFromTokenIdNumber,
   generateContractSpecificId,
   generateProjectScriptId,
-  addWhitelisting
+  addWhitelisting,
+  removeWhitelisting
 } from "./helpers";
 
 import { NULL_ADDRESS } from "./constants";
@@ -744,20 +745,20 @@ function refreshContract(
     contractEntity.mintWhitelisted = [];
     contractEntity.newProjectsForbidden = false;
     contractEntity.nextProjectId = contract.nextProjectId();
+  } else {
+    // clear the previous admin Whitelisting entity admin was previously defined
+    if (contractEntity.admin) {
+      removeWhitelisting(contractEntity.id, contractEntity.admin.toHexString());
+    }
   }
   let _admin = contract.admin();
   if (_admin.toHexString() == NULL_ADDRESS) {
     contractEntity.admin = Bytes.fromHexString(NULL_ADDRESS);
-    contractEntity.whitelisted = [];
   } else {
     let adminACLContract = IAdminACLV0.bind(_admin);
     let superAdminAddress = adminACLContract.superAdmin();
     contractEntity.admin = superAdminAddress;
-    let whitelisting = addWhitelisting(
-      contractEntity.id,
-      superAdminAddress.toHexString()
-    );
-    contractEntity.whitelisted = [whitelisting.id];
+    addWhitelisting(contractEntity.id, superAdminAddress.toHexString());
   }
   contractEntity.type = contract.coreType();
   contractEntity.renderProviderAddress = contract.artblocksPrimarySalesAddress();

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -748,6 +748,7 @@ function refreshContract(
   } else {
     // clear the previous admin Whitelisting entity admin was previously defined
     if (contractEntity.admin) {
+      // this properly handles the case where previous whitelisting does not exist
       removeWhitelisting(contractEntity.id, contractEntity.admin.toHexString());
     }
   }
@@ -756,9 +757,17 @@ function refreshContract(
     contractEntity.admin = Bytes.fromHexString(NULL_ADDRESS);
   } else {
     let adminACLContract = IAdminACLV0.bind(_admin);
-    let superAdminAddress = adminACLContract.superAdmin();
-    contractEntity.admin = superAdminAddress;
-    addWhitelisting(contractEntity.id, superAdminAddress.toHexString());
+    if (adminACLContract) {
+      let superAdminAddress = adminACLContract.superAdmin();
+      contractEntity.admin = superAdminAddress;
+      addWhitelisting(contractEntity.id, superAdminAddress.toHexString());
+    } else {
+      log.warning(
+        "[WARN] Could not load AdminACL contract at address {}, so set admin for contract {} to null address.",
+        [_admin.toHexString(), contract._address.toHexString()]
+      );
+      contractEntity.admin = Bytes.fromHexString(NULL_ADDRESS);
+    }
   }
   contractEntity.type = contract.coreType();
   contractEntity.renderProviderAddress = contract.artblocksPrimarySalesAddress();

--- a/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
@@ -36,7 +36,8 @@ import {
   ONE_MILLION,
   booleanToString,
   TEST_CONTRACT,
-  TEST_SUPER_ADMIN_ADDRESS
+  TEST_SUPER_ADMIN_ADDRESS,
+  WHITELISTING_ENTITY_TYPE
 } from "../shared-helpers";
 import {
   mockProjectScriptDetailsCall,
@@ -261,15 +262,13 @@ test("GenArt721CoreV3: Handles OwnershipTransferred to new address and zero addr
         newOwnerSuperAdmin.toHexString()
       );
       assert.fieldEquals(
-        CONTRACT_ENTITY_TYPE,
-        TEST_CONTRACT_ADDRESS.toHexString(),
-        "whitelisted",
-        "[" +
-          generateWhitelistingId(
-            TEST_CONTRACT_ADDRESS.toHexString(),
-            newOwnerSuperAdmin.toHexString()
-          ) +
-          "]"
+        WHITELISTING_ENTITY_TYPE,
+        generateWhitelistingId(
+          TEST_CONTRACT_ADDRESS.toHexString(),
+          newOwnerSuperAdmin.toHexString()
+        ),
+        "account",
+        newOwnerSuperAdmin.toHexString()
       );
     } else {
       assert.fieldEquals(
@@ -278,12 +277,7 @@ test("GenArt721CoreV3: Handles OwnershipTransferred to new address and zero addr
         "admin",
         Address.zero().toHexString()
       );
-      assert.fieldEquals(
-        CONTRACT_ENTITY_TYPE,
-        TEST_CONTRACT_ADDRESS.toHexString(),
-        "whitelisted",
-        "[]"
-      );
+      assert.entityCount(WHITELISTING_ENTITY_TYPE, 0);
     }
     assert.fieldEquals(
       CONTRACT_ENTITY_TYPE,
@@ -377,15 +371,13 @@ test("GenArt721CoreV3: Handles OwnershipTransferred to new address and zero addr
         newOwnerSuperAdmin.toHexString()
       );
       assert.fieldEquals(
-        CONTRACT_ENTITY_TYPE,
-        TEST_CONTRACT_ADDRESS.toHexString(),
-        "whitelisted",
-        "[" +
-          generateWhitelistingId(
-            TEST_CONTRACT_ADDRESS.toHexString(),
-            newOwnerSuperAdmin.toHexString()
-          ) +
-          "]"
+        WHITELISTING_ENTITY_TYPE,
+        generateWhitelistingId(
+          TEST_CONTRACT_ADDRESS.toHexString(),
+          newOwnerSuperAdmin.toHexString()
+        ),
+        "account",
+        newOwnerSuperAdmin.toHexString()
       );
     } else {
       assert.fieldEquals(
@@ -394,12 +386,7 @@ test("GenArt721CoreV3: Handles OwnershipTransferred to new address and zero addr
         "admin",
         Address.zero().toHexString()
       );
-      assert.fieldEquals(
-        CONTRACT_ENTITY_TYPE,
-        TEST_CONTRACT_ADDRESS.toHexString(),
-        "whitelisted",
-        "[]"
-      );
+      assert.entityCount(WHITELISTING_ENTITY_TYPE, 0);
     }
     assert.fieldEquals(
       CONTRACT_ENTITY_TYPE,
@@ -954,16 +941,16 @@ describe("GenArt721CoreV3: handleIAdminACLV0SuperAdminTransferred", () => {
       newOwnerSuperAdmin.toHexString()
     );
     assert.fieldEquals(
-      CONTRACT_ENTITY_TYPE,
-      TEST_CONTRACT_ADDRESS.toHexString(),
-      "whitelisted",
-      "[" +
-        generateWhitelistingId(
-          TEST_CONTRACT_ADDRESS.toHexString(),
-          newOwnerSuperAdmin.toHexString()
-        ) +
-        "]"
+      WHITELISTING_ENTITY_TYPE,
+      generateWhitelistingId(
+        TEST_CONTRACT_ADDRESS.toHexString(),
+        newOwnerSuperAdmin.toHexString()
+      ),
+      "account",
+      newOwnerSuperAdmin.toHexString()
     );
+    // check that old super admin is removed from whitelist by confirming 1 Whitelisting entity
+    assert.entityCount(WHITELISTING_ENTITY_TYPE, 1);
   });
 });
 


### PR DESCRIPTION
## Merge after #102 

Update V3 core handler to properly clear and re-assign whitelisting entities during contract refresh.

Previously, the code improperly assigned an array to the Contract entity's non-existent field, "whitelisted". This bug was only surfaced when running the subgraph locally.