### PR TITLE
Add additional block data to Transfer entity. Index the transfer that occurs on Mint

### DIFF
--- a/generated/schema.ts
+++ b/generated/schema.ts
@@ -2396,15 +2396,6 @@ export class Transfer extends Entity {
     this.set("id", Value.fromString(value));
   }
 
-  get transactionHash(): Bytes {
-    let value = this.get("transactionHash");
-    return value!.toBytes();
-  }
-
-  set transactionHash(value: Bytes) {
-    this.set("transactionHash", Value.fromBytes(value));
-  }
-
   get token(): string {
     let value = this.get("token");
     return value!.toString();
@@ -2412,15 +2403,6 @@ export class Transfer extends Entity {
 
   set token(value: string) {
     this.set("token", Value.fromString(value));
-  }
-
-  get createdAt(): BigInt {
-    let value = this.get("createdAt");
-    return value!.toBigInt();
-  }
-
-  set createdAt(value: BigInt) {
-    this.set("createdAt", Value.fromBigInt(value));
   }
 
   get to(): Bytes {
@@ -2439,6 +2421,42 @@ export class Transfer extends Entity {
 
   set from(value: Bytes) {
     this.set("from", Value.fromBytes(value));
+  }
+
+  get transactionHash(): Bytes {
+    let value = this.get("transactionHash");
+    return value!.toBytes();
+  }
+
+  set transactionHash(value: Bytes) {
+    this.set("transactionHash", Value.fromBytes(value));
+  }
+
+  get blockHash(): Bytes {
+    let value = this.get("blockHash");
+    return value!.toBytes();
+  }
+
+  set blockHash(value: Bytes) {
+    this.set("blockHash", Value.fromBytes(value));
+  }
+
+  get blockNumber(): BigInt {
+    let value = this.get("blockNumber");
+    return value!.toBigInt();
+  }
+
+  set blockNumber(value: BigInt) {
+    this.set("blockNumber", Value.fromBigInt(value));
+  }
+
+  get blockTimestamp(): BigInt {
+    let value = this.get("blockTimestamp");
+    return value!.toBigInt();
+  }
+
+  set blockTimestamp(value: BigInt) {
+    this.set("blockTimestamp", Value.fromBigInt(value));
   }
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -541,15 +541,17 @@ type SaleLookupTable @entity {
 type Transfer @entity(immutable: true) {
   id: ID!
 
-  transactionHash: Bytes!
-
   token: Token!
-
-  createdAt: BigInt!
 
   to: Bytes!
 
   from: Bytes!
+
+  transactionHash: Bytes!
+  
+  blockHash: Bytes!
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
 }
 
 enum ProjectExternalAssetDependencyType {
@@ -558,6 +560,7 @@ enum ProjectExternalAssetDependencyType {
   "Asset hosted on Arweave"
   ARWEAVE
 }
+
 type ProjectExternalAssetDependency @entity {
   "Unique identifier made up of projectId-index"
   id: ID!

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -286,3 +286,10 @@ export function bytesToJSONValue(value: Bytes): JSONValue {
 export function stringToJSONString(value: string): string {
   return '"' + value + '"';
 }
+
+export function generateTransferId(
+  transactionHash: Bytes,
+  logIndex: BigInt
+): string {
+  return transactionHash.toHexString() + "-" + logIndex.toString();
+}

--- a/src/mapping-v1-core.ts
+++ b/src/mapping-v1-core.ts
@@ -74,7 +74,8 @@ import {
   generateContractSpecificId,
   generateProjectScriptId,
   addWhitelisting,
-  removeWhitelisting
+  removeWhitelisting,
+  generateTransferId
 } from "./helpers";
 import { GEN_ART_721_CORE_V1 } from "./constants";
 
@@ -134,9 +135,11 @@ export function handleMint(event: Mint): void {
 export function handleTransfer(event: Transfer): void {
   // This will only create a new token if a token with the
   // same id does not already exist
-  let token = Token.load(
-    generateContractSpecificId(event.address, event.params.tokenId)
+  const tokenId = generateContractSpecificId(
+    event.address,
+    event.params.tokenId
   );
+  let token = Token.load(tokenId);
 
   // Let mint handlers deal with new tokens
   if (token) {
@@ -180,17 +183,20 @@ export function handleTransfer(event: Transfer): void {
     token.owner = event.params.to.toHexString();
     token.updatedAt = event.block.timestamp;
     token.save();
-
-    let transfer = new TokenTransfer(
-      event.transaction.hash.toHex() + "-" + event.logIndex.toString()
-    );
-    transfer.transactionHash = event.transaction.hash;
-    transfer.createdAt = event.block.timestamp;
-    transfer.to = event.params.to;
-    transfer.from = event.params.from;
-    transfer.token = token.id;
-    transfer.save();
   }
+
+  let transfer = new TokenTransfer(
+    generateTransferId(event.transaction.hash, event.logIndex)
+  );
+  transfer.transactionHash = event.transaction.hash;
+  transfer.to = event.params.to;
+  transfer.from = event.params.from;
+  transfer.token = tokenId;
+
+  transfer.blockHash = event.block.hash;
+  transfer.blockNumber = event.block.number;
+  transfer.blockTimestamp = event.block.timestamp;
+  transfer.save();
 }
 /*** END EVENT HANDLERS ***/
 

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -38,7 +38,8 @@ import {
   generateContractSpecificId,
   generateProjectScriptId,
   addWhitelisting,
-  removeWhitelisting
+  removeWhitelisting,
+  generateTransferId
 } from "./helpers";
 
 import { NULL_ADDRESS } from "./constants";
@@ -129,9 +130,11 @@ export function handleMint(event: Mint): void {
 export function handleTransfer(event: Transfer): void {
   // This will only create a new token if a token with the
   // same id does not already exist
-  let token = Token.load(
-    generateContractSpecificId(event.address, event.params.tokenId)
+  const tokenId = generateContractSpecificId(
+    event.address,
+    event.params.tokenId
   );
+  let token = Token.load(tokenId);
 
   // Let mint handlers deal with new tokens
   if (token) {
@@ -175,17 +178,20 @@ export function handleTransfer(event: Transfer): void {
     token.owner = event.params.to.toHexString();
     token.updatedAt = event.block.timestamp;
     token.save();
-
-    let transfer = new TokenTransfer(
-      event.transaction.hash.toHex() + "-" + event.logIndex.toString()
-    );
-    transfer.transactionHash = event.transaction.hash;
-    transfer.createdAt = event.block.timestamp;
-    transfer.to = event.params.to;
-    transfer.from = event.params.from;
-    transfer.token = token.id;
-    transfer.save();
   }
+
+  let transfer = new TokenTransfer(
+    generateTransferId(event.transaction.hash, event.logIndex)
+  );
+  transfer.transactionHash = event.transaction.hash;
+  transfer.to = event.params.to;
+  transfer.from = event.params.from;
+  transfer.token = tokenId;
+
+  transfer.blockHash = event.block.hash;
+  transfer.blockNumber = event.block.number;
+  transfer.blockTimestamp = event.block.timestamp;
+  transfer.save();
 }
 
 export const FIELD_PROJECT_ACTIVE = "active";

--- a/tests/subgraph/mapping-v0-core/original-mapping.test.ts
+++ b/tests/subgraph/mapping-v0-core/original-mapping.test.ts
@@ -5,7 +5,7 @@ import {
   newMockCall,
   newMockEvent
 } from "matchstick-as/assembly/index";
-import { BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
 import {
   ACCOUNT_ENTITY_TYPE,
   PROJECT_ENTITY_TYPE,
@@ -112,6 +112,7 @@ import {
 import {
   generateContractSpecificId,
   generateProjectScriptId,
+  generateTransferId,
   generateWhitelistingId
 } from "../../../src/helpers";
 
@@ -1912,6 +1913,94 @@ test("GenArt721: Can handle transfer", () => {
     "token",
     fullTokenId
   );
+ 
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockHash",
+    event.block.hash.toHexString()
+  )
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockNumber",
+    event.block.number.toString()
+  )
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockTimestamp",
+    event.block.timestamp.toString()
+  )
+});
+
+test("GenArt721: Can handle mint transfer", () => {
+  clearStore();
+  const tokenId = BigInt.fromI32(0);
+  const fullTokenId = generateContractSpecificId(
+    TEST_CONTRACT_ADDRESS,
+    tokenId
+  );
+
+  const fromAddress = Address.zero();
+  const toAddress = randomAddressGenerator.generateRandomAddress();
+
+  const hash = Bytes.fromUTF8("QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG");
+
+  const logIndex = BigInt.fromI32(0);
+
+  const event: Transfer = changetype<Transfer>(newMockEvent());
+  event.address = TEST_CONTRACT_ADDRESS;
+  event.transaction.hash = hash;
+  event.logIndex = logIndex;
+  event.parameters = [
+    new ethereum.EventParam("from", ethereum.Value.fromAddress(fromAddress)),
+    new ethereum.EventParam("to", ethereum.Value.fromAddress(toAddress)),
+    new ethereum.EventParam(
+      "tokenId",
+      ethereum.Value.fromUnsignedBigInt(tokenId)
+    )
+  ];
+
+  handleTransfer(event);
+
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    hash.toHex() + "-" + logIndex.toString(),
+    "to",
+    toAddress.toHexString()
+  );
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    hash.toHex() + "-" + logIndex.toString(),
+    "from",
+    fromAddress.toHexString()
+  );
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    hash.toHex() + "-" + logIndex.toString(),
+    "token",
+    fullTokenId
+  );
+ 
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockHash",
+    event.block.hash.toHexString()
+  )
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockNumber",
+    event.block.number.toString()
+  )
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockTimestamp",
+    event.block.timestamp.toString()
+  )
 });
 export {
   handleAddProject,

--- a/tests/subgraph/mapping-v1-core/mapping.test.ts
+++ b/tests/subgraph/mapping-v1-core/mapping.test.ts
@@ -7,7 +7,7 @@ import {
   logStore,
   newMockEvent
 } from "matchstick-as/assembly/index";
-import { BigInt, Bytes, ethereum, store, Value } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
 import {
   ACCOUNT_ENTITY_TYPE,
   PROJECT_ENTITY_TYPE,
@@ -131,6 +131,7 @@ import {
 import {
   generateContractSpecificId,
   generateProjectScriptId,
+  generateTransferId,
   generateWhitelistingId
 } from "../../../src/helpers";
 
@@ -2364,6 +2365,94 @@ test("GenArt721Core: Can handle transfer", () => {
     "token",
     fullTokenId
   );
+
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockHash",
+    event.block.hash.toHexString()
+  )
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockNumber",
+    event.block.number.toString()
+  )
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockTimestamp",
+    event.block.timestamp.toString()
+  )
+});
+
+test("GenArt721Core: Can handle mint transfer", () => {
+  clearStore();
+  const tokenId = BigInt.fromI32(0);
+  const fullTokenId = generateContractSpecificId(
+    TEST_CONTRACT_ADDRESS,
+    tokenId
+  );
+
+  const fromAddress = Address.zero();
+  const toAddress = randomAddressGenerator.generateRandomAddress();
+
+  const hash = Bytes.fromUTF8("QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG");
+
+  const logIndex = BigInt.fromI32(0);
+
+  const event: Transfer = changetype<Transfer>(newMockEvent());
+  event.address = TEST_CONTRACT_ADDRESS;
+  event.transaction.hash = hash;
+  event.logIndex = logIndex;
+  event.parameters = [
+    new ethereum.EventParam("from", ethereum.Value.fromAddress(fromAddress)),
+    new ethereum.EventParam("to", ethereum.Value.fromAddress(toAddress)),
+    new ethereum.EventParam(
+      "tokenId",
+      ethereum.Value.fromUnsignedBigInt(tokenId)
+    )
+  ];
+
+  handleTransfer(event);
+
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    hash.toHex() + "-" + logIndex.toString(),
+    "to",
+    toAddress.toHexString()
+  );
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    hash.toHex() + "-" + logIndex.toString(),
+    "from",
+    fromAddress.toHexString()
+  );
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    hash.toHex() + "-" + logIndex.toString(),
+    "token",
+    fullTokenId
+  );
+
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockHash",
+    event.block.hash.toHexString()
+  )
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockNumber",
+    event.block.number.toString()
+  )
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockTimestamp",
+    event.block.timestamp.toString()
+  )
 });
 
 // export handlers for test coverage https://github.com/LimeChain/demo-subgraph#test-coverage

