### PR TITLE
Update subgraph configs to account for new Minter Suite full minter set deployments.

### DIFF
--- a/config/goerli-staging.json
+++ b/config/goerli-staging.json
@@ -216,6 +216,11 @@
       "address": "0x3CB6381203f6c9d75B70F0af70E905cC67d68437",
       "name": "V2 Flagship Minter for V3 core",
       "startBlock": 7723582
+    },
+    {
+      "address": "0xb5629f232cE932E214Fb548Ed049795b04e58FB9",
+      "name": "V4 minter for V3 Flagship core",
+      "startBlock": 8405833
     }
   ],
   "minterSetPriceERC20Contracts": [
@@ -233,6 +238,11 @@
       "address": "0x37007e0561E219e77dAF24Ef0984a5488239512A",
       "name": "V2 Flagship Minter for V3 core",
       "startBlock": 7723584
+    },
+    {
+      "address": "0x7a1Ee96dCAF0b65Abc68D78D12b81523360838E1",
+      "name": "V4 minter for V3 Flagship core",
+      "startBlock": 8405834
     }
   ],
   "minterDAExpContracts": [
@@ -250,6 +260,11 @@
       "address": "0xb61ABA1c6b4079c976Fb664F27a0D9C47b81a05B",
       "name": "V2 Flagship Minter for V3 core",
       "startBlock": 7723587
+    },
+    {
+      "address": "0x6FBbfbdbF71D319c5F007C9DF1c2ae63b3F463a6",
+      "name": "V4 minter for V3 Flagship core",
+      "startBlock": 8405827
     }
   ],
   "minterDALinContracts": [
@@ -267,6 +282,11 @@
       "address": "0xb228C4dce0929D3d1dC7C386ba3cC2c0671e1751",
       "name": "V2 Flagship Minter for V3 core",
       "startBlock": 7723585
+    },
+    {
+      "address": "0x99980fEa1397a33E7058E01A73099bfF81d310d2",
+      "name": "V4 minter for V3 Flagship core",
+      "startBlock": 8405830
     }
   ],
   "minterDAExpSettlementContracts": [
@@ -274,6 +294,11 @@
       "address": "0x1D5E143CDf39ed1c50adF400e7c6c1E7da7c43A7",
       "name": "V0 Flagship Minter for V3 core",
       "startBlock": 8339496
+    },
+    {
+      "address": "0xCee138625d669b49bDde0Bf1600A2EaF29C2C9C8",
+      "name": "V1 minter for V3 Flagship core",
+      "startBlock": 8405829
     }
   ],
   "minterMerkleContracts": [
@@ -291,6 +316,11 @@
       "address": "0xD3241C7101D5BDD0A8cC6f866D2d8b7AF1fF1962",
       "name": "V3 Flagship Minter for V3 core",
       "startBlock": 8136221
+    },
+    {
+      "address": "0x8632212Fca423fe868C6C93c59DCcAdAB59f4e41",
+      "name": "V5 minter for V3 Flagship core",
+      "startBlock": 8405832
     }
   ],
   "minterHolderContracts": [
@@ -303,6 +333,11 @@
       "address": "0xdCe333bEdFc584E43d7D494393AD4bd990479844",
       "name": "V2 Flagship Minter for V3 core",
       "startBlock": 8369991
+    },
+    {
+      "address": "0x0EA91da0C3338f88510cBB2a3cf20Cd1863551a8",
+      "name": "V4 minter for V3 Flagship core",
+      "startBlock": 8405831
     }
   ],
   "adminACLV0Contracts": [

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -183,6 +183,11 @@
       "address": "0x6FB3104B0b3Cd665c7B8506b23eE833eA44d8E91",
       "name": "V2 Explorations Minter",
       "startBlock": 15799084
+    },
+    {
+      "address": "0x234B25288011081817B5cC199C3754269cCb76D2",
+      "name": "V4 minter for V3 Flagship core",
+      "startBlock": 16523001
     }
   ],
   "minterSetPriceERC20Contracts": [
@@ -205,6 +210,11 @@
       "address": "0xe4c6EeF13649e9C4Ad8ae8A9C7fA9A7F26B4287a",
       "name": "V2 Flagship Minter for V3 core",
       "startBlock": 15726709
+    },
+    {
+      "address": "0x9fEcd2FbC6D890fB93632DcE9b1a01c4090A7E2d",
+      "name": "V4 minter for V3 Flagship core",
+      "startBlock": 16523002
     }
   ],
   "minterDAExpContracts": [
@@ -227,6 +237,11 @@
       "address": "0x706d6C6ef700a3c1C3a727f0c46492492E0A72b5",
       "name": "V2 Flagship Minter for V3 core",
       "startBlock": 15726712
+    },
+    {
+      "address": "0x47e2df2723238f913741Cc6b1963e76fdfD19B94",
+      "name": "V4 minter for V3 Flagship core",
+      "startBlock": 16522995
     }
   ],
   "minterDALinContracts": [
@@ -249,6 +264,11 @@
       "address": "0xdaa6D1e224f4B9f7c4f1368C362C4333A8e385A6",
       "name": "V2 Flagship Minter for V3 core",
       "startBlock": 15726710
+    },
+    {
+      "address": "0x419501DD208BFf237e3E32C40D074065e12DfF4d",
+      "name": "V4 minter for V3 Flagship core",
+      "startBlock": 16522997
     }
   ],
   "minterMerkleContracts": [
@@ -281,6 +301,11 @@
       "address": "0xD06A5109bEdEf92696B29FcC0F6184640b19c310",
       "name": "DO NOT USE | V2 Explorations Minter",
       "startBlock": 15822393
+    },
+    {
+      "address": "0xB8Bd1D2836C466DB149f665F777928bEE267304d",
+      "name": "V5 minter for V3 Flagship core",
+      "startBlock": 16523000
     }
   ],
   "minterHolderContracts": [
@@ -288,6 +313,18 @@
       "address": "0xa198E22C32879f4214a37eB3051525bD9aff9145",
       "name": "V1 Flagship Minter for V3 core",
       "startBlock": 15726716
+    },
+    {
+      "address": "0xCCFF562017bdAAa064184b3Eb9bd892d8Acce7d6",
+      "name": "V4 minter for V3 Flagship core",
+      "startBlock": 16522999
+    }
+  ],
+  "minterDAExpSettlementContracts": [
+    {
+      "address": "0xfdE58c821D1c226b4a45c22904de20b114EDe7E7",
+      "name": "V1 minter for V3 Flagship core",
+      "startBlock": 16522996
     }
   ],
   "adminACLV0Contracts": [


### PR DESCRIPTION
## Description of the change

This adds deployed minter details for the minters deployed and documented in https://github.com/ArtBlocks/artblocks-contracts/pull/470