### PR TITLE
Make sure minter updatedAt is set after update

### DIFF
--- a/src/minter-suite-mapping.ts
+++ b/src/minter-suite-mapping.ts
@@ -889,6 +889,11 @@ export function handleAddManyValueGeneric<T, C>(
   if (project) {
     project.updatedAt = event.block.timestamp;
   }
+
+  if (config instanceof Minter) {
+    config.updatedAt = event.block.timestamp;
+  }
+
   let jsonResult = json.try_fromString(config.extraMinterDetails);
 
   let minterDetails: TypedMap<string, JSONValue>;


### PR DESCRIPTION
## Description of the change

Previously, the `handleAddManyValueGeneric` function did not update the `updatedAt` field on `Minter` when updating the `extraMinterDetails` field. As a result the sync worker was not picking up changes made in this function. This PR fixes this issue.

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
