### PR TITLE
Add serial English auction minter

### DIFF
--- a/abis/IFilteredMinterSEAV0.json
+++ b/abis/IFilteredMinterSEAV0.json
@@ -1,0 +1,953 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "IFilteredMinterSEAV0",
+  "sourceName": "contracts/interfaces/0.8.x/IFilteredMinterSEAV0.sol",
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "bidder",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "bidAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "AuctionBid",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "minAuctionDurationSeconds",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "maxAuctionDurationSeconds",
+          "type": "uint32"
+        }
+      ],
+      "name": "AuctionDurationSecondsRangeUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "bidder",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "bidAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint64",
+          "name": "endTime",
+          "type": "uint64"
+        }
+      ],
+      "name": "AuctionInitialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "winner",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "price",
+          "type": "uint256"
+        }
+      ],
+      "name": "AuctionSettled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ConfigKeyRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_value",
+          "type": "uint256"
+        }
+      ],
+      "name": "ConfigValueAddedToSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "_value",
+          "type": "address"
+        }
+      ],
+      "name": "ConfigValueAddedToSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_value",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ConfigValueAddedToSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_value",
+          "type": "uint256"
+        }
+      ],
+      "name": "ConfigValueRemovedFromSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "_value",
+          "type": "address"
+        }
+      ],
+      "name": "ConfigValueRemovedFromSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_value",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ConfigValueRemovedFromSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "_value",
+          "type": "bool"
+        }
+      ],
+      "name": "ConfigValueSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_value",
+          "type": "uint256"
+        }
+      ],
+      "name": "ConfigValueSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "_value",
+          "type": "address"
+        }
+      ],
+      "name": "ConfigValueSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_value",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ConfigValueSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint64",
+          "name": "timestampStart",
+          "type": "uint64"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "auctionDurationSeconds",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "basePrice",
+          "type": "uint256"
+        }
+      ],
+      "name": "ConfiguredFutureAuctions",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "minterMinBidIncrementPercentage",
+          "type": "uint8"
+        }
+      ],
+      "name": "MinterMinBidIncrementPercentageUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "minterTimeBufferSeconds",
+          "type": "uint32"
+        }
+      ],
+      "name": "MinterTimeBufferUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_pricePerTokenInWei",
+          "type": "uint256"
+        }
+      ],
+      "name": "PricePerTokenInWeiUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_currencyAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "_currencySymbol",
+          "type": "string"
+        }
+      ],
+      "name": "ProjectCurrencyInfoUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_maxInvocations",
+          "type": "uint256"
+        }
+      ],
+      "name": "ProjectMaxInvocationsLimitUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "_purchaseToDisabled",
+          "type": "bool"
+        }
+      ],
+      "name": "PurchaseToDisabledUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "ResetAuctionDetails",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_timestampStart",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_auctionDurationSeconds",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_basePrice",
+          "type": "uint256"
+        }
+      ],
+      "name": "configureFutureAuctions",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "createBid",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "createBid_4cM",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "genArt721CoreAddress",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getPriceInfo",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "isConfigured",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tokenPriceInWei",
+          "type": "uint256"
+        },
+        {
+          "internalType": "string",
+          "name": "currencySymbol",
+          "type": "string"
+        },
+        {
+          "internalType": "address",
+          "name": "currencyAddress",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_targetTokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "initializeAuction",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_maxInvocations",
+          "type": "uint256"
+        }
+      ],
+      "name": "manuallyLimitProjectMaxInvocations",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "minterConfigurationDetails",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "minAuctionDurationSeconds_",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint32",
+          "name": "maxAuctionDurationSeconds_",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint8",
+          "name": "minterMinBidIncrementPercentage_",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint32",
+          "name": "minterTimeBufferSeconds_",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "minterFilterAddress",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "minterType",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "projectActiveAuctionDetails",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "tokenId",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "currentBid",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address payable",
+              "name": "currentBidder",
+              "type": "address"
+            },
+            {
+              "internalType": "uint64",
+              "name": "endTime",
+              "type": "uint64"
+            },
+            {
+              "internalType": "bool",
+              "name": "settled",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "initialized",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct IFilteredMinterSEAV0.Auction",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "projectConfigurationDetails",
+      "outputs": [
+        {
+          "internalType": "uint24",
+          "name": "maxInvocations",
+          "type": "uint24"
+        },
+        {
+          "internalType": "uint64",
+          "name": "timestampStart",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint32",
+          "name": "auctionDurationSeconds",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint256",
+          "name": "basePrice",
+          "type": "uint256"
+        },
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "tokenId",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "currentBid",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address payable",
+              "name": "currentBidder",
+              "type": "address"
+            },
+            {
+              "internalType": "uint64",
+              "name": "endTime",
+              "type": "uint64"
+            },
+            {
+              "internalType": "bool",
+              "name": "settled",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "initialized",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct IFilteredMinterSEAV0.Auction",
+          "name": "auction",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "purchase",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "purchaseTo",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "resetAuctionDetails",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "setProjectMaxInvocations",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_settleTokenId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_initializeTokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "settleAndInitializeAuction",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "settleAuction",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "togglePurchaseToDisabled",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x",
+  "deployedBytecode": "0x",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/abis/IFilteredMinterSEAV0.json
+++ b/abis/IFilteredMinterSEAV0.json
@@ -629,6 +629,25 @@
       "inputs": [
         {
           "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getTokenToBidOrInitialize",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
           "name": "_targetTokenId",
           "type": "uint256"
         }

--- a/abis/IFilteredMinterSEAV0.json
+++ b/abis/IFilteredMinterSEAV0.json
@@ -633,7 +633,7 @@
           "type": "uint256"
         }
       ],
-      "name": "getTokenToBidOrInitialize",
+      "name": "getTokenToBid",
       "outputs": [
         {
           "internalType": "uint256",
@@ -642,19 +642,6 @@
         }
       ],
       "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_targetTokenId",
-          "type": "uint256"
-        }
-      ],
-      "name": "initializeAuction",
-      "outputs": [],
-      "stateMutability": "payable",
       "type": "function"
     },
     {
@@ -929,11 +916,11 @@
         },
         {
           "internalType": "uint256",
-          "name": "_initializeTokenId",
+          "name": "_bidTokenId",
           "type": "uint256"
         }
       ],
