### PR TITLE
Update dev and staging configs

### DIFF
--- a/config/goerli-dev.json
+++ b/config/goerli-dev.json
@@ -81,16 +81,6 @@
       "startBlock": 7799145
     },
     {
-      "address": "0x5E22FBBB6bb2C45aE060b4C96f5039efdF7Fb328",
-      "name": "Flagship Minter Filter for ABxPace core at 0x0eba0bd3702d850EEc7a8215EB53FFC293c42341",
-      "startBlock": 8178165
-    },
-    {
-      "address": "0x75b123eAcBf813804bAc83e1D6e5c3d1758746e6",
-      "name": "Flagship Minter Filter for ABxBMG core at 0x5112c52535449513c81bDF113b8DCC757d7f122b",
-      "startBlock": 8178172
-    },
-    {
       "address": "0xd4C74Ba7f65B4F13Fd09cDfB0DAA7154f9C0FAA2",
       "name": "Minter Filter for AB V3 Engine Dev core at 0x849CfA68915f2a9adf34bD20dc62E6f56fad23Cc",
       "startBlock": 8407450
@@ -278,11 +268,6 @@
     }
   ],
   "engineRegistryV0Contracts": [
-    {
-      "address": "0xEa698596b6009A622C3eD00dD5a8b5d1CAE4fC36",
-      "name": "Goerli dev engine registry contract",
-      "startBlock": 8178162
-    },
     {
       "address": "0x2A39132E8d594d2c840D6656327fB26d900C05bA",
       "name": "Goerli dev engine registry contract, AB Dev Wallet as Deployer",

--- a/config/goerli-dev.json
+++ b/config/goerli-dev.json
@@ -111,6 +111,11 @@
       "address": "0xBF5F2541A34B406195dB6ae09C3d98979F1e5FC4",
       "name": "V4 Minter for AB V3 Engine Dev core at 0x849CfA68915f2a9adf34bD20dc62E6f56fad23Cc",
       "startBlock": 8407450
+    },
+    {
+      "address": "0x6e8f18DAA4cec615d6997631118483179696225c",
+      "name": "V4 Minter for AB V3 Engine Dev #2 core at 0xd47A017282E3a67D17421C6d98655eFb7D5ED1E6",
+      "startBlock": 8411116
     }
   ],
   "minterSetPriceERC20Contracts": [

--- a/config/goerli-dev.json
+++ b/config/goerli-dev.json
@@ -84,6 +84,11 @@
       "address": "0xd4C74Ba7f65B4F13Fd09cDfB0DAA7154f9C0FAA2",
       "name": "Minter Filter for AB V3 Engine Dev core at 0x849CfA68915f2a9adf34bD20dc62E6f56fad23Cc",
       "startBlock": 8407450
+    },
+    {
+      "address": "0xBc86F31413AE950FC732A923284D5c74045878C3",
+      "name": "Minter Filter for AB V3 Engine Dev #2 core at 0xd47A017282E3a67D17421C6d98655eFb7D5ED1E6",
+      "startBlock": 8411115
     }
   ],
   "minterSetPriceContracts": [

--- a/config/goerli-staging.json
+++ b/config/goerli-staging.json
@@ -192,6 +192,21 @@
       "address": "0x6eA558Bb1A3C5437970AdA80f8c686448A9c31fC",
       "name": "Art Blocks Flagship Minter Filter for V3 core",
       "startBlock": 7723580
+    },
+    {
+      "address": "0x5E22FBBB6bb2C45aE060b4C96f5039efdF7Fb328",
+      "name": "Minter Filter for ABxPace core at 0x0eba0bd3702d850EEc7a8215EB53FFC293c42341",
+      "startBlock": 8178165
+    },
+    {
+      "address": "0x75b123eAcBf813804bAc83e1D6e5c3d1758746e6",
+      "name": "Minter Filter for ABxBMG core at 0x5112c52535449513c81bDF113b8DCC757d7f122b",
+      "startBlock": 8178172
+    },
+    {
+      "address": "0x9bC71a0380f2cc5C099e58b0d836bEddB1B5CE1C",
+      "name": "Minter Filter for AB Managed Engine core at 0xa504BF82Db6347165A39294FB0CaE761074661Ee",
+      "startBlock": 8178177
     }
   ],
   "minterSetPriceContracts": [
@@ -303,6 +318,11 @@
       "address": "0x94Cc7981227D9e644e153766C386eF47556C3147",
       "name": "Admin ACL V0 for V3 core",
       "startBlock": 7723576
+    },
+    {
+      "address": "0xEa698596b6009A622C3eD00dD5a8b5d1CAE4fC36",
+      "name": "Goerli staging Engine registry contract",
+      "startBlock": 8178162
     }
   ],
   "startBlock": 7011002

