### PR TITLE
Patch flex config and enum

### DIFF
--- a/config/goerli-dev.json
+++ b/config/goerli-dev.json
@@ -10,6 +10,11 @@
       "address": "0x7244352F6C7aFbB74D4b63Bd7e8189e84a83f179",
       "name": "Dev Goerli V3 Explorations Contract",
       "startBlock": 7799143
+    },
+    {
+      "address": "0xd2363Acbf8CdF01A5FdfcB8f0295e0a5dF94518D",
+      "name": "Dev Goerli V3 Engine Flex Contract",
+      "startBlock": 8538323
     }
   ],
   "ownableGenArt721CoreV3Contracts": [
@@ -22,6 +27,11 @@
       "address": "0x7244352F6C7aFbB74D4b63Bd7e8189e84a83f179",
       "name": "Dev Goerli V3 Explorations Contract",
       "startBlock": 7799143
+    },
+    {
+      "address": "0xd2363Acbf8CdF01A5FdfcB8f0295e0a5dF94518D",
+      "name": "Dev Goerli V3 Engine Flex Contract",
+      "startBlock": 8538323
     }
   ],
   "iERC721GenArt721CoreV3Contracts": [
@@ -34,6 +44,11 @@
       "address": "0x7244352F6C7aFbB74D4b63Bd7e8189e84a83f179",
       "name": "Dev Goerli V3 Explorations Contract",
       "startBlock": 7799143
+    },
+    {
+      "address": "0xd2363Acbf8CdF01A5FdfcB8f0295e0a5dF94518D",
+      "name": "Dev Goerli V3 Engine Flex Contract",
+      "startBlock": 8538323
     }
   ],
   "iGenArt721CoreContractV3_Engine_FlexContracts": [

--- a/schema.graphql
+++ b/schema.graphql
@@ -190,6 +190,8 @@ enum CoreType {
   GenArt721CoreV3
   "V3 Derivative - Art Blocks Engine core"
   GenArt721CoreV3_Engine
+  "V3 Derivative - Art Blocks Engine Flex core"
+  GenArt721CoreV3_Engine_Flex
 }
 
 type Contract @entity {


### PR DESCRIPTION
## Description of the change

Fix dev config by adding flex contract to all locations in dev config, and add flex to core type enum.

This is follow-on to what was intended to be included in #201.

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.
