### PR TITLE
Update subgraph config for latest pre-EOY Engine Goerli deployments

### DIFF
--- a/config/goerli-staging.json
+++ b/config/goerli-staging.json
@@ -67,6 +67,11 @@
       "address": "0xD94C7060808f3c876824E57e685702f3834D2e13",
       "name": "ITERATION-02",
       "startBlock": 7917739
+    },
+    {
+      "address": "0xAbf9B1c2c14399CFD1753BE2090b7dA3c0A1434B",
+      "name": "VerticalCrypto Gen Art",
+      "startBlock": 8171667
     }
   ],
   "minterFilterV0Contracts": [
@@ -234,6 +239,16 @@
       "address": "0xc2aeC8A571e8D40d3606fAD9Cd10EbB1731D2816",
       "name": "GENCLO Flex",
       "startBlock": 7917787
+    },
+    {
+      "address": "0xc8FA62D76fbbCD71482C603cae4a5ebfaD5c7C78",
+      "name": "TRAMExCPG",
+      "startBlock": 8170848
+    },
+    {
+      "address": "0x9dF9dc3Fe9985aa4e1F93543f5a20688f49E6dCa",
+      "name": "XCORE",
+      "startBlock": 8165411
     }
   ],
   "adminACLV0Contracts": [


### PR DESCRIPTION
## Description of the change

Adds subgraph details for https://github.com/ArtBlocks/artblocks/issues/324, https://github.com/ArtBlocks/artblocks/issues/384, and https://github.com/ArtBlocks/artblocks/issues/388

Subgraph config detail updates for: https://github.com/ArtBlocks/artblocks/issues/388, https://github.com/ArtBlocks/artblocks/issues/384, and https://github.com/ArtBlocks/artblocks/issues/324

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
