### PR TITLE
remove some abis from subgraph yaml to induce failure only during sync

### DIFF
--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -714,34 +714,6 @@ dataSources:
           file: ./abis/IEngineRegistryV0.json
         - name: EngineRegistryV0
           file: ./abis/EngineRegistryV0.json
-        - name: IGenArt721CoreContractV3_Base
-          file: ./abis/IGenArt721CoreContractV3_Base.json
-        - name: IGenArt721CoreContractV3
-          file: ./abis/IGenArt721CoreContractV3.json
-        - name: IGenArt721CoreContractV3_Engine
-          file: ./abis/IGenArt721CoreContractV3_Engine.json
-        - name: GenArt721CoreV3
-          file: ./abis/GenArt721CoreV3.json
-        - name: GenArt721CoreV3_Engine
-          file: ./abis/GenArt721CoreV3_Engine.json
-        - name: IERC721
-          file: ./abis/IERC721.json
-        - name: Ownable
-          file: ./abis/Ownable.json
-        - name: IAdminACLV0
-          file: ./abis/IAdminACLV0.json
-        - name: IMinterFilterV0
-          file: ./abis/IMinterFilterV0.json
-        - name: MinterFilterV0
-          file: ./abis/MinterFilterV0.json
-        - name: MinterFilterV1
-          file: ./abis/MinterFilterV1.json
-        - name: IFilteredMinterV2
-          file: ./abis/IFilteredMinterV2.json
-        - name: IFilteredMinterDALinV1
-          file: ./abis/IFilteredMinterDALinV1.json
-        - name: IFilteredMinterDAExpV1
-          file: ./abis/IFilteredMinterDAExpV1.json
       eventHandlers:
         - event: ContractRegistered(indexed address,bytes32,bytes32)
           handler: handleContractRegistered


### PR DESCRIPTION
## Description of the change

Remove ABIs from a portion of our subgraph template to induce missing ABI failure that only occurs during sync.
