### PR TITLE
Re-deployed MinterHolderV2

### DIFF
--- a/config/goerli-staging.json
+++ b/config/goerli-staging.json
@@ -293,9 +293,9 @@
   ],
   "minterHolderV2Contracts": [
     {
-      "address": "0x6f9953e06675904AAE18568b1697544778616DAA",
+      "address": "0xdCe333bEdFc584E43d7D494393AD4bd990479844",
       "name": "Flagship Minter for V3 core",
-      "startBlock": 8136182
+      "startBlock": 8369991
     }
   ],
   "adminACLV0Contracts": [


### PR DESCRIPTION
## Description of the change
A bug on MinterHolderV2 was fixed so this PR re-deploys the staging subgraph.

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).