### PR TITLE
Sync latest purchase price as string so we don't lose precision when we parse JSON

### DIFF
--- a/src/minter-suite-mapping.ts
+++ b/src/minter-suite-mapping.ts
@@ -1238,7 +1238,7 @@ function syncLatestPurchasePrice(
     projectId
   );
   // update extraMinterDetails key `currentSettledPrice` to be latestPurchasePrice
-  let genericEvent: ConfigValueSetBigInt = new ConfigValueSetBigInt(
+  let genericEvent: ConfigValueSetBytes = new ConfigValueSetBytes(
     event.address,
     event.logIndex,
     event.transactionLogIndex,
@@ -1259,7 +1259,7 @@ function syncLatestPurchasePrice(
     ),
     new ethereum.EventParam(
       "_value",
-      ethereum.Value.fromUnsignedBigInt(latestPurchasePrice)
+      ethereum.Value.fromBytes(Bytes.fromUTF8(latestPurchasePrice.toString()))
     )
   ];
   // call generic handler to populate project's extraMinterDetails

--- a/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
+++ b/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
@@ -1649,7 +1649,9 @@ describe("DAExpSettlementMinters", () => {
         PROJECT_MINTER_CONFIGURATION_ENTITY_TYPE,
         getProjectMinterConfigId(minterAddress.toHexString(), project.id),
         "extraMinterDetails",
-        `{"currentSettledPrice":${actualPurchasePrice.toString()},"numSettleableInvocations":${1}}`
+        `{"currentSettledPrice":${'"' +
+          actualPurchasePrice.toString() +
+          '"'},"numSettleableInvocations":${1}}`
       );
       assert.fieldEquals(
         RECEIPT_ENTITY_TYPE,
@@ -1833,7 +1835,9 @@ describe("DAExpSettlementMinters", () => {
         PROJECT_MINTER_CONFIGURATION_ENTITY_TYPE,
         getProjectMinterConfigId(minterAddress.toHexString(), project.id),
         "extraMinterDetails",
-        `{"currentSettledPrice":${actualPurchasePrice.toString()},"numSettleableInvocations":${numPurchased.toString()}}`
+        `{"currentSettledPrice":${'"' +
+          actualPurchasePrice.toString() +
+          '"'},"numSettleableInvocations":${numPurchased.toString()}}`
       );
       assert.fieldEquals(
         RECEIPT_ENTITY_TYPE,
@@ -1953,7 +1957,7 @@ describe("DAExpSettlementMinters", () => {
         PROJECT_MINTER_CONFIGURATION_ENTITY_TYPE,
         getProjectMinterConfigId(minterAddress.toHexString(), project.id),
         "extraMinterDetails",
-        `{"currentSettledPrice":${selloutPrice.toString()}}`
+        `{"currentSettledPrice":${'"' + selloutPrice.toString() + '"'}}`
       );
     });
 
@@ -2052,7 +2056,7 @@ describe("DAExpSettlementMinters", () => {
         PROJECT_MINTER_CONFIGURATION_ENTITY_TYPE,
         getProjectMinterConfigId(minterAddress.toHexString(), project.id),
         "extraMinterDetails",
-        `{"currentSettledPrice":${selloutPrice.toString()}}`
+        `{"currentSettledPrice":${'"' + selloutPrice.toString() + '"'}}`
       );
     });
   });
@@ -2131,7 +2135,9 @@ describe("DAExpSettlementMinters", () => {
         PROJECT_MINTER_CONFIGURATION_ENTITY_TYPE,
         getProjectMinterConfigId(minterAddress.toHexString(), project.id),
         "extraMinterDetails",
-        `{"currentSettledPrice":${updatedLatestPurchasePrice.toString()},"auctionRevenuesCollected":${true}}`
+        `{"currentSettledPrice":${'"' +
+          updatedLatestPurchasePrice.toString() +
+          '"'},"auctionRevenuesCollected":${true}}`
       );
     });
   });


### PR DESCRIPTION
## Description of the change

Previously, when we sync this data and parse it, we are losing precision which has ramnifications on the math used for `excess_settlement_funds`. If we sync it as string, JSON.parse() in sync should sync it to the db as as string, instead of a number

see precision loss here 
<img width="401" alt="Screenshot 2022-12-20 at 10 13 51 AM" src="https://user-images.githubusercontent.com/13852077/208739360-32b2a53c-4279-4ff1-8f03-8c38265f4757.png">


>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
