### PR TITLE
Remove unnecessary OpenZeppelin dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,6 @@
     "matchstick-as": "^0.5.0"
   },
   "devDependencies": {
-    "@openzeppelin/contracts": "4.7.1",
-    "@openzeppelin/contracts-upgradeable": "4.8.0",
     "assemblyscript": "^0.19.22",
     "mustache": "^4.1.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -284,14 +284,12 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
   integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==
 
-"@openzeppelin-4.7/contracts@npm:@openzeppelin/contracts@4.7.1", "@openzeppelin/contracts@4.7.1":
-  name "@openzeppelin-4.7/contracts"
+"@openzeppelin-4.7/contracts@npm:@openzeppelin/contracts@4.7.1":
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.1.tgz#33d0a857b76b18d313e6bb6ed28cdaf367e90cfe"
   integrity sha512-UXmAjKARsXORHlHZu5GCD7ZbRKm6nU8UHnbuT/QJJa2JEOEcbvV/X8w/sUk62Sl9VZuuljM1akrZLyAtzUgsxw==
 
-"@openzeppelin-4.8/contracts-upgradeable@npm:@openzeppelin/contracts-upgradeable@4.8.0", "@openzeppelin/contracts-upgradeable@4.8.0":
-  name "@openzeppelin-4.8/contracts-upgradeable"
+"@openzeppelin-4.8/contracts-upgradeable@npm:@openzeppelin/contracts-upgradeable@4.8.0":
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.0.tgz#26688982f46969018e3ed3199e72a07c8d114275"
   integrity sha512-5GeFgqMiDlqGT8EdORadp1ntGF0qzWZLmEY7Wbp/yVhN7/B3NNzCxujuI77ktlyG81N3CUZP8cZe3ZAQ/cW10w==


### PR DESCRIPTION
## Description of the change

This repo doesn't need to include OpenZeppelin dependencies, since the correct versions are already dependencies of the imported `@artblocks/contracts` package
