### PR TITLE
Add admin ACL contract to staging config

### DIFF
--- a/config/goerli-staging.json
+++ b/config/goerli-staging.json
@@ -197,5 +197,12 @@
       "startBlock": 7705887
     }
   ],
+  "adminACLV0Contracts": [
+    {
+      "address": "0x94Cc7981227D9e644e153766C386eF47556C3147",
+      "name": "Admin ACL V0 for V3 core",
+      "startBlock": 7723576
+    }
+  ],
   "startBlock": 7011002
 }


### PR DESCRIPTION
Add new V3 core's AdminACLV0 contract to artist-staging config.

This was accidentally left out of yesterday's config update.

Will deploy a new subgraph after this is merged.