### PR TITLE
Palm-testnet Template

### DIFF
--- a/config/palm-testnet.json
+++ b/config/palm-testnet.json
@@ -1,0 +1,10 @@
+{
+  "network": "palm_testnet",
+  "pbabContracts": [
+    {
+      "address": "0x4C7E1e1Ba5e35934C8323d75AF838fDa26588177",
+      "name": "Art Blocks Engine Palm Testnet Demo",
+      "startBlock": 8732253
+    }
+  ]
+}

--- a/config/palm-testnet.json
+++ b/config/palm-testnet.json
@@ -1,5 +1,5 @@
 {
-  "network": "palm_testnet",
+  "network": "palm-testnet",
   "pbabContracts": [
     {
       "address": "0x4C7E1e1Ba5e35934C8323d75AF838fDa26588177",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prepare:goerli-dev": "mustache config/goerli-dev.json subgraph.template.yaml > subgraph.yaml",
     "prepare:goerli-staging": "mustache config/goerli-staging.json subgraph.template.yaml > subgraph.yaml",
     "prepare:palm": "mustache config/palm.json subgraph.template.yaml > subgraph.yaml",
+    "prepare:palm-testnet": "mustache config/palm-testnet.json subgraph.template.yaml > subgraph.yaml",
     "prepare:local": "mustache config/local.json subgraph.template.yaml > subgraph.yaml"
   },
   "dependencies": {


### PR DESCRIPTION
## Description of the change
Added palm-testnet configuration with deployed test contract address and start block. Will add documentation around deployment process after syncing with the Palm team.

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
