### PR TITLE
new minter addy's to the staging config

### DIFF
--- a/config/goerli-staging.json
+++ b/config/goerli-staging.json
@@ -178,11 +178,35 @@
       "startBlock": 7723588
     }
   ],
+  "minterMerkleV3Contracts": [
+    {
+      "address": "0x2FB0d2410117ac190CD6FfF017B989195A522a87",
+      "name": "Flagship Minter for V3 core",
+      "startBlock": 8128478
+    },
+    {
+      "address": "0xc4081Fbc41859b7749D97FE363DE671d51f9bD01",
+      "name": "Explorations Minter",
+      "startBlock": 8128520
+    }
+  ],
   "minterHolderV1Contracts": [
     {
       "address": "0x3e8d9D70906d39225bDcb14002cAFD8a652aD97A",
       "name": "Flagship Minter for V3 core",
       "startBlock": 7723589
+    }
+  ],
+  "minterHolderV2Contracts": [
+    {
+      "address": "0xB5Cc0e80e2043cBB5F63d548E1832F22CD1a97b2",
+      "name": "Flagship Minter for V3 core",
+      "startBlock": 8128721
+    },
+    {
+      "address": "0x980b482072838C38090c40e3F95A150E572719Dd",
+      "name": "Explorations Minter",
+      "startBlock": 8128726
     }
   ],
   "engineFlexContracts": [


### PR DESCRIPTION
## Description of the change
MerkleV3 and HolderV2 contracts added for a staging (hosted) deployment.

*Note that we skipped MerkleV2 in the staging env from what I can see. Is there any reason that might cause an issue, since we do define `minterMerkleV2Contracts` in our template.yaml?

\<add description here\>

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
