### PR TITLE
Index minter filter type

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -195,6 +195,15 @@ enum CoreType {
   GenArt721CoreV3_Engine_Flex
 }
 
+enum MinterFilterType {
+  "IMinterFilterV0, no minterFilterType function"
+  MinterFilterV0
+  "IMinterFilterV0, added minterFilterType function"
+  MinterFilterV1
+  "IMinterFilterV1 includes minterFilterType function"
+  MinterFilterV2
+}
+
 type Contract @entity {
   "Unique identifier made up of the contract address"
   id: ID!
@@ -364,6 +373,11 @@ type MinterFilter @entity {
   contains a single allowlisted core contract.
   """
   coreRegistry: CoreRegistry!
+
+  """
+  Speficies which MinterFilter type this MinterFilter is
+  """
+  type: MinterFilterType!
 
   updatedAt: BigInt!
 }

--- a/tests/subgraph/legacy-minter-suite/minter-filter-mapping.test.ts
+++ b/tests/subgraph/legacy-minter-suite/minter-filter-mapping.test.ts
@@ -66,7 +66,7 @@ import { toJSONValue } from "../../../src/json";
 
 const randomAddressGenerator = new RandomAddressGenerator();
 
-test("handleDeployed should add MinterFilter to the store", () => {
+test("handleDeployed should add V0 MinterFilter to the store", () => {
   clearStore();
   addTestContractToStore(BigInt.fromI32(0));
 
@@ -85,6 +85,14 @@ test("handleDeployed should add MinterFilter to the store", () => {
     "genArt721CoreAddress",
     "genArt721CoreAddress():(address)"
   ).returns([ethereum.Value.fromAddress(TEST_CONTRACT_ADDRESS)]);
+
+  // MinterFilterV0 does not have this function and should revert.
+  // In this case we assume the type is MinterFilterV0
+  createMockedFunction(
+    minterFilterAddress,
+    "minterFilterType",
+    "minterFilterType():(string)"
+  ).reverts();
 
   assert.notInStore(
     MINTER_FILTER_ENTITY_TYPE,
@@ -114,6 +122,14 @@ test("handleDeployed should add MinterFilter to the store", () => {
     "registeredOn",
     "null"
   );
+
+  assert.fieldEquals(
+    MINTER_FILTER_ENTITY_TYPE,
+    minterFilterAddress.toHexString(),
+    "type",
+    "MinterFilterV0"
+  );
+
   clearStore();
 });
 
@@ -781,6 +797,7 @@ test("handleMinterApproved should not add minter to minterGlobalAllowlist if the
   );
   minterFilter.updatedAt = minterFilterUpdatedAt;
   minterFilter.minterGlobalAllowlist = [];
+  minterFilter.type = "MinterFilterV1";
   minterFilter.save();
 
   const otherMinterFilterAddress = randomAddressGenerator.generateRandomAddress();
@@ -838,6 +855,7 @@ test("handleMinterApproved should add new minter to store", () => {
   );
   minterFilter.updatedAt = minterFilterUpdatedAt;
   minterFilter.minterGlobalAllowlist = [];
+  minterFilter.type = "MinterFilterV1";
   minterFilter.save();
 
   const minterToBeApprovedAddress = randomAddressGenerator.generateRandomAddress();
@@ -909,6 +927,7 @@ test("handleMinterApproved should handle the same minter being approved more tha
   );
   minterFilter.updatedAt = minterFilterUpdatedAt;
   minterFilter.minterGlobalAllowlist = [];
+  minterFilter.type = "MinterFilterV1";
   minterFilter.save();
 
   const minterToBeApprovedAddress = randomAddressGenerator.generateRandomAddress();
@@ -976,6 +995,7 @@ test("handleMinterApproved should populate DA Exp default half life ranges", () 
     );
     minterFilter.updatedAt = minterFilterUpdatedAt;
     minterFilter.minterGlobalAllowlist = [];
+    minterFilter.type = "MinterFilterV1";
     minterFilter.save();
 
     const minterToBeApprovedAddress = randomAddressGenerator.generateRandomAddress();
@@ -1049,6 +1069,7 @@ test("handleMinterApproved should populate DA Lin min auction time", () => {
     );
     minterFilter.updatedAt = minterFilterUpdatedAt;
     minterFilter.minterGlobalAllowlist = [];
+    minterFilter.type = "MinterFilterV1";
     minterFilter.save();
 
     const minterToBeApprovedAddress = randomAddressGenerator.generateRandomAddress();
@@ -1112,6 +1133,7 @@ test("handleMinterRevoke should do nothing to MinterFilter if minter is not in s
   );
   minterFilter.updatedAt = minterFilterUpdatedAt;
   minterFilter.minterGlobalAllowlist = [];
+  minterFilter.type = "MinterFilterV1";
   minterFilter.save();
 
   const minterToBeRevokedAddress = randomAddressGenerator.generateRandomAddress();
@@ -1151,6 +1173,7 @@ test("handleMinterRevoke should remove minter from MinterFilter's minterGlobalAl
   // dummy coreRegistry is set to core contract address
   minterFilter.coreRegistry = TEST_CONTRACT_ADDRESS.toHexString();
   minterFilter.minterGlobalAllowlist = [];
+  minterFilter.type = "MinterFilterV1";
   minterFilter.updatedAt = minterFilterUpdatedAt;
   minterFilter.save();
 
@@ -1251,6 +1274,7 @@ test("handleMinterRevoke should handle revoking a minter more than once", () => 
   // dummy coreRegistry is set to core contract address
   minterFilter.coreRegistry = TEST_CONTRACT_ADDRESS.toHexString();
   minterFilter.minterGlobalAllowlist = [];
+  minterFilter.type = "MinterFilterV1";
   minterFilter.updatedAt = minterFilterUpdatedAt;
   minterFilter.save();
 
@@ -1325,6 +1349,7 @@ test("handleProjectMinterRegistered should do nothing if the minter being regist
   minterFilter.coreRegistry = TEST_CONTRACT_ADDRESS.toHexString();
   minterFilter.updatedAt = minterFilterUpdatedAt;
   minterFilter.minterGlobalAllowlist = [];
+  minterFilter.type = "MinterFilterV1";
   minterFilter.save();
 
   const minterAddress = randomAddressGenerator.generateRandomAddress();
@@ -1385,6 +1410,7 @@ test("handleProjectMinterRegistered should do nothing if the minter filter's cor
   minterFilter.coreRegistry = TEST_CONTRACT_ADDRESS.toHexString();
   minterFilter.updatedAt = minterFilterUpdatedAt;
   minterFilter.minterGlobalAllowlist = [];
+  minterFilter.type = "MinterFilterV1";
   minterFilter.save();
 
   const minter = addNewMinterToStore("MinterSetPriceV0");
@@ -1455,6 +1481,7 @@ test("handleProjectMinterRegistered should do nothing if the minter filter is no
   minterFilter.coreRegistry = TEST_CONTRACT_ADDRESS.toHexString();
   minterFilter.updatedAt = minterFilterUpdatedAt;
   minterFilter.minterGlobalAllowlist = [];
+  minterFilter.type = "MinterFilterV1";
   minterFilter.save();
 
   const minter = addNewMinterToStore("MinterSetPriceV0");
@@ -1534,6 +1561,7 @@ test("handleProjectMinterRegistered should populate project from prior minter co
   minterFilter.coreRegistry = TEST_CONTRACT_ADDRESS.toHexString();
   minterFilter.updatedAt = minterFilterUpdatedAt;
   minterFilter.minterGlobalAllowlist = [];
+  minterFilter.type = "MinterFilterV1";
   minterFilter.save();
 
   const contract = addTestContractToStore(BigInt.fromI32(1));
@@ -1672,6 +1700,7 @@ test("handleProjectMinterRegistered should populate project from scratch for pro
   minterFilter.coreRegistry = TEST_CONTRACT_ADDRESS.toHexString();
   minterFilter.updatedAt = minterFilterUpdatedAt;
   minterFilter.minterGlobalAllowlist = [];
+  minterFilter.type = "MinterFilterV1";
   minterFilter.save();
 
   const contract = addTestContractToStore(BigInt.fromI32(1));
@@ -1771,6 +1800,7 @@ test("handleProjectMinterRemoved should do nothing if core contract is not in st
   minterFilter.coreRegistry = TEST_CONTRACT_ADDRESS.toHexString();
   minterFilter.updatedAt = minterFilterUpdatedAt;
   minterFilter.minterGlobalAllowlist = [];
+  minterFilter.type = "MinterFilterV1";
   minterFilter.save();
 
   const minterType = "MinterSetPriceV0";
@@ -1826,6 +1856,7 @@ test("handleProjectMinterRemoved should do nothing if core contract does not hav
   minterFilter.coreRegistry = TEST_CONTRACT_ADDRESS.toHexString();
   minterFilter.updatedAt = minterFilterUpdatedAt;
   minterFilter.minterGlobalAllowlist = [];
+  minterFilter.type = "MinterFilterV1";
   minterFilter.save();
 
   const contract = addTestContractToStore(BigInt.fromI32(1));
@@ -1881,6 +1912,7 @@ test("handleProjectMinterRemoved should remove minter configuration from project
   minterFilter.coreRegistry = TEST_CONTRACT_ADDRESS.toHexString();
   minterFilter.updatedAt = minterFilterUpdatedAt;
   minterFilter.minterGlobalAllowlist = [];
+  minterFilter.type = "MinterFilterV1";
   minterFilter.save();
 
   const contract = addTestContractToStore(BigInt.fromI32(1));

--- a/tests/subgraph/mapping-v1-core/mapping.test.ts
+++ b/tests/subgraph/mapping-v1-core/mapping.test.ts
@@ -452,6 +452,7 @@ test("GenArt721Core: Removing a whitelisted minter filter should leave existing 
   minterFilter.coreRegistry = TEST_CONTRACT_ADDRESS.toHexString();
   minterFilter.minterGlobalAllowlist = [];
   minterFilter.updatedAt = CURRENT_BLOCK_TIMESTAMP;
+  minterFilter.type = "MinterFilterV1";
   minterFilter.save();
 
   let project0 = addNewProjectToStore(
@@ -2105,7 +2106,7 @@ test("GenArt721Core: Can handleUpdateProjectScriptJSON", () => {
   const updateCallBlockTimestamp = CURRENT_BLOCK_TIMESTAMP.plus(
     BigInt.fromI32(10)
   );
-  const scriptJSON = '{}';
+  const scriptJSON = "{}";
 
   const call = changetype<UpdateProjectScriptJSONCall>(newMockCall());
 

--- a/tests/subgraph/mapping-v3-core/helpers.ts
+++ b/tests/subgraph/mapping-v3-core/helpers.ts
@@ -132,7 +132,10 @@ export function mockRefreshContractCalls(
       "artblocksCurationRegistryAddress",
       "artblocksCurationRegistryAddress():(address)"
     ).returns([ethereum.Value.fromAddress(TEST_CONTRACT.curationRegistry)]);
-  } else if (coreType == "GenArt721CoreV3_Engine" || coreType == "GenArt721CoreV3_Engine_Flex") {
+  } else if (
+    coreType == "GenArt721CoreV3_Engine" ||
+    coreType == "GenArt721CoreV3_Engine_Flex"
+  ) {
     // engine contract functions
     createMockedFunction(
       TEST_CONTRACT_ADDRESS,
@@ -272,6 +275,12 @@ export function mockMinterUpdatedCallsNoPreconfiguredProjects(
     "getNumProjectsWithMinters",
     "getNumProjectsWithMinters():(uint256)"
   ).returns([ethereum.Value.fromI32(0)]);
+
+  createMockedFunction(
+    TEST_MINTER_FILTER_ADDRESS,
+    "minterFilterType",
+    "minterFilterType():(string)"
+  ).returns([ethereum.Value.fromString("MinterFilterV1")]);
 }
 
 export function mockTokenURICall(tokenId: BigInt, tokenURI: string): void {

--- a/tests/subgraph/shared-helpers.ts
+++ b/tests/subgraph/shared-helpers.ts
@@ -401,6 +401,7 @@ export function addTestMinterFilterToStore(): MinterFilter {
   let minterFilter = new MinterFilter(TEST_MINTER_FILTER_ADDRESS.toHexString());
   minterFilter.coreRegistry = TEST_CONTRACT_ADDRESS.toHexString();
   minterFilter.updatedAt = CURRENT_BLOCK_TIMESTAMP.minus(BigInt.fromI32(10));
+  minterFilter.type = "MinterFilterV1";
   minterFilter.minterGlobalAllowlist = [];
   minterFilter.save();
 


### PR DESCRIPTION
## Description of the change
Updates subgraph to index minter filter type. Note: this will need to be added within the new minter suite architecture handlers as well, cc: @ryley-o 

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