--- a/config/goerli-staging.json
+++ b/config/goerli-staging.json
@@ -227,6 +227,11 @@
       "address": "0xde6DCA519049473Da8826c57B4F45f6dE7f22a73",
       "name": "V4 minter for ABxPace V3 Engine core",
       "startBlock": 8411200
+    },
+    {
+      "address": "0xcBA628BcF6f458f6F929d875B69FE5f0F3fB99b6",
+      "name": "V4 minter for ABxBMG V3 Engine core",
+      "startBlock": 8411200
     }
   ],
   "minterSetPriceERC20Contracts": [
@@ -253,6 +258,11 @@
     {
       "address": "0x0D4BeE9AfbB364cF32F37912845C770A4badd83E",
       "name": "V4 minter for ABxPace V3 Engine core",
+      "startBlock": 8411200
+    },
+    {
+      "address": "0xdADB127c1565156C3Ce004E11db7E1ba626267E7",
+      "name": "V4 minter for ABxBMG V3 Engine core",
       "startBlock": 8411200
     }
   ],
@@ -281,6 +291,11 @@
       "address": "0x5d292CFfD4e3EA08049760D42F8F67bcde4E9260",
       "name": "V4 minter for ABxPace V3 Engine core",
       "startBlock": 8411200
+    },
+    {
+      "address": "0x10BD2A01996711b0A66d8D5203a919463383701A",
+      "name": "V4 minter for ABxBMG V3 Engine core",
+      "startBlock": 8411200
     }
   ],
   "minterDALinContracts": [
@@ -308,6 +323,11 @@
       "address": "0x1353fd9d3dC70d1a18149C8FB2ADB4FB906DE4E8",
       "name": "V4 minter for ABxPace V3 Engine core",
       "startBlock": 8411200
+    },
+    {
+      "address": "0xD00495689D5161C511882364E0C342e12Dcc5f08",
+      "name": "V4 minter for ABxBMG V3 Engine core",
+      "startBlock": 8411200
     }
   ],
   "minterDAExpSettlementContracts": [
@@ -324,6 +344,11 @@
     {
       "address": "0x8ABdb5c40BB6593550ff0027d15D8B6BEc416a24",
       "name": "V1 minter for ABxPace V3 Engine core",
+      "startBlock": 8411200
+    },
+    {
+      "address": "0x9e05816E151708Efc1C52243a18A0cC804b33819",
+      "name": "V1 minter for ABxBMG V3 Engine core",
       "startBlock": 8411200
     }
   ],
@@ -352,6 +377,11 @@
       "address": "0x8F7DbE58B34710510E44FE9d513e54F01729c686",
       "name": "V5 minter for ABxPace V3 Engine core",
       "startBlock": 8411200
+    },
+    {
+      "address": "0x7a67130593A161124686EA55484D1A64d99eefc9",
+      "name": "V5 minter for ABxBMG V3 Engine core",
+      "startBlock": 8411200
     }
   ],
   "minterHolderContracts": [
@@ -373,6 +403,11 @@
     {
       "address": "0xA3ae49B0fE17A0735dBc9f11Fb51122687DbC27E",
       "name": "V4 minter for ABxPace V3 Engine core",
+      "startBlock": 8411200
+    },
+    {
+      "address": "0xB64116A7D5D84fE9795DD022ea191217A2e32076",
+      "name": "V4 minter for ABxBMG V3 Engine core",
       "startBlock": 8411200
     }
   ],

--- a/config/goerli-staging.json
+++ b/config/goerli-staging.json
@@ -222,6 +222,11 @@
       "address": "0xb5629f232cE932E214Fb548Ed049795b04e58FB9",
       "name": "V4 minter for V3 Flagship core",
       "startBlock": 8405833
