### PR TITLE
Add Admin ACL data source templates

### DIFF
--- a/config/goerli-dev.json
+++ b/config/goerli-dev.json
@@ -275,16 +275,6 @@
       "address": "0x8ADfF069C897383c107F95743b944f78e0BefC2D",
       "name": "Explorations Admin ACL V0",
       "startBlock": 7799141
-    },
-    {
-      "address": "0x50DB09A76E9B762d9161c1710102B8C407Fd3ae0",
-      "name": "Admin ACL V0 for ABxPace, ABxBMG, and AB Managed V3 Engine cores",
-      "startBlock": 8178161
-    },
-    {
-      "address": "0xCf54E0AD108Ec3b961190a402808FCc73dA7EbDf",
-      "name": "Admin ACL V0 for AB V3 Engine Dev Core",
-      "startBlock": 8407450
     }
   ],
   "engineRegistryV0Contracts": [

--- a/src/engine-registry.ts
+++ b/src/engine-registry.ts
@@ -6,13 +6,16 @@ import { EngineRegistry, Contract } from "../generated/schema";
 import {
   IGenArt721CoreV3_Base_Template,
   OwnableGenArt721CoreV3Contract_Template,
-  IERC721GenArt721CoreV3Contract_Template
+  IERC721GenArt721CoreV3Contract_Template,
+  AdminACLV0_Template
 } from "../generated/templates";
 
 import {
   ContractRegistered,
   ContractUnregistered
 } from "../generated/EngineRegistryV0/IEngineRegistryV0";
+
+import { Ownable } from "../generated/OwnableGenArt721CoreV3Contract/Ownable";
 
 /*** EVENT HANDLERS ***/
 // Registered contracts are tracked dynamically, and the contract's `registeredOn`
@@ -30,6 +33,12 @@ export function handleContractRegistered(event: ContractRegistered): void {
     IGenArt721CoreV3_Base_Template.create(coreAddress);
     OwnableGenArt721CoreV3Contract_Template.create(coreAddress);
     IERC721GenArt721CoreV3Contract_Template.create(coreAddress);
+    // also track the new contract's Admin ACL contract to enable indexing if admin changes
+    // @dev for V3 core contracts, the admin acl contract is the core contract's owner
+    const ownableV3Core = Ownable.bind(coreAddress);
+    const adminACLAddress = ownableV3Core.owner();
+    AdminACLV0_Template.create(adminACLAddress);
+    // refresh contract
     refreshContractAtAddress(coreAddress, event.block.timestamp);
   }
   // set this engine registry as the contract's registeredOn field

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -1488,3 +1488,51 @@ templates:
         - event: Transfer(indexed address,indexed address,indexed uint256)
           handler: handleTransfer
       file: ./src/mapping-v3-core.ts
+    
+  - name: AdminACLV0_Template
+    kind: ethereum/contract
+    network: {{network}}
+    source:
+      abi: AdminACLV0
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      entities:
+        - Project
+        - Contract
+      abis:
+        - name: AdminACLV0
+          file: ./abis/AdminACLV0.json
+        - name: IAdminACLV0
+          file: ./abis/IAdminACLV0.json
+        - name: IGenArt721CoreContractV3_Base
+          file: ./abis/IGenArt721CoreContractV3_Base.json
+        - name: IGenArt721CoreContractV3
+          file: ./abis/IGenArt721CoreContractV3.json
+        - name: IGenArt721CoreContractV3_Engine
+          file: ./abis/IGenArt721CoreContractV3_Engine.json
+        - name: GenArt721CoreV3
+          file: ./abis/GenArt721CoreV3.json
+        - name: GenArt721CoreV3_Engine
+          file: ./abis/GenArt721CoreV3_Engine.json
+        - name: IERC721
+          file: ./abis/IERC721.json
+        - name: Ownable
+          file: ./abis/Ownable.json
+        - name: IMinterFilterV0
+          file: ./abis/IMinterFilterV0.json
+        - name: MinterFilterV0
+          file: ./abis/MinterFilterV0.json
+        - name: MinterFilterV1
+          file: ./abis/MinterFilterV1.json
+        - name: IFilteredMinterV2
+          file: ./abis/IFilteredMinterV2.json
+        - name: IFilteredMinterDALinV1
+          file: ./abis/IFilteredMinterDALinV1.json
+        - name: IFilteredMinterDAExpV1
+          file: ./abis/IFilteredMinterDAExpV1.json
+      eventHandlers:
+        - event: SuperAdminTransferred(indexed address,indexed address,address[])
+          handler: handleIAdminACLV0SuperAdminTransferred
+      file: ./src/mapping-v3-core.ts

--- a/tests/subgraph/mapping-v3-core/helpers.ts
+++ b/tests/subgraph/mapping-v3-core/helpers.ts
@@ -50,6 +50,13 @@ export function mockRefreshContractCalls(
     "admin():(address)"
   ).returns([ethereum.Value.fromAddress(TEST_CONTRACT.admin)]);
 
+  // for V3, owner() also returns admin address
+  createMockedFunction(
+    TEST_CONTRACT_ADDRESS,
+    "owner",
+    "owner():(address)"
+  ).returns([ethereum.Value.fromAddress(TEST_CONTRACT.admin)]);
+
   createMockedFunction(
     TEST_CONTRACT.admin,
     "superAdmin",

--- a/tests/subgraph/shared-helpers.ts
+++ b/tests/subgraph/shared-helpers.ts
@@ -77,6 +77,7 @@ const randomAddressGenerator = new RandomAddressGenerator();
 export const ACCOUNT_ENTITY_TYPE = "Account";
 export const PROJECT_ENTITY_TYPE = "Project";
 export const CONTRACT_ENTITY_TYPE = "Contract";
+export const ADMIN_ACL_ENTITY_TYPE = "AdminACL";
 export const ENGINE_REGISTRY_TYPE = "EngineRegistry";
 export const WHITELISTING_ENTITY_TYPE = "Whitelisting";
 export const PROJECT_EXTERNAL_ASSET_DEPENDENCY_ENTITY_TYPE =


### PR DESCRIPTION
## Description of the change

This adds Admin ACL Data source templates so we don't require a subgraph redeployment for every new Engine contract being indexed.

Admin ACL contracts are required to be indexed to handle the case where the superAdmin address is changed.

This update also updates the dev config to remove the adminACL contracts currently deployed to dev (since they will now be automatically added via data source templates in the Engine Registry handler).

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.