-      "name": "settleAndInitializeAuction",
+      "name": "settleAndCreateBid",
       "outputs": [],
       "stateMutability": "payable",
       "type": "function"

--- a/config/generic.json
+++ b/config/generic.json
@@ -85,6 +85,11 @@
       "address": ""
     }
   ],
+  "minterSEAContracts": [
+    {
+      "address": ""
+    }
+  ],
   "adminACLV0Contracts": [
     {
       "address": ""

--- a/src/minter-suite-mapping.ts
+++ b/src/minter-suite-mapping.ts
@@ -492,10 +492,6 @@ export function handleDelegationRegistryUpdatedGeneric<T>(event: T): void {
 
   let minter = loadOrCreateMinter(event.address, event.block.timestamp);
 
-  if (!minter) {
-    return;
-  }
-
   handleSetMinterDetailsGeneric(
     "delegationRegistryAddress",
     event.params.delegationRegistryAddress,
@@ -510,10 +506,6 @@ export function handleAuctionDurationSecondsRangeUpdated(
   event: AuctionDurationSecondsRangeUpdated
 ): void {
   let minter = loadOrCreateMinter(event.address, event.block.timestamp);
-
-  if (!minter) {
-    return;
-  }
 
   // update Minter.extraMinterDetails with new values
   handleSetMinterDetailsGeneric(
@@ -536,10 +528,6 @@ export function handleMinterMinBidIncrementPercentageUpdated(
 ): void {
   let minter = loadOrCreateMinter(event.address, event.block.timestamp);
 
-  if (!minter) {
-    return;
-  }
-
   // update Minter.extraMinterDetails with new value
   handleSetMinterDetailsGeneric(
     "minterMinBidIncrementPercentage",
@@ -555,10 +543,6 @@ export function handleMinterTimeBufferUpdated(
   event: MinterTimeBufferUpdated
 ): void {
   let minter = loadOrCreateMinter(event.address, event.block.timestamp);
-
-  if (!minter) {
-    return;
-  }
 
   // update Minter.extraMinterDetails with new value
   handleSetMinterDetailsGeneric(
@@ -1061,9 +1045,7 @@ export function handleAddManyMinterConfig<T>(event: T): void {
   }
 
   let minter = loadOrCreateMinter(event.address, event.block.timestamp);
-  if (minter) {
-    handleAddManyValueGeneric(event, minter, null);
-  }
+  handleAddManyValueGeneric(event, minter, null);
 }
 
 export function handleAddManyBigIntValueProjectConfig(
@@ -1201,9 +1183,7 @@ export function handleRemoveManyMinterConfig<T>(event: T): void {
     return;
   }
   let minter = loadOrCreateMinter(event.address, event.block.timestamp);
-  if (minter) {
-    handleRemoveManyValueGeneric(event, minter, null);
-  }
+  handleRemoveManyValueGeneric(event, minter, null);
 }
 
 export function handleRemoveBigIntManyValueProjectConfig(

--- a/src/minter-suite-mapping.ts
+++ b/src/minter-suite-mapping.ts
@@ -89,6 +89,18 @@ import {
 } from "../generated/MinterHolder/IFilteredMinterHolderV2";
 
 import { DelegationRegistryUpdated as MinterMerkleDelegationRegistryUpdated } from "../generated/MinterMerkle/IFilteredMinterMerkleV2";
+
+import {
+  AuctionDurationSecondsRangeUpdated,
+  MinterMinBidIncrementPercentageUpdated,
+  MinterTimeBufferUpdated,
+  ConfiguredFutureAuctions,
+  ResetAuctionDetails,
+  AuctionInitialized,
+  AuctionBid,
+  AuctionSettled
+} from "../generated/MinterSEA/IFilteredMinterSEAV0";
+
 import { MinterConfigSetAddressEvent } from "./util-types";
 
 // IFilteredMinterV0 events
@@ -488,6 +500,32 @@ export function handleDelegationRegistryUpdatedGeneric<T>(event: T): void {
     event.params.delegationRegistryAddress,
     minter
   );
+  minter.updatedAt = event.block.timestamp;
+  minter.save();
+}
+
+// MinterSEA specific handlers
+export function handleAuctionDurationSecondsRangeUpdated(
+  event: AuctionDurationSecondsRangeUpdated
+): void {
+  let minter = loadOrCreateMinter(event.address, event.block.timestamp);
+
+  if (!minter) {
+    return;
+  }
+
+  // update Minter.extraMinterDetails with new values
+  handleSetMinterDetailsGeneric(
+    "minAuctionDurationSeconds",
+    event.params.minAuctionDurationSeconds,
+    minter
+  );
+  handleSetMinterDetailsGeneric(
+    "maxAuctionDurationSeconds",
+    event.params.maxAuctionDurationSeconds,
+    minter
+  );
+
   minter.updatedAt = event.block.timestamp;
   minter.save();
 }

--- a/src/minter-suite-mapping.ts
+++ b/src/minter-suite-mapping.ts
@@ -732,6 +732,28 @@ export function handleAuctionBid(event: AuctionBid): void {
   }
 }
 
+export function handleAuctionSettled(event: AuctionSettled): void {
+  const projectIdNumber = generateProjectIdNumberFromTokenIdNumber(
+    event.params.tokenId
+  );
+  let minterProjectAndConfig = loadMinterProjectAndConfig(
+    event.address,
+    projectIdNumber,
+    event.block.timestamp
+  );
+
+  if (minterProjectAndConfig) {
+    let projectMinterConfig = minterProjectAndConfig.projectMinterConfiguration;
+    // update relevant auction details in project minter configuration extraMinterDetails json field
+    handleSetMinterDetailsGeneric("auctionSettled", true, projectMinterConfig);
+
+    // update project updatedAt to sync new projectMinterConfiguration changes
+    let project = minterProjectAndConfig.project;
+    project.updatedAt = event.block.timestamp;
+    project.save();
+  }
+}
+
 // Generic Handlers
 // Below is all logic pertaining to generic handlers used for maintaining JSON config stores on both the ProjectMinterConfiguration and Minter entities.
 // Most logic is shared and bubbled up each respective handler for each action. We utilize ducktype to allow these to work on either a Minter or ProjectMinterConfiguration

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -55,6 +55,8 @@ dataSources:
           file: ./abis/IFilteredMinterDALinV1.json
         - name: IFilteredMinterDAExpV1
           file: ./abis/IFilteredMinterDAExpV1.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: Mint(indexed address,indexed uint256)
           handler: handleMint
@@ -123,6 +125,8 @@ dataSources:
           file: ./abis/IFilteredMinterDALinV1.json
         - name: IFilteredMinterDAExpV1
           file: ./abis/IFilteredMinterDAExpV1.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: OwnershipTransferred(indexed address,indexed address)
           handler: handleOwnershipTransferred
@@ -181,6 +185,8 @@ dataSources:
           file: ./abis/IFilteredMinterDALinV1.json
         - name: IFilteredMinterDAExpV1
           file: ./abis/IFilteredMinterDAExpV1.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,indexed uint256)
           handler: handleTransfer
@@ -742,6 +748,8 @@ dataSources:
           file: ./abis/IFilteredMinterDALinV1.json
         - name: IFilteredMinterDAExpV1
           file: ./abis/IFilteredMinterDAExpV1.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: ContractRegistered(indexed address,bytes32,bytes32)
           handler: handleContractRegistered
@@ -778,6 +786,8 @@ dataSources:
           file: ./abis/IFilteredMinterDALinV1.json
         - name: IFilteredMinterDAExpV1
           file: ./abis/IFilteredMinterDAExpV1.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: IsCanonicalMinterFilter(indexed address)
           handler: handleIsCanonicalMinterFilter
@@ -822,6 +832,8 @@ dataSources:
           file: ./abis/IFilteredMinterDALinV1.json
         - name: IFilteredMinterDAExpV1
           file: ./abis/IFilteredMinterDAExpV1.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: Deployed()
           handler: handleDeployed
@@ -873,6 +885,8 @@ dataSources:
           file: ./abis/IFilteredMinterHolderV2.json
         - name: IFilteredMinterMerkleV2
           file: ./abis/IFilteredMinterMerkleV2.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: PricePerTokenInWeiUpdated(indexed uint256,indexed uint256)
           handler: handlePricePerTokenInWeiUpdated
@@ -917,6 +931,8 @@ dataSources:
           file: ./abis/IFilteredMinterHolderV2.json
         - name: IFilteredMinterMerkleV2
           file: ./abis/IFilteredMinterMerkleV2.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: PricePerTokenInWeiUpdated(indexed uint256,indexed uint256)
           handler: handlePricePerTokenInWeiUpdated
@@ -961,6 +977,8 @@ dataSources:
           file: ./abis/IFilteredMinterHolderV2.json
         - name: IFilteredMinterMerkleV2
           file: ./abis/IFilteredMinterMerkleV2.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: AuctionHalfLifeRangeSecondsUpdated(uint256,uint256)
           handler: handleAuctionHalfLifeRangeSecondsUpdated
@@ -1011,6 +1029,8 @@ dataSources:
           file: ./abis/IFilteredMinterHolderV2.json
         - name: IFilteredMinterMerkleV2
           file: ./abis/IFilteredMinterMerkleV2.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: MinimumAuctionLengthSecondsUpdated(uint256)
           handler: handleMinimumAuctionLengthSecondsUpdated
@@ -1062,6 +1082,8 @@ dataSources:
           file: ./abis/IFilteredMinterHolderV2.json
         - name: IFilteredMinterMerkleV2
           file: ./abis/IFilteredMinterMerkleV2.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: PricePerTokenInWeiUpdated(indexed uint256,indexed uint256)
           handler: handlePricePerTokenInWeiUpdated
@@ -1116,6 +1138,8 @@ dataSources:
           file: ./abis/IFilteredMinterHolderV2.json
         - name: IFilteredMinterMerkleV2
           file: ./abis/IFilteredMinterMerkleV2.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: PricePerTokenInWeiUpdated(indexed uint256,indexed uint256)
           handler: handlePricePerTokenInWeiUpdated
@@ -1166,6 +1190,8 @@ dataSources:
           file: ./abis/IFilteredMinterHolderV2.json
         - name: IFilteredMinterMerkleV2
           file: ./abis/IFilteredMinterMerkleV2.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: PricePerTokenInWeiUpdated(indexed uint256,indexed uint256)
           handler: handlePricePerTokenInWeiUpdated
@@ -1185,6 +1211,66 @@ dataSources:
           handler: handleProjectMaxInvocationsLimitUpdated
       file: ./src/minter-suite-mapping.ts
   {{/minterHolderContracts}}
+  {{#minterSEAContracts}}
+  - kind: ethereum/contract
+    name: 'MinterSEA{{#address}}-{{address}}{{/address}}'
+    network: {{network}}
+    source:
+      address: "{{#address}}{{address}}{{/address}}{{^address}}0x0000000000000000000000000000000000000000{{/address}}"
+      abi: IFilteredMinterSEAV0
+      {{#startBlock}}startBlock: {{startBlock}}{{/startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      entities:
+        - Project
+        - Contract
+        - MinterFilter
+        - Minter
+        - ProjectMinterConfiguration
+      abis:
+        - name: IFilteredMinterV2
+          file: ./abis/IFilteredMinterV2.json
+        - name: IFilteredMinterDALinV1
+          file: ./abis/IFilteredMinterDALinV1.json
+        - name: IFilteredMinterDAExpV1
+          file: ./abis/IFilteredMinterDAExpV1.json
+        - name: IFilteredMinterDAExpSettlementV1
+          file: ./abis/IFilteredMinterDAExpSettlementV1.json
+        - name: IFilteredMinterV2
+          file: ./abis/IFilteredMinterV2.json
+        - name: IFilteredMinterHolderV2
+          file: ./abis/IFilteredMinterHolderV2.json
+        - name: IFilteredMinterMerkleV2
+          file: ./abis/IFilteredMinterMerkleV2.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
+      eventHandlers:
+        - event: PricePerTokenInWeiUpdated(indexed uint256,indexed uint256)
+          handler: handlePricePerTokenInWeiUpdated
+        - event: ProjectCurrencyInfoUpdated(indexed uint256,indexed address,string)
+          handler: handleProjectCurrencyInfoUpdated
+        - event: ProjectMaxInvocationsLimitUpdated(indexed uint256,uint256)
+          handler: handleProjectMaxInvocationsLimitUpdated
+        - event: AuctionDurationSecondsRangeUpdated(uint32,uint32)
+          handler: handleAuctionDurationSecondsRangeUpdated
+        - event: MinterMinBidIncrementPercentageUpdated(uint8)
+          handler: handleMinterMinBidIncrementPercentageUpdated
+        - event: MinterTimeBufferUpdated(uint32)
+          handler: handleMinterTimeBufferUpdated
+        - event: ConfiguredFutureAuctions(indexed uint256,uint64,uint32,uint256)
+          handler: handleConfiguredFutureAuctions
+        - event: ResetAuctionDetails(indexed uint256)
+          handler: handleResetAuctionDetails
+        - event: AuctionInitialized(indexed uint256,indexed address,uint256,uint64)
+          handler: handleAuctionInitialized
+        - event: AuctionBid(indexed uint256,indexed address,uint256)
+          handler: handleAuctionBid
+        - event: AuctionSettled(indexed uint256,indexed address,uint256)
+          handler: handleAuctionSettled
+      file: ./src/minter-suite-mapping.ts
+  {{/minterSEAContracts}}
   {{#adminACLV0Contracts}}
   - kind: ethereum/contract
     name: 'AdminACLV0{{#address}}-{{address}}{{/address}}'
@@ -1231,6 +1317,8 @@ dataSources:
           file: ./abis/IFilteredMinterDALinV1.json
         - name: IFilteredMinterDAExpV1
           file: ./abis/IFilteredMinterDAExpV1.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: SuperAdminTransferred(indexed address,indexed address,address[])
           handler: handleIAdminACLV0SuperAdminTransferred
@@ -1368,6 +1456,8 @@ templates:
           file: ./abis/IFilteredMinterDALinV1.json
         - name: IFilteredMinterDAExpV1
           file: ./abis/IFilteredMinterDAExpV1.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: Mint(indexed address,indexed uint256)
           handler: handleMint
@@ -1433,6 +1523,8 @@ templates:
           file: ./abis/IFilteredMinterDALinV1.json
         - name: IFilteredMinterDAExpV1
           file: ./abis/IFilteredMinterDAExpV1.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: OwnershipTransferred(indexed address,indexed address)
           handler: handleOwnershipTransferred
@@ -1488,6 +1580,8 @@ templates:
           file: ./abis/IFilteredMinterDALinV1.json
         - name: IFilteredMinterDAExpV1
           file: ./abis/IFilteredMinterDAExpV1.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: Transfer(indexed address,indexed address,indexed uint256)
           handler: handleTransfer
@@ -1536,6 +1630,8 @@ templates:
           file: ./abis/IFilteredMinterDALinV1.json
         - name: IFilteredMinterDAExpV1
           file: ./abis/IFilteredMinterDAExpV1.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
         - event: SuperAdminTransferred(indexed address,indexed address,address[])
           handler: handleIAdminACLV0SuperAdminTransferred

--- a/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
+++ b/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
@@ -78,6 +78,8 @@ import {
   ArtistAndAdminRevenuesWithdrawn
 } from "../../../generated/MinterDAExpSettlement/IFilteredMinterDAExpSettlementV1";
 
+import { AuctionDurationSecondsRangeUpdated } from "../../../generated/MinterSEA/IFilteredMinterSEAV0";
+
 import { ProjectMaxInvocationsLimitUpdated } from "../../../generated/MinterSetPrice/IFilteredMinterV2";
 
 // import handlers from minter-suite-mapping
@@ -111,7 +113,8 @@ import {
   handleSelloutPriceUpdated,
   handleReceiptUpdated,
   handleArtistAndAdminRevenuesWithdrawn,
-  handleProjectMaxInvocationsLimitUpdated
+  handleProjectMaxInvocationsLimitUpdated,
+  handleAuctionDurationSecondsRangeUpdated
 } from "../../../src/minter-suite-mapping";
 
 import {
@@ -1949,6 +1952,51 @@ describe("DAExpSettlementMinters", () => {
           '"'},"auctionRevenuesCollected":${true}}`
       );
     });
+  });
+});
+
+describe("MinterSEAV tests", () => {
+  test("handleAuctionDurationSecondsRangeUpdated updates store", () => {
+    // mock, pass event to handler, etc
+    clearStore();
+    const minter = addNewMinterToStore("MinterSEAV0");
+    const minterAddress: Address = changetype<Address>(
+      Address.fromHexString(minter.id)
+    );
+    minter.save();
+
+    const testMinAuctionDurationSeconds = BigInt.fromI32(100);
+    const testMaxAuctionDurationSeconds = BigInt.fromI32(200);
+
+    const event: AuctionDurationSecondsRangeUpdated = changetype<
+      AuctionDurationSecondsRangeUpdated
+    >(newMockEvent());
+    event.address = minterAddress;
+    event.parameters = [
+      new ethereum.EventParam(
+        "minAuctionDurationSeconds",
+        ethereum.Value.fromUnsignedBigInt(testMinAuctionDurationSeconds)
+      ),
+      new ethereum.EventParam(
+        "maxAuctionDurationSeconds",
+        ethereum.Value.fromUnsignedBigInt(testMaxAuctionDurationSeconds)
+      )
+    ];
+
+    event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
+
+    handleAuctionDurationSecondsRangeUpdated(event);
+
+    assert.fieldEquals(
+      MINTER_ENTITY_TYPE,
+      minter.id,
+      "extraMinterDetails",
+      '{"minAuctionDurationSeconds":' +
+        testMinAuctionDurationSeconds.toString() +
+        ',"maxAuctionDurationSeconds":' +
+        testMaxAuctionDurationSeconds.toString() +
+        "}"
+    );
   });
 });
 

--- a/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
+++ b/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
@@ -78,7 +78,16 @@ import {
   ArtistAndAdminRevenuesWithdrawn
 } from "../../../generated/MinterDAExpSettlement/IFilteredMinterDAExpSettlementV1";
 
-import { AuctionDurationSecondsRangeUpdated } from "../../../generated/MinterSEA/IFilteredMinterSEAV0";
+import {
+  AuctionDurationSecondsRangeUpdated,
+  MinterMinBidIncrementPercentageUpdated,
+  MinterTimeBufferUpdated,
+  ConfiguredFutureAuctions,
+  ResetAuctionDetails,
+  AuctionInitialized,
+  AuctionBid,
+  AuctionSettled
+} from "../../../generated/MinterSEA/IFilteredMinterSEAV0";
 
 import { ProjectMaxInvocationsLimitUpdated } from "../../../generated/MinterSetPrice/IFilteredMinterV2";
 
@@ -114,7 +123,10 @@ import {
   handleReceiptUpdated,
   handleArtistAndAdminRevenuesWithdrawn,
   handleProjectMaxInvocationsLimitUpdated,
-  handleAuctionDurationSecondsRangeUpdated
+  handleAuctionDurationSecondsRangeUpdated,
+  handleMinterMinBidIncrementPercentageUpdated,
+  handleMinterTimeBufferUpdated,
+  handleConfiguredFutureAuctions
 } from "../../../src/minter-suite-mapping";
 
 import {
@@ -1987,6 +1999,7 @@ describe("MinterSEAV tests", () => {
 
     handleAuctionDurationSecondsRangeUpdated(event);
 
+    // assert store is updated
     assert.fieldEquals(
       MINTER_ENTITY_TYPE,
       minter.id,
@@ -1995,6 +2008,189 @@ describe("MinterSEAV tests", () => {
         testMinAuctionDurationSeconds.toString() +
         ',"maxAuctionDurationSeconds":' +
         testMaxAuctionDurationSeconds.toString() +
+        "}"
+    );
+    assert.fieldEquals(
+      MINTER_ENTITY_TYPE,
+      minter.id,
+      "updatedAt",
+      CURRENT_BLOCK_TIMESTAMP.toString()
+    );
+  });
+
+  test("handleMinterMinBidIncrementPercentageUpdated updates store", () => {
+    // mock, pass event to handler, etc
+    clearStore();
+    const minter = addNewMinterToStore("MinterSEAV0");
+    const minterAddress: Address = changetype<Address>(
+      Address.fromHexString(minter.id)
+    );
+    minter.save();
+
+    const testMinterMinBidIncrementPercentage = BigInt.fromI32(6);
+
+    const event: MinterMinBidIncrementPercentageUpdated = changetype<
+      MinterMinBidIncrementPercentageUpdated
+    >(newMockEvent());
+    event.address = minterAddress;
+    event.parameters = [
+      new ethereum.EventParam(
+        "minterMinBidIncrementPercentage",
+        ethereum.Value.fromUnsignedBigInt(testMinterMinBidIncrementPercentage)
+      )
+    ];
+
+    event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
+
+    handleMinterMinBidIncrementPercentageUpdated(event);
+
+    // assert store is updated
+    assert.fieldEquals(
+      MINTER_ENTITY_TYPE,
+      minter.id,
+      "extraMinterDetails",
+      '{"minterMinBidIncrementPercentage":' +
+        testMinterMinBidIncrementPercentage.toString() +
+        "}"
+    );
+    assert.fieldEquals(
+      MINTER_ENTITY_TYPE,
+      minter.id,
+      "updatedAt",
+      CURRENT_BLOCK_TIMESTAMP.toString()
+    );
+  });
+
+  test("handleMinterTimeBufferUpdated updates store", () => {
+    // mock, pass event to handler, etc
+    clearStore();
+    const minter = addNewMinterToStore("MinterSEAV0");
+    const minterAddress: Address = changetype<Address>(
+      Address.fromHexString(minter.id)
+    );
+    minter.save();
+
+    const testMinterTimeBuffer = BigInt.fromI32(300);
+
+    const event: MinterTimeBufferUpdated = changetype<MinterTimeBufferUpdated>(
+      newMockEvent()
+    );
+    event.address = minterAddress;
+    event.parameters = [
+      new ethereum.EventParam(
+        "minterTimeBufferSeconds",
+        ethereum.Value.fromUnsignedBigInt(testMinterTimeBuffer)
+      )
+    ];
+
+    event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
+
+    handleMinterTimeBufferUpdated(event);
+
+    // assert store is updated
+    assert.fieldEquals(
+      MINTER_ENTITY_TYPE,
+      minter.id,
+      "extraMinterDetails",
+      '{"minterTimeBufferSeconds":' + testMinterTimeBuffer.toString() + "}"
+    );
+    assert.fieldEquals(
+      MINTER_ENTITY_TYPE,
+      minter.id,
+      "updatedAt",
+      CURRENT_BLOCK_TIMESTAMP.toString()
+    );
+  });
+
+  test("handleConfiguredFutureAuctions updates store", () => {
+    // mock, pass event to handler, etc
+    clearStore();
+    const minter = addNewMinterToStore("MinterSEAV0");
+    const testProjectId = BigInt.fromI32(42);
+    const project = addNewProjectToStore(
+      TEST_CONTRACT_ADDRESS,
+      testProjectId,
+      "Test Project",
+      randomAddressGenerator.generateRandomAddress(),
+      BigInt.fromI32(0),
+      null
+    );
+    const minterAddress: Address = changetype<Address>(
+      Address.fromHexString(minter.id)
+    );
+    minter.save();
+
+    // update values
+    const testTimestampStart = BigInt.fromI32(999);
+    const testAuctionDurationSeconds = BigInt.fromI32(10000);
+    const testBasePrice = ONE_ETH_IN_WEI.div(BigInt.fromI32(10));
+
+    const event: ConfiguredFutureAuctions = changetype<
+      ConfiguredFutureAuctions
+    >(newMockEvent());
+    event.address = minterAddress;
+    event.parameters = [
+      new ethereum.EventParam(
+        "projectId",
+        ethereum.Value.fromUnsignedBigInt(testProjectId)
+      ),
+      new ethereum.EventParam(
+        "timestampStart",
+        ethereum.Value.fromUnsignedBigInt(testTimestampStart)
+      ),
+      new ethereum.EventParam(
+        "auctionDurationSeconds",
+        ethereum.Value.fromUnsignedBigInt(testAuctionDurationSeconds)
+      ),
+      new ethereum.EventParam(
+        "basePrice",
+        ethereum.Value.fromUnsignedBigInt(testBasePrice)
+      )
+    ];
+
+    event.block.timestamp = CURRENT_BLOCK_TIMESTAMP;
+
+    handleConfiguredFutureAuctions(event);
+
+    // assert store is updated
+    const projectEntityId = generateContractSpecificId(
+      TEST_CONTRACT_ADDRESS,
+      testProjectId
+    );
+    assert.fieldEquals(
+      PROJECT_ENTITY_TYPE,
+      projectEntityId,
+      "updatedAt",
+      CURRENT_BLOCK_TIMESTAMP.toString()
+    );
+    const projectMinterConfigEntityId = getProjectMinterConfigId(
+      minter.id,
+      projectEntityId
+    );
+    assert.fieldEquals(
+      PROJECT_MINTER_CONFIGURATION_ENTITY_TYPE,
+      projectMinterConfigEntityId,
+      "priceIsConfigured",
+      "true"
+    );
+    assert.fieldEquals(
+      PROJECT_MINTER_CONFIGURATION_ENTITY_TYPE,
+      projectMinterConfigEntityId,
+      "basePrice",
+      testBasePrice.toString()
+    );
+    assert.fieldEquals(
+      PROJECT_MINTER_CONFIGURATION_ENTITY_TYPE,
+      projectMinterConfigEntityId,
+      "startTime",
+      testTimestampStart.toString()
+    );
+    assert.fieldEquals(
+      PROJECT_MINTER_CONFIGURATION_ENTITY_TYPE,
+      projectMinterConfigEntityId,
+      "extraMinterDetails",
+      '{"projectAuctionDurationSeconds":' +
+        testAuctionDurationSeconds.toString() +
         "}"
     );
   });


### PR DESCRIPTION
## Description of the change

Add support for indexing a new serial English Auction (SEA) minter.

This PR includes all updates and tests associated with indexing the new minter added in: https://github.com/ArtBlocks/artblocks-contracts/pull/504

No schema changes are required. This is due to using existing fields and generic json fields to store all new minter parameters.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203665500354291