--- a/tests/subgraph/mapping-v2-core/pbab-mapping.test.ts
+++ b/tests/subgraph/mapping-v2-core/pbab-mapping.test.ts
@@ -6,7 +6,7 @@ import {
   newMockEvent,
   createMockedFunction,
 } from "matchstick-as/assembly/index";
-import { BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
 import {
   ACCOUNT_ENTITY_TYPE,
   PROJECT_ENTITY_TYPE,
@@ -125,6 +125,7 @@ import {
 import {
   generateContractSpecificId,
   generateProjectScriptId,
+  generateTransferId,
   generateWhitelistingId
 } from "../../../src/helpers";
 
@@ -1861,6 +1862,92 @@ test("GenArt721Core2PBAB: Can handle transfer", () => {
     "token",
     fullTokenId
   );
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockHash",
+    event.block.hash.toHexString()
+  )
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockNumber",
+    event.block.number.toString()
+  )
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockTimestamp",
+    event.block.timestamp.toString()
+  )
+});
+
+test("GenArt721Core2PBAB: Can handle mint transfer", () => {
+  clearStore();
+  const tokenId = BigInt.fromI32(0);
+  const fullTokenId = generateContractSpecificId(
+    TEST_CONTRACT_ADDRESS,
+    tokenId
+  );
+
+  const fromAddress = Address.zero();
+  const toAddress = randomAddressGenerator.generateRandomAddress();
+
+  const hash = Bytes.fromUTF8("QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG");
+
+  const logIndex = BigInt.fromI32(0);
+
+  const event: Transfer = changetype<Transfer>(newMockEvent());
+  event.address = TEST_CONTRACT_ADDRESS;
+  event.transaction.hash = hash;
+  event.logIndex = logIndex;
+  event.parameters = [
+    new ethereum.EventParam("from", ethereum.Value.fromAddress(fromAddress)),
+    new ethereum.EventParam("to", ethereum.Value.fromAddress(toAddress)),
+    new ethereum.EventParam(
+      "tokenId",
+      ethereum.Value.fromUnsignedBigInt(tokenId)
+    )
+  ];
+
+  handleTransfer(event);
+
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    hash.toHex() + "-" + logIndex.toString(),
+    "to",
+    toAddress.toHexString()
+  );
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    hash.toHex() + "-" + logIndex.toString(),
+    "from",
+    fromAddress.toHexString()
+  );
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    hash.toHex() + "-" + logIndex.toString(),
+    "token",
+    fullTokenId
+  );
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockHash",
+    event.block.hash.toHexString()
+  )
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockNumber",
+    event.block.number.toString()
+  )
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(hash, logIndex),
+    "blockTimestamp",
+    event.block.timestamp.toString()
+  )
 });
 
 test("GenArt721Core2EngineFlex: Can add/update a project external asset dependency", () => {

--- a/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
@@ -83,6 +83,7 @@ import {
 import {
   generateContractSpecificId,
   generateProjectScriptId,
+  generateTransferId,
   generateWhitelistingId
 } from "../../../src/helpers";
 
@@ -197,6 +198,91 @@ test("GenArt721CoreV3: Can handle transfer", () => {
     "token",
     fullTokenId
   );
+
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(TEST_TX_HASH, logIndex),
+    "blockHash",
+    event.block.hash.toHexString()
+  )
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(TEST_TX_HASH, logIndex),
+    "blockNumber",
+    event.block.number.toString()
+  )
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(TEST_TX_HASH, logIndex),
+    "blockTimestamp",
+    event.block.timestamp.toString()
+  )
+});
+
+test("GenArt721CoreV3: Can handle mint transfer", () => {
+  clearStore();
+  const tokenId = BigInt.fromI32(0);
+  const fullTokenId = generateContractSpecificId(
+    TEST_CONTRACT_ADDRESS,
+    tokenId
+  );
+
+  const fromAddress = Address.zero();
+  const toAddress = randomAddressGenerator.generateRandomAddress();
+
+  const logIndex = BigInt.fromI32(0);
+  const event: Transfer = changetype<Transfer>(newMockEvent());
+  event.address = TEST_CONTRACT_ADDRESS;
+  event.transaction.hash = TEST_TX_HASH;
+  event.logIndex = logIndex;
+  event.parameters = [
+    new ethereum.EventParam("from", ethereum.Value.fromAddress(fromAddress)),
+    new ethereum.EventParam("to", ethereum.Value.fromAddress(toAddress)),
+    new ethereum.EventParam(
+      "tokenId",
+      ethereum.Value.fromUnsignedBigInt(tokenId)
+    )
+  ];
+
+  handleTransfer(event);
+
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    TEST_TX_HASH.toHex() + "-" + logIndex.toString(),
+    "to",
+    toAddress.toHexString()
+  );
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    TEST_TX_HASH.toHex() + "-" + logIndex.toString(),
+    "from",
+    fromAddress.toHexString()
+  );
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    TEST_TX_HASH.toHex() + "-" + logIndex.toString(),
+    "token",
+    fullTokenId
+  );
+
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(TEST_TX_HASH, logIndex),
+    "blockHash",
+    event.block.hash.toHexString()
+  )
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(TEST_TX_HASH, logIndex),
+    "blockNumber",
+    event.block.number.toString()
+  )
+  assert.fieldEquals(
+    TRANSFER_ENTITY_TYPE,
+    generateTransferId(TEST_TX_HASH, logIndex),
+    "blockTimestamp",
+    event.block.timestamp.toString()
+  )
 });
 
 test("GenArt721CoreV3: Handles OwnershipTransferred to new address and zero address, when Contract not in store", () => {


### PR DESCRIPTION
## Description of the change
This PR updates the transfer entity by adding fields for blockHash, blockNumber, and blockTimestamp.  `blockTimestamp` replaces the `createdAt` field, however our indexed `Transfers` are not being used anywhere in our pipeline so this shouldn't break anything. Additionally this PR updates the transfer event handlers to create a Transfer for the initial mint transfer from the zero address to the primary purchaser. 

Both of these changes should allow us to do better re-org protection in the future, however given the relative infrequency of re-orgs after the merge this subsequent work is low priority. 

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