+    },
+    {
+      "address": "0xde6DCA519049473Da8826c57B4F45f6dE7f22a73",
+      "name": "V4 minter for ABxPace V3 Engine core",
+      "startBlock": 8411200
     }
   ],
   "minterSetPriceERC20Contracts": [
@@ -244,6 +249,11 @@
       "address": "0x7a1Ee96dCAF0b65Abc68D78D12b81523360838E1",
       "name": "V4 minter for V3 Flagship core",
       "startBlock": 8405834
+    },
+    {
+      "address": "0x0D4BeE9AfbB364cF32F37912845C770A4badd83E",
+      "name": "V4 minter for ABxPace V3 Engine core",
+      "startBlock": 8411200
     }
   ],
   "minterDAExpContracts": [
@@ -266,6 +276,11 @@
       "address": "0x6FBbfbdbF71D319c5F007C9DF1c2ae63b3F463a6",
       "name": "V4 minter for V3 Flagship core",
       "startBlock": 8405827
+    },
+    {
+      "address": "0x5d292CFfD4e3EA08049760D42F8F67bcde4E9260",
+      "name": "V4 minter for ABxPace V3 Engine core",
+      "startBlock": 8411200
     }
   ],
   "minterDALinContracts": [
@@ -288,6 +303,11 @@
       "address": "0x99980fEa1397a33E7058E01A73099bfF81d310d2",
       "name": "V4 minter for V3 Flagship core",
       "startBlock": 8405830
+    },
+    {
+      "address": "0x1353fd9d3dC70d1a18149C8FB2ADB4FB906DE4E8",
+      "name": "V4 minter for ABxPace V3 Engine core",
+      "startBlock": 8411200
     }
   ],
   "minterDAExpSettlementContracts": [
@@ -300,6 +320,11 @@
       "address": "0xCee138625d669b49bDde0Bf1600A2EaF29C2C9C8",
       "name": "V1 minter for V3 Flagship core",
       "startBlock": 8405829
+    },
+    {
+      "address": "0x8ABdb5c40BB6593550ff0027d15D8B6BEc416a24",
+      "name": "V1 minter for ABxPace V3 Engine core",
+      "startBlock": 8411200
     }
   ],
   "minterMerkleContracts": [
@@ -322,6 +347,11 @@
       "address": "0x8632212Fca423fe868C6C93c59DCcAdAB59f4e41",
       "name": "V5 minter for V3 Flagship core",
       "startBlock": 8405832
+    },
+    {
+      "address": "0x8F7DbE58B34710510E44FE9d513e54F01729c686",
+      "name": "V5 minter for ABxPace V3 Engine core",
+      "startBlock": 8411200
     }
   ],
   "minterHolderContracts": [
@@ -339,6 +369,11 @@
       "address": "0x0EA91da0C3338f88510cBB2a3cf20Cd1863551a8",
       "name": "V4 minter for V3 Flagship core",
       "startBlock": 8405831
+    },
+    {
+      "address": "0xA3ae49B0fE17A0735dBc9f11Fb51122687DbC27E",
+      "name": "V4 minter for ABxPace V3 Engine core",
+      "startBlock": 8411200
     }
   ],
   "adminACLV0Contracts": [

--- a/config/goerli-staging.json
+++ b/config/goerli-staging.json
@@ -423,5 +423,12 @@
       "startBlock": 8178162
     }
   ],
+  "engineRegistryV0Contracts": [
+    {
+      "address": "0xEa698596b6009A622C3eD00dD5a8b5d1CAE4fC36",
+      "name": "Goerli staging engine registry contract",
+      "startBlock": 8178162
+    }
+  ],
   "startBlock": 7011002
 }

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -208,6 +208,11 @@
       "address": "0x234B25288011081817B5cC199C3754269cCb76D2",
       "name": "V4 minter for V3 Flagship core",
       "startBlock": 16523001
