### PR TITLE
Add new sea minter to dev config

### DIFF
--- a/config/goerli-dev.json
+++ b/config/goerli-dev.json
@@ -364,9 +364,9 @@
   ],
   "minterSEAContracts": [
     {
-      "address": "0x39d97fbcCC17b1c7c09aBc6F0fdFC3403D5d9A2F",
+      "address": "0x7cd69aa289BDb64AB8139F896a9FF7B8c8fB5a2B",
       "name": "V0 Minter for AB V3 Engine Dev C core at 0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6",
-      "startBlock": 8729319
+      "startBlock": 8740834
     }
   ],
   "adminACLV0Contracts": [

--- a/config/goerli-dev.json
+++ b/config/goerli-dev.json
@@ -362,6 +362,13 @@
       "startBlock": 8655364
     }
   ],
+  "minterSEAContracts": [
+    {
+      "address": "0x39d97fbcCC17b1c7c09aBc6F0fdFC3403D5d9A2F",
+      "name": "V0 Minter for AB V3 Engine Dev C core at 0x5702797Ff45FCb0a70eB6AE1E4563299dCFa9Dd6",
+      "startBlock": 8729319
+    }
+  ],
   "adminACLV0Contracts": [
     {
       "address": "0x4Cbf3805011f0f4d4daeDa710b2215fBF37288Ad",


### PR DESCRIPTION
## Description of the change

Add new sea minter to dev config

Note that this has already been released as a grafted deployment: https://github.com/ArtBlocks/artblocks-subgraph/releases/tag/v0.2.21-goerli%2Fdev%2Fhosted

