### PR TITLE
Additional testnet bug fixes

### DIFF
--- a/config/goerli-staging.json
+++ b/config/goerli-staging.json
@@ -21,6 +21,13 @@
       "startBlock": 7723578
     }
   ],
+  "genArt721CoreContracts": [
+    {
+      "address": "0xDa62f67BE7194775A75BE91CBF9FEeDcC5776D4b",
+      "name": "Artist Staging Goerli Flagship Core V1 Contract",
+      "startBlock": 7011002
+    }
+  ],
   "pbabContracts": [
     {
       "address": "0x5503a3B96D845f33F135429AB18C03C79477B14f",

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -696,21 +696,24 @@ function _handleMinterUpdated<T>(contract: T, event: MinterUpdated): void {
     // this should never happen
     return;
   }
-  if (contract instanceof GenArt721CoreV3_Engine) {
-    // For Engine contracts, only index minter filters that are in the config
-    // and actively being indexed
-    let minterFilter = MinterFilter.load(
-      event.params._currentMinter.toHexString()
-    );
-    if (!minterFilter) {
-      // minter filter is not in config, set minterFilter to null
-      contractEntity.minterFilter = null;
-      contractEntity.save();
-      // refresh contract to update mintWhitelisted
-      refreshContract(contract, event.block.timestamp);
-      return;
-    }
-  }
+  // @dev this logic is temporarily disabled until we can determine the best way
+  // to handle determining if we should index an Engine contract's minter
+  // suite. For now, we will index all minter filters on Engine contracts.
+  // if (contract instanceof GenArt721CoreV3_Engine) {
+  //   // For Engine contracts, only index minter filters that are in the config
+  //   // and actively being indexed
+  //   let minterFilter = MinterFilter.load(
+  //     event.params._currentMinter.toHexString()
+  //   );
+  //   if (!minterFilter) {
+  //     // minter filter is not in config, set minterFilter to null
+  //     contractEntity.minterFilter = null;
+  //     contractEntity.save();
+  //     // refresh contract to update mintWhitelisted
+  //     refreshContract(contract, event.block.timestamp);
+  //     return;
+  //   }
+  // }
 
   // Clear the minter config for all projects on core contract when a new
   // minter filter is set

--- a/tests/subgraph/mapping-v3-core/mapping-v3-engine-core-minter-updated.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-engine-core-minter-updated.test.ts
@@ -135,11 +135,18 @@ test(`${coreType}/MinterUpdated: should list invalid MinterFilter with different
     "updatedAt",
     updateCallBlockTimestamp.toString()
   );
-  // minter filter should NOT be added to store for engine contracts
-  assert.notInStore(
+  // patch: minter filter should be added for all engine contracts, temporarily
+  assert.fieldEquals(
     MINTER_FILTER_ENTITY_TYPE,
+    TEST_MINTER_FILTER_ADDRESS.toHexString(),
+    "id",
     TEST_MINTER_FILTER_ADDRESS.toHexString()
   );
+  // // minter filter should NOT be added to store for engine contracts
+  // assert.notInStore(
+  //   MINTER_FILTER_ENTITY_TYPE,
+  //   TEST_MINTER_FILTER_ADDRESS.toHexString()
+  // );
 });
 
 test(`${coreType}/MinterUpdated: should create Contract but NOT MinterFilter entities when not yet created, and NOT assign minterFilter`, () => {
@@ -171,12 +178,19 @@ test(`${coreType}/MinterUpdated: should create Contract but NOT MinterFilter ent
   // handle event
   handleMinterUpdated(event);
   // assertions
+  // patch: minter filter should be added for all engine contracts, temporarily
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
     "minterFilter",
-    "null"
+    TEST_MINTER_FILTER_ADDRESS.toHexString()
   );
+  // assert.fieldEquals(
+  //   CONTRACT_ENTITY_TYPE,
+  //   TEST_CONTRACT_ADDRESS.toHexString(),
+  //   "minterFilter",
+  //   "null"
+  // );
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
@@ -189,10 +203,17 @@ test(`${coreType}/MinterUpdated: should create Contract but NOT MinterFilter ent
     "updatedAt",
     updateCallBlockTimestamp.toString()
   );
-  assert.notInStore(
+  // patch: minter filter should be added for all engine contracts, temporarily
+  assert.fieldEquals(
     MINTER_FILTER_ENTITY_TYPE,
+    TEST_MINTER_FILTER_ADDRESS.toHexString(),
+    "id",
     TEST_MINTER_FILTER_ADDRESS.toHexString()
   );
+  // assert.notInStore(
+  //   MINTER_FILTER_ENTITY_TYPE,
+  //   TEST_MINTER_FILTER_ADDRESS.toHexString()
+  // );
 });
 
 test(`${coreType}/MinterUpdated: should populate project minter configurations for all projects preconfigured on existing minter filter`, () => {


### PR DESCRIPTION
## Description of the change

Add a missing V1 core contract to artist staging config, and temporarily index all V3 Engine Minter Filters until a better path forward can be determined.

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.