+    },
+    {
+      "address": "0x9DA0aA1ECec6Aa824Fe67E3a19b1cA6a7045356F",
+      "name": "V4 minter for ABxPace V3 Engine core",
+      "startBlock": 16529300
     }
   ],
   "minterSetPriceERC20Contracts": [
@@ -235,6 +240,11 @@
       "address": "0x9fEcd2FbC6D890fB93632DcE9b1a01c4090A7E2d",
       "name": "V4 minter for V3 Flagship core",
       "startBlock": 16523002
+    },
+    {
+      "address": "0x6D136683CF43aF32387321A9b338809549dB0d9C",
+      "name": "V4 minter for ABxPace V3 Engine core",
+      "startBlock": 16529300
     }
   ],
   "minterDAExpContracts": [
@@ -262,6 +272,11 @@
       "address": "0x47e2df2723238f913741Cc6b1963e76fdfD19B94",
       "name": "V4 minter for V3 Flagship core",
       "startBlock": 16522995
+    },
+    {
+      "address": "0x67cdbA57b992E57Dc455134934771bB6Abc82BEc",
+      "name": "V4 minter for ABxPace V3 Engine core",
+      "startBlock": 16529300
     }
   ],
   "minterDALinContracts": [
@@ -289,6 +304,11 @@
       "address": "0x419501DD208BFf237e3E32C40D074065e12DfF4d",
       "name": "V4 minter for V3 Flagship core",
       "startBlock": 16522997
+    },
+    {
+      "address": "0x69F46b9e0fB09251f9d4466b39646e24bd511BBd",
+      "name": "V4 minter for ABxPace V3 Engine core",
+      "startBlock": 16529300
     }
   ],
   "minterMerkleContracts": [
@@ -326,6 +346,11 @@
       "address": "0xB8Bd1D2836C466DB149f665F777928bEE267304d",
       "name": "V5 minter for V3 Flagship core",
       "startBlock": 16523000
+    },
+    {
+      "address": "0x5F3562610dEDE0120087ec20BB61CF4A66124416",
+      "name": "V5 minter for ABxPace V3 Engine core",
+      "startBlock": 16529300
     }
   ],
   "minterHolderContracts": [
@@ -338,6 +363,11 @@
       "address": "0xCCFF562017bdAAa064184b3Eb9bd892d8Acce7d6",
       "name": "V4 minter for V3 Flagship core",
       "startBlock": 16522999
+    },
+    {
+      "address": "0x69326faf88ed5B423a7fC4063Fc814bfb451fEd6",
+      "name": "V4 minter for ABxPace V3 Engine core",
+      "startBlock": 16529300
     }
   ],
   "minterDAExpSettlementContracts": [
@@ -345,6 +375,11 @@
       "address": "0xfdE58c821D1c226b4a45c22904de20b114EDe7E7",
       "name": "V1 minter for V3 Flagship core",
       "startBlock": 16522996
+    },
+    {
+      "address": "0x3aA2D7e6CE5f08E59b0511cdeB6ba866d9fe9994",
+      "name": "V1 minter for ABxPace V3 Engine core",
+      "startBlock": 16529300
     }
   ],
   "adminACLV0Contracts": [

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -213,6 +213,11 @@
       "address": "0x9DA0aA1ECec6Aa824Fe67E3a19b1cA6a7045356F",
       "name": "V4 minter for ABxPace V3 Engine core",
       "startBlock": 16529300
+    },
+    {
+      "address": "0x090860b07ae1413B9A08339F54cb621B392bB73d",
+      "name": "V4 minter for ABxBMG V3 Engine core",
+      "startBlock": 16529300
     }
   ],
   "minterSetPriceERC20Contracts": [
@@ -244,6 +249,11 @@
     {
       "address": "0x6D136683CF43aF32387321A9b338809549dB0d9C",
       "name": "V4 minter for ABxPace V3 Engine core",
+      "startBlock": 16529300
+    },
+    {
+      "address": "0x07619C21fBf6A9CB10ce0B3B34934ba3b995C9Fb",
+      "name": "V4 minter for ABxBMG V3 Engine core",
       "startBlock": 16529300
     }
   ],
@@ -277,6 +287,11 @@
       "address": "0x67cdbA57b992E57Dc455134934771bB6Abc82BEc",
       "name": "V4 minter for ABxPace V3 Engine core",
       "startBlock": 16529300
