### PR TITLE
Try super admin call

### DIFF
--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -1285,8 +1285,9 @@ function refreshContract<T>(contract: T, timestamp: BigInt): Contract | null {
     contractEntity.admin = Bytes.fromHexString(NULL_ADDRESS);
   } else {
     let adminACLContract = IAdminACLV0.bind(_admin);
-    if (adminACLContract) {
-      let superAdminAddress = adminACLContract.superAdmin();
+    const superAdmingResult = adminACLContract.try_superAdmin();
+    if (!superAdmingResult.reverted) {
+      const superAdminAddress = superAdmingResult.value;
       contractEntity.admin = superAdminAddress;
       addWhitelisting(contractEntity.id, superAdminAddress.toHexString());
     } else {


### PR DESCRIPTION
## Description of the change
Previously we were checking for the existence of the contract returned by AdminAcl.bind but a contract will always be returned here. This updates the logic in refresh contract to try and handle the revert case.

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
