### PR TITLE
Remove minter types enum

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -321,35 +321,12 @@ type MinterFilter @entity {
   updatedAt: BigInt!
 }
 
-enum MinterType {
-  MinterSetPriceV0
-  MinterSetPriceERC20V0
-  MinterDALinV0
-  MinterDAExpV0
-  MinterSetPriceV1
-  MinterSetPriceERC20V1
-  MinterDALinV1
-  MinterDAExpV1
-  MinterHolderV0
-  MinterMerkleV0
-  MinterSetPriceV2
-  MinterSetPriceERC20V2
-  MinterDALinV2
-  MinterDAExpV2
-  MinterHolderV1
-  MinterHolderV2
-  MinterMerkleV1
-  MinterMerkleV2
-  MinterDAExpSettlementV0
-  MinterMerkleV3
-}
-
 type Minter @entity {
   "Unique identifier made up of minter contract address"
   id: ID!
 
-  "Minter type"
-  type: MinterType!
+  "Minter type - String if minter returns it's type, empty string otherwise"
+  type: String!
 
   "Associated Minter Filter"
   minterFilter: MinterFilter!


### PR DESCRIPTION
## Description of the change

This removes the minter types enum, and instead allows the subgraph to index any type of contract without immediately failing.

fixes #54 

## Benefits
- When adding new minters with new types, our subgraph won't immediately fail.

## Drawbacks
- ~a bit more likely to hit this failure mode: If we attempt to index a minter that doesn't return expected values from expected minter functions, our subgraph could fail. For example, we call `contract.minimumPriceDecayHalfLifeSeconds()` when indexing any minter who's returned type starts with `MinterDAExp`. If that function does not actually exist and the call fails, our subgraph could fail.
  - solution: we may want to harden our subgraph in follow-on PRs, for example only using try/catch patterns on all minter calls, e.g. use: `contract._minimumPriceDecayHalfLifeSeconds()`
- It is no longer obvious which minter versions are handled in our subgraph.
  - @yoshiwarab Would it be helpful to add a list of supported minters to this repo's readme? (seems like we might forget to update it?)
  
## Items not addressed in this PR:
- Ability to index new minters on-the-fly

## Design Choices
- Opted to keep minter.type as non-nullable, but it could be made nullable, e.g. in the case the call to minterType() reverts. Keeping minter.type as non-nullable keeps our schema the same and therefore does not impact downstream code, but making it nullable may be worth the effort. Cc @yoshiwarab to help weigh in on this detail.




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203760077930845