+    },
+    {
+      "address": "0x609564FDd916e45E4396BceD647Ac800c1621F4d",
+      "name": "V4 minter for ABxBMG V3 Engine core",
+      "startBlock": 16529300
     }
   ],
   "minterDALinContracts": [
@@ -308,6 +323,11 @@
     {
       "address": "0x69F46b9e0fB09251f9d4466b39646e24bd511BBd",
       "name": "V4 minter for ABxPace V3 Engine core",
+      "startBlock": 16529300
+    },
+    {
+      "address": "0x40A07aD414EC4214d03bF76571FDF38D6b0DE598",
+      "name": "V4 minter for ABxBMG V3 Engine core",
       "startBlock": 16529300
     }
   ],
@@ -351,6 +371,11 @@
       "address": "0x5F3562610dEDE0120087ec20BB61CF4A66124416",
       "name": "V5 minter for ABxPace V3 Engine core",
       "startBlock": 16529300
+    },
+    {
+      "address": "0x4610dB225D7305e31690658D674E7D37eB244f7e",
+      "name": "V5 minter for ABxBMG V3 Engine core",
+      "startBlock": 16529300
     }
   ],
   "minterHolderContracts": [
@@ -368,6 +393,11 @@
       "address": "0x69326faf88ed5B423a7fC4063Fc814bfb451fEd6",
       "name": "V4 minter for ABxPace V3 Engine core",
       "startBlock": 16529300
+    },
+    {
+      "address": "0x27F79CB37B08E4C2FF56DB0f69aE875d4f5A6311",
+      "name": "V4 minter for ABxBMG V3 Engine core",
+      "startBlock": 16529300
     }
   ],
   "minterDAExpSettlementContracts": [
@@ -379,6 +409,11 @@
     {
       "address": "0x3aA2D7e6CE5f08E59b0511cdeB6ba866d9fe9994",
       "name": "V1 minter for ABxPace V3 Engine core",
+      "startBlock": 16529300
+    },
+    {
+      "address": "0xd38CB6D95BFb5Eb7C61F36938e7B3Ca08810e7F7",
+      "name": "V1 minter for ABxBMG V3 Engine core",
       "startBlock": 16529300
     }
   ],

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -161,6 +161,21 @@
       "address": "0x3F4bbde879F9BB0E95AEa08fF12F55E171495C8f",
       "name": "Art Blocks Explorations Minter Filter",
       "startBlock": 15791057
+    },
+    {
+      "address": "0xc89c6dfDE92AacD293AF930bD8D290a33D35eEf0",
+      "name": "Minter Filter for ABxPace core at 0xEa698596b6009A622C3eD00dD5a8b5d1CAE4fC36",
+      "startBlock": 16237201
+    },
+    {
+      "address": "0x6E522449C1642E7cB0B12a2889CcBf79b51C69f8",
+      "name": "Minter Filter for ABxBMG core at 0x145789247973C5D612bF121e9E4Eef84b63Eb707",
+      "startBlock": 16237496
+    },
+    {
+      "address": "0x3BB525024093b3ba5a6C7803Fa1718Fc6fc27a37",
+      "name": "Minter Filter for AB Managed Engine core at 0x73b4797E2FD04fA42a9F3c9bCfbcEe19374A9060",
+      "startBlock": 16237571
     }
   ],
   "minterSetPriceContracts": [

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -433,5 +433,12 @@
       "name": "Admin ACL V1 for V3 core and Explorations core, treated as an AdminACLV0 for subgraph indexing purposes",
       "startBlock": 15799761
     }
+  ],
+  "engineRegistryV0Contracts": [
+    {
+      "address": "0x652490c8BB6e7ec3Fd798537D2F348D7904BBbc2",
+      "name": "Mainnet Engine registry contract",
+      "startBlock": 16237184
+    }
   ]
 }


### PR DESCRIPTION
## Description of the change

Shuffle which contracts are being indexed on dev and staging, and add any new dev or staging minters we want to index for the new V3 Engine contracts.

Also updates mainnet config to include ABxPace, ABxBMG, and the AB managed Engine contract. Minters are included for ABxPace and ABxBMG.

This PR is intended to wrap up our recent set of subgraph changes and deployments, and should be used for releases on all testnet and mainnet subgraphs. 🥳 