### PR TITLE
add new minter types to MinterType enum in schema

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -326,6 +326,12 @@ enum MinterType {
   MinterDAExpV1
   MinterHolderV0
   MinterMerkleV0
+  MinterSetPriceV2
+  MinterSetPriceERC20V2
+  MinterDALinV2
+  MinterDAExpV2
+  MinterHolderV1
+  MinterMerkleV1
 }
 
 type Minter @entity {


### PR DESCRIPTION
Update MinterType enum in schema for the new V3-compatible minters.

This bug was surfaced when testing the subgraph locally.