### PR TITLE
Make sure account exists

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -133,7 +133,12 @@ export function loadOrCreateReceipt(
   // populate based on format of receiptId
   receipt.minter = minterId;
   receipt.project = projectId;
+
+  // Make sure the account exists before adding to receipt
+  const account = new Account(accountAddress.toHexString());
+  account.save();
   receipt.account = accountAddress.toHexString();
+
   // populate non-nullable values with default solidity values
   receipt.netPosted = BigInt.fromI32(0);
   receipt.numPurchased = BigInt.fromI32(0);


### PR DESCRIPTION
## Description of the change

Previously a Receipt entity could be created with an account address that does not correspond to an existing Account entity. This PR makes sure that this can't happen.

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
