### PR TITLE
Fix Other ABI + Add correct generated code

### DIFF
--- a/abis/MinterDAExpSettlementV0.json
+++ b/abis/MinterDAExpSettlementV0.json
@@ -401,13 +401,13 @@
         {
           "indexed": false,
           "internalType": "uint256",
-          "name": "_netPosted",
+          "name": "_numPurchased",
           "type": "uint256"
         },
         {
           "indexed": false,
           "internalType": "uint256",
-          "name": "_numPurchased",
+          "name": "_netPosted",
           "type": "uint256"
         }
       ],

--- a/generated/MinterDAExpSettlementV0/IFilteredMinterDAExpSettlementV0.ts
+++ b/generated/MinterDAExpSettlementV0/IFilteredMinterDAExpSettlementV0.ts
@@ -423,11 +423,11 @@ export class ReceiptUpdated__Params {
     return this._event.parameters[1].value.toBigInt();
   }
 
-  get _netPosted(): BigInt {
+  get _numPurchased(): BigInt {
     return this._event.parameters[2].value.toBigInt();
   }
 
-  get _numPurchased(): BigInt {
+  get _netPosted(): BigInt {
     return this._event.parameters[3].value.toBigInt();
   }
 }
@@ -651,6 +651,41 @@ export class IFilteredMinterDAExpSettlementV0 extends ethereum.SmartContract {
         value[3].toAddress()
       )
     );
+  }
+
+  getProjectExcessSettlementFunds(
+    _projectId: BigInt,
+    _walletAddress: Address
+  ): BigInt {
+    let result = super.call(
+      "getProjectExcessSettlementFunds",
+      "getProjectExcessSettlementFunds(uint256,address):(uint256)",
+      [
+        ethereum.Value.fromUnsignedBigInt(_projectId),
+        ethereum.Value.fromAddress(_walletAddress)
+      ]
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_getProjectExcessSettlementFunds(
+    _projectId: BigInt,
+    _walletAddress: Address
+  ): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "getProjectExcessSettlementFunds",
+      "getProjectExcessSettlementFunds(uint256,address):(uint256)",
+      [
+        ethereum.Value.fromUnsignedBigInt(_projectId),
+        ethereum.Value.fromAddress(_walletAddress)
+      ]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   getProjectLatestPurchasePrice(_projectId: BigInt): BigInt {

--- a/generated/MinterDAExpSettlementV0/MinterDAExpSettlementV0.ts
+++ b/generated/MinterDAExpSettlementV0/MinterDAExpSettlementV0.ts
@@ -423,11 +423,11 @@ export class ReceiptUpdated__Params {
     return this._event.parameters[1].value.toBigInt();
   }
 
-  get _netPosted(): BigInt {
+  get _numPurchased(): BigInt {
     return this._event.parameters[2].value.toBigInt();
   }
 
-  get _numPurchased(): BigInt {
+  get _netPosted(): BigInt {
     return this._event.parameters[3].value.toBigInt();
   }
 }
@@ -766,6 +766,41 @@ export class MinterDAExpSettlementV0 extends ethereum.SmartContract {
         value[3].toAddress()
       )
     );
+  }
+
+  getProjectExcessSettlementFunds(
+    _projectId: BigInt,
+    _walletAddress: Address
+  ): BigInt {
+    let result = super.call(
+      "getProjectExcessSettlementFunds",
+      "getProjectExcessSettlementFunds(uint256,address):(uint256)",
+      [
+        ethereum.Value.fromUnsignedBigInt(_projectId),
+        ethereum.Value.fromAddress(_walletAddress)
+      ]
+    );
+
+    return result[0].toBigInt();
+  }
+
+  try_getProjectExcessSettlementFunds(
+    _projectId: BigInt,
+    _walletAddress: Address
+  ): ethereum.CallResult<BigInt> {
+    let result = super.tryCall(
+      "getProjectExcessSettlementFunds",
+      "getProjectExcessSettlementFunds(uint256,address):(uint256)",
+      [
+        ethereum.Value.fromUnsignedBigInt(_projectId),
+        ethereum.Value.fromAddress(_walletAddress)
+      ]
+    );
+    if (result.reverted) {
+      return new ethereum.CallResult();
+    }
+    let value = result.value;
+    return ethereum.CallResult.fromValue(value[0].toBigInt());
   }
 
   getProjectLatestPurchasePrice(_projectId: BigInt): BigInt {

--- a/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
+++ b/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
@@ -1614,12 +1614,12 @@ describe("DAExpSettlementMinters", () => {
           ethereum.Value.fromUnsignedBigInt(projectId)
         ),
         new ethereum.EventParam(
-          "_netPosted",
-          ethereum.Value.fromUnsignedBigInt(netPosted)
-        ),
-        new ethereum.EventParam(
           "_numPurchased",
           ethereum.Value.fromUnsignedBigInt(numPurchased)
+        ),
+        new ethereum.EventParam(
+          "_netPosted",
+          ethereum.Value.fromUnsignedBigInt(netPosted)
         )
       ];
       event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
@@ -1751,12 +1751,12 @@ describe("DAExpSettlementMinters", () => {
           ethereum.Value.fromUnsignedBigInt(projectId)
         ),
         new ethereum.EventParam(
-          "_netPosted",
-          ethereum.Value.fromUnsignedBigInt(netPosted)
-        ),
-        new ethereum.EventParam(
           "_numPurchased",
           ethereum.Value.fromUnsignedBigInt(numPurchased)
+        ),
+        new ethereum.EventParam(
+          "_netPosted",
+          ethereum.Value.fromUnsignedBigInt(netPosted)
         )
       ];
       event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
@@ -1815,12 +1815,12 @@ describe("DAExpSettlementMinters", () => {
           ethereum.Value.fromUnsignedBigInt(projectId)
         ),
         new ethereum.EventParam(
-          "_netPosted",
-          ethereum.Value.fromUnsignedBigInt(netPosted)
-        ),
-        new ethereum.EventParam(
           "_numPurchased",
           ethereum.Value.fromUnsignedBigInt(numPurchased)
+        ),
+        new ethereum.EventParam(
+          "_netPosted",
+          ethereum.Value.fromUnsignedBigInt(netPosted)
         )
       ];
       const newBlockTimestamp = CURRENT_BLOCK_TIMESTAMP.plus(BigInt.fromI32(1));


### PR DESCRIPTION
## Description of the change
See #144 - this completes that work with a few new changes missed

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
