### PR TITLE
Add DA Exp end time to extraMinterDetails

### DIFF
--- a/src/minter-suite-mapping.ts
+++ b/src/minter-suite-mapping.ts
@@ -364,6 +364,8 @@ export function handleDAExpSetAuctionDetails(
     const completedHalfLives = BigInt.fromString(
       u8(Math.floor(Math.log(priceRatio) / Math.log(2))).toString()
     );
+    // @dev max possible completedHalfLives is 255 due to on-chain use of uint256,
+    // so this is safe
     const completedHalfLivesU8: u8 = u8(
       Number.parseInt(completedHalfLives.toString())
     );

--- a/src/minter-suite-mapping.ts
+++ b/src/minter-suite-mapping.ts
@@ -355,6 +355,38 @@ export function handleDAExpSetAuctionDetails(
       event.params._priceDecayHalfLifeSeconds,
       projectMinterConfig
     );
+    // pre-calculate the approximate DA end time
+    const startPriceFloatingPoint = event.params._startPrice.toBigDecimal();
+    const basePriceFloatingPoint = event.params._basePrice.toBigDecimal();
+    const priceRatio: f64 = Number.parseFloat(
+      startPriceFloatingPoint.div(basePriceFloatingPoint).toString()
+    );
+    const completedHalfLives = BigInt.fromString(
+      u8(Math.floor(Math.log(priceRatio) / Math.log(2))).toString()
+    );
+    const completedHalfLivesU8: u8 = u8(
+      Number.parseInt(completedHalfLives.toString())
+    );
+    const x1 = completedHalfLives.times(
+      event.params._priceDecayHalfLifeSeconds
+    );
+    const x2 = x1.plus(event.params._priceDecayHalfLifeSeconds);
+    const y1 = event.params._startPrice.div(
+      BigInt.fromI32(2).pow(completedHalfLivesU8)
+    );
+    const y2 = y1.div(BigInt.fromI32(2));
+    const totalAuctionTime = x1.plus(
+      x2
+        .minus(x1)
+        .times(event.params._basePrice.minus(y1))
+        .div(y2.minus(y1))
+    );
+    handleSetMinterDetailsGeneric(
+      "approximateDAExpEndTime",
+      event.params._auctionTimestampStart.plus(totalAuctionTime),
+      projectMinterConfig
+    );
+
     projectMinterConfig.priceIsConfigured = true;
     projectMinterConfig.save();
     // update project.updatedAt to queue sync of projectMinterConfig changes

--- a/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
+++ b/tests/subgraph/minter-suite/minter-suite-mapping.test.ts
@@ -1076,6 +1076,13 @@ describe("MinterDAExp-related tests", () => {
           "halfLifeSeconds",
           halfLifeSeconds.toString()
         );
+        // approx DA length calculated separately via calculator
+        const approxDAExpLength = BigInt.fromI32(1360);
+        assertJsonFieldEquals(
+          updatedProjectMinterConfig.extraMinterDetails,
+          "approximateDAExpEndTime",
+          startTime.plus(approxDAExpLength).toString()
+        );
 
         // @dev Deprecated fields ----------------
         assert.fieldEquals(

--- a/tests/subgraph/shared-helpers.ts
+++ b/tests/subgraph/shared-helpers.ts
@@ -665,7 +665,7 @@ export function assertJsonFieldEquals(
   if (_val.kind == JSONValueKind.STRING) {
     if (_val.toString() != expectedValue) {
       throw new Error(
-        `Expected json value ${_val.toString()} == ${expectedValue}, but did not`
+        `Expected json value for key ${key} to be ${expectedValue}, but was ${_val.toString()}`
       );
     }
   } else if (_val.kind == JSONValueKind.NUMBER) {


### PR DESCRIPTION
## Description of the change

Add DA Exp end time to extraMinterDetails.

This is related to moving all minter-specific fields into `extraMinterDetails`.

## Limitations

Note that `BigInt`'s `.pow()` function only accepts a `u8`, meaning that this calculation fails when an auction has >255 half lives until reaching base price. However, this is okay, since 2^255 is equal to the maximum possible ratio of startPrice/basePrice ratio (since we use uint256 to define prices on-chain) 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204374827899369