### PR TITLE
Bug fix current settled price type

### DIFF
--- a/src/i-shared-da-exp-settlement-mapping.ts
+++ b/src/i-shared-da-exp-settlement-mapping.ts
@@ -160,7 +160,7 @@ function syncNumSettleableInvocations(
   // update extraMinterDetails key `currentSettledPrice` to be latestPurchasePrice
   setProjectMinterConfigExtraMinterDetailsValue(
     "numSettleableInvocations",
-    numSettleableInvocationsResult.value.toString(), // Price is likely to overflow js Number.MAX_SAFE_INTEGER, so store as string
+    numSettleableInvocationsResult.value,
     minterProjectAndConfig.projectMinterConfiguration
   );
 

--- a/src/i-shared-minter-mapping.ts
+++ b/src/i-shared-minter-mapping.ts
@@ -190,11 +190,25 @@ function handleSetValueProjectMinterConfig<EventType>(event: EventType): void {
   }
 
   const projectMinterConfig = minterProjectAndConfig.projectMinterConfiguration;
-  setProjectMinterConfigExtraMinterDetailsValue(
-    event.params._key.toString(),
-    event.params._value,
-    projectMinterConfig
-  );
+  const key = event.params._key.toString();
+  if (
+    event instanceof ConfigValueSetBigInt &&
+    (key.includes("price") || key.includes("Price"))
+  ) {
+    // always convert BigInt price values to strings to avoid js numeric overflow
+    setProjectMinterConfigExtraMinterDetailsValue(
+      key,
+      event.params._value.toString(), // <--- convert to string
+      projectMinterConfig
+    );
+  } else {
+    // default: do not convert to a string
+    setProjectMinterConfigExtraMinterDetailsValue(
+      key,
+      event.params._value,
+      projectMinterConfig
+    );
+  }
 
   // induce sync if the project minter configuration is the active one
   updateProjectIfMinterConfigIsActive(

--- a/tests/e2e/runner/__tests__/minter-suite-v2/i-filtered-shared-da-exp-settlement.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/i-filtered-shared-da-exp-settlement.test.ts
@@ -22,8 +22,10 @@ import { Logger } from "@ethersproject/logger";
 Logger.setLogLevel(Logger.levels.ERROR);
 
 // waiting for subgraph to sync can take longer than the default 5s timeout
-// @dev specifically for this test, we need to wait for auction to complete, so need extra time
-jest.setTimeout(75 * 1000);
+// @dev specifically for this test, we need to wait for auction to complete, which is half of 45-second min half life
+// length = 22.5 seconds, plus 6 buffer seconds for the auction to start ~=30 seconds,
+// times 2 margin since this is just a timeout = 60 seconds timeout
+jest.setTimeout(60 * 1000);
 
 const config = getSubgraphConfig();
 

--- a/tests/e2e/runner/__tests__/minter-suite-v2/i-filtered-shared-da-exp-settlement.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/i-filtered-shared-da-exp-settlement.test.ts
@@ -22,7 +22,8 @@ import { Logger } from "@ethersproject/logger";
 Logger.setLogLevel(Logger.levels.ERROR);
 
 // waiting for subgraph to sync can take longer than the default 5s timeout
-jest.setTimeout(30 * 1000);
+// @dev specifically for this test, we need to wait for auction to complete, so need extra time
+jest.setTimeout(75 * 1000);
 
 const config = getSubgraphConfig();
 
@@ -96,7 +97,7 @@ describe("iSharedMinterDAExpSettlement event handling", () => {
         );
     });
 
-    test("subgraph is updated after event emitted", async () => {
+    test("subgraph is updated after event emitted, settled price is accurate and a string", async () => {
       // add new project to use with this irreversible test
       currentProjectNumber = await genArt721CoreContract.nextProjectId();
       await genArt721CoreContract
@@ -120,17 +121,18 @@ describe("iSharedMinterDAExpSettlement event handling", () => {
       const latestBlock = await deployer.provider.getBlock("latest");
       const targetAuctionStart = latestBlock.timestamp + 5; // 5 seconds of margin
       // make a very short auction so it ends quickly
-      const targetStartPrice = ethers.utils.parseEther("1.0");
-      const targetBasePrice = ethers.utils.parseEther("0.1");
+      // @dev intentionally use a low price here to ensure use of string
+      const targetStartPrice = ethers.utils.parseEther("0.005");
+      const targetBasePrice = ethers.utils.parseEther("0.00375"); // total auction time is 1/2 of a half life
       await minterDAExpSettlementV3Contract.connect(artist).setAuctionDetails(
         currentProjectNumber, // _projectId
         genArt721CoreAddress, // _coreContract
         targetAuctionStart, // _timestampStart
-        600, // _priceDecayHalfLifeSeconds
+        45, // _priceDecayHalfLifeSeconds
         targetStartPrice, // _startPrice
         targetBasePrice // _basePrice
       );
-      // purchase a token to trigger Receipt update event
+      // PART 1: purchase a token to trigger Receipt update event
       await new Promise((f) => setTimeout(f, 6000)); // extra second of margin so auction has started
       const tx = await minterDAExpSettlementV3Contract
         .connect(artist)
@@ -155,6 +157,47 @@ describe("iSharedMinterDAExpSettlement event handling", () => {
       expect(receiptRes.netPosted).toBe(targetStartPrice.toString());
       expect(receiptRes.numPurchased).toBe("1");
       expect(receiptRes.updatedAt.toString()).toBe(blockTimestamp?.toString());
+
+      // validate the state of extraMinterDetails in the subgraph
+      // get last purchase price directly from minter contract
+      const latestPurchasePrice =
+        await minterDAExpSettlementV3Contract.getProjectLatestPurchasePrice(
+          currentProjectNumber,
+          genArt721CoreAddress
+        );
+      const targetConfigId = `${minterDAExpSettlementV3Address.toLowerCase()}-${genArt721CoreAddress.toLowerCase()}-${currentProjectNumber.toString()}`;
+      const projectMinterConfigRes = await getProjectMinterConfigurationDetails(
+        client,
+        targetConfigId
+      );
+      const extraMinterDetails = JSON.parse(
+        projectMinterConfigRes.extraMinterDetails
+      );
+      // @dev important that this is a string due to potential for numeric overflow in js
+      expect(extraMinterDetails.currentSettledPrice).toBe(
+        latestPurchasePrice.toString()
+      );
+
+      // PART 2: Artist withdraws revenues, and settled price is updated, remains a string
+      await new Promise((f) => setTimeout(f, 22500)); // wait the length of the auction, 22.5 seconds
+      await minterDAExpSettlementV3Contract
+        .connect(artist)
+        .withdrawArtistAndAdminRevenues(
+          currentProjectNumber,
+          genArt721CoreAddress
+        );
+      // validate state of projectMinterConfig in the subgraph
+      await waitUntilSubgraphIsSynced(client);
+      const projectMinterConfigRes2 =
+        await getProjectMinterConfigurationDetails(client, targetConfigId);
+      const extraMinterDetails2 = JSON.parse(
+        projectMinterConfigRes2.extraMinterDetails
+      );
+      // price should be updated to base price because auction reached end
+      // @dev important that this is a string due to potential for numeric overflow in js
+      expect(extraMinterDetails2.currentSettledPrice).toBe(
+        targetBasePrice.toString()
+      );
     });
   });
 });

--- a/tests/e2e/runner/supplemental_abis/MinterDAExpSettlementV3.json
+++ b/tests/e2e/runner/supplemental_abis/MinterDAExpSettlementV3.json
@@ -1,0 +1,1146 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "MinterDAExpSettlementV3",
+  "sourceName": "contracts/minter-suite/Minters/MinterDAExpSettlementV3.sol",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_minterFilter",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_minimumPriceDecayHalfLifeSeconds",
+          "type": "uint256"
+        }
+      ],
+      "name": "AuctionMinHalfLifeSecondsUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ConfigKeyRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_value",
+          "type": "uint256"
+        }
+      ],
+      "name": "ConfigValueAddedToSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "_value",
+          "type": "address"
+        }
+      ],
+      "name": "ConfigValueAddedToSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_value",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ConfigValueAddedToSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_value",
+          "type": "uint256"
+        }
+      ],
+      "name": "ConfigValueRemovedFromSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "_value",
+          "type": "address"
+        }
+      ],
+      "name": "ConfigValueRemovedFromSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_value",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ConfigValueRemovedFromSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "_value",
+          "type": "bool"
+        }
+      ],
+      "name": "ConfigValueSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_value",
+          "type": "uint256"
+        }
+      ],
+      "name": "ConfigValueSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "_value",
+          "type": "address"
+        }
+      ],
+      "name": "ConfigValueSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_value",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ConfigValueSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_pricePerTokenInWei",
+          "type": "uint256"
+        }
+      ],
+      "name": "PricePerTokenInWeiUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_currencyAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "_currencySymbol",
+          "type": "string"
+        }
+      ],
+      "name": "ProjectCurrencyInfoUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_maxInvocations",
+          "type": "uint256"
+        }
+      ],
+      "name": "ProjectMaxInvocationsLimitUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_purchaser",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint24",
+          "name": "_numPurchased",
+          "type": "uint24"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_netPosted",
+          "type": "uint256"
+        }
+      ],
+      "name": "ReceiptUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "ResetAuctionDetails",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint40",
+          "name": "_auctionTimestampStart",
+          "type": "uint40"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint40",
+          "name": "_priceDecayHalfLifeSeconds",
+          "type": "uint40"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_startPrice",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_basePrice",
+          "type": "uint256"
+        }
+      ],
+      "name": "SetAuctionDetailsExp",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "internalType": "uint128",
+          "name": "_newSelloutPrice",
+          "type": "uint128"
+        }
+      ],
+      "name": "adminEmergencyReduceSelloutPrice",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "getNumSettleableInvocations",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "numSettleableInvocations",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "getPriceInfo",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "isConfigured",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tokenPriceInWei",
+          "type": "uint256"
+        },
+        {
+          "internalType": "string",
+          "name": "currencySymbol",
+          "type": "string"
+        },
+        {
+          "internalType": "address",
+          "name": "currencyAddress",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_walletAddress",
+          "type": "address"
+        }
+      ],
+      "name": "getProjectExcessSettlementFunds",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "excessSettlementFundsInWei",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "getProjectLatestPurchasePrice",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "latestPurchasePrice",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "isEngineView",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "internalType": "uint24",
+          "name": "_maxInvocations",
+          "type": "uint24"
+        }
+      ],
+      "name": "manuallyLimitProjectMaxInvocations",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "maxInvocationsProjectConfig",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bool",
+              "name": "maxHasBeenInvoked",
+              "type": "bool"
+            },
+            {
+              "internalType": "uint24",
+              "name": "maxInvocations",
+              "type": "uint24"
+            }
+          ],
+          "internalType": "struct MaxInvocationsLib.MaxInvocationsProjectConfig",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "minimumPriceDecayHalfLifeSeconds",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "minterFilterAddress",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "minterType",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "minterVersion",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "projectAuctionParameters",
+      "outputs": [
+        {
+          "internalType": "uint40",
+          "name": "timestampStart",
+          "type": "uint40"
+        },
+        {
+          "internalType": "uint40",
+          "name": "priceDecayHalfLifeSeconds",
+          "type": "uint40"
+        },
+        {
+          "internalType": "uint256",
+          "name": "startPrice",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "basePrice",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "projectMaxHasBeenInvoked",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "projectMaxInvocations",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "purchase",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "purchaseTo",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "reclaimProjectExcessSettlementFunds",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address payable",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "reclaimProjectExcessSettlementFundsTo",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "_projectIds",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "address[]",
+          "name": "_coreContracts",
+          "type": "address[]"
+        }
+      ],
+      "name": "reclaimProjectsExcessSettlementFunds",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address payable",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "_projectIds",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "address[]",
+          "name": "_coreContracts",
+          "type": "address[]"
+        }
+      ],
+      "name": "reclaimProjectsExcessSettlementFundsTo",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "resetAuctionDetails",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "internalType": "uint40",
+          "name": "_auctionTimestampStart",
+          "type": "uint40"
+        },
+        {
+          "internalType": "uint40",
+          "name": "_priceDecayHalfLifeSeconds",
+          "type": "uint40"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_startPrice",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_basePrice",
+          "type": "uint256"
+        }
+      ],
+      "name": "setAuctionDetails",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_minimumPriceDecayHalfLifeSeconds",
+          "type": "uint256"
+        }
+      ],
+      "name": "setMinimumPriceDecayHalfLifeSeconds",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "syncProjectMaxInvocationsToCore",
+      "outputs": [],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "withdrawArtistAndAdminRevenues",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x60c0604052602d6001553480156200001657600080fd5b50604051620035953803806200359583398101604081905262000039916200008d565b600160008190556001600160a01b038216608081905260a052546040519081527fdae7136b6b1f9f3031d9536e8bdd02f1d223eb793054446ff278143abeafa21b9060200160405180910390a150620000bf565b600060208284031215620000a057600080fd5b81516001600160a01b0381168114620000b857600080fd5b9392505050565b60805160a0516134a9620000ec60003960006109ab0152600081816104c40152610ee701526134a96000f3fe6080604052600436106101315760003560e01c806301000da7146101365780632b001e6c1461016b5780633c22f1d0146101995780634869f3df146101bb5780634e8d8787146102055780635418789c1461021857806367e6aad9146102385780636a9f62fc146102585780638fe8a90b146102a257806395c575fa146102c25780639a94488a146102e2578063ae77c2371461037a578063b000e3341461038d578063b3fe4723146103ad578063c0244587146103cd578063cce7c909146103ed578063cf6681ea1461040d578063d3ddabe614610423578063d9bffbce14610462578063d9eb16db14610482578063dd85582f146104b2578063e8af2b3b146104fe578063e9d1e8ac1461051e578063fdca4cb814610561578063fe676d2614610581578063fea1d7b4146105a1575b600080fd5b34801561014257600080fd5b50610156610151366004612c3c565b610621565b60405190151581526020015b60405180910390f35b34801561017757600080fd5b5061018b610186366004612c59565b610662565b604051908152602001610162565b3480156101a557600080fd5b506101b96101b4366004612c89565b61069d565b005b3480156101c757600080fd5b5061018b6101d6366004612c59565b6001600160a01b031660009081526006602090815260408083209383529290522054610100900462ffffff1690565b61018b610213366004612c89565b610831565b34801561022457600080fd5b506101b9610233366004612ccb565b610aac565b34801561024457600080fd5b506101b9610253366004612d52565b610bc8565b34801561026457600080fd5b5061018b610273366004612c59565b6001600160a01b031660009081526003602090815260408083209383529290522054610100900462ffffff1690565b3480156102ae57600080fd5b506101b96102bd366004612c59565b610bdb565b3480156102ce57600080fd5b506101b96102dd366004612c59565b610db6565b3480156102ee57600080fd5b506103586102fd366004612c59565b6040805180820190915260008082526020820152506001600160a01b031660009081526006602090815260408083209383529281529082902082518084019093525460ff811615158352610100900462ffffff169082015290565b6040805182511515815260209283015162ffffff169281019290925201610162565b61018b610388366004612c59565b610e60565b34801561039957600080fd5b506101b96103a8366004612dbd565b610e6d565b3480156103b957600080fd5b506101b96103c8366004612dfc565b610ee2565b3480156103d957600080fd5b506101b96103e8366004612e15565b610fa0565b3480156103f957600080fd5b50610156610408366004612c59565b6111e6565b34801561041957600080fd5b5061018b60015481565b34801561042f57600080fd5b5061045560405180604001604052806006815260200165076332e302e360d41b81525081565b6040516101629190612ee7565b34801561046e57600080fd5b506101b961047d366004612c59565b611212565b34801561048e57600080fd5b506104a261049d366004612c59565b611257565b6040516101629493929190612efa565b3480156104be57600080fd5b506104e67f000000000000000000000000000000000000000000000000000000000000000081565b6040516001600160a01b039091168152602001610162565b34801561050a57600080fd5b506101b9610519366004612c59565b61132f565b34801561052a57600080fd5b50610455604051806040016040528060178152602001764d696e7465724441457870536574746c656d656e74563360481b81525081565b34801561056d57600080fd5b506101b961057c366004612f4e565b61133e565b34801561058d57600080fd5b5061018b61059c366004612faf565b611586565b3480156105ad57600080fd5b506106116105bc366004612c59565b6001600160a01b03166000908152600560209081526040808320938352929052205464ffffffffff80821692600160281b8304909116916001600160581b03600160501b8204811692600160a81b9092041690565b6040516101629493929190612fe6565b6001600160a01b03811660009081526002602052604081208054610100900460ff1615610652575460ff1692915050565b61065b83611624565b9392505050565b6001600160a01b0381166000908152600360209081526040808320858452909152902054600160201b90046001600160801b03165b92915050565b6002600054036106c85760405162461bcd60e51b81526004016106bf9061300d565b60405180910390fd5b60026000556001600160a01b0383166106f35760405162461bcd60e51b81526004016106bf90613044565b6001600160a01b03811660008181526003602090815260408083208684528252808320338452600483528184209484529382528083208684529091528120908061073d848461175c565b91509150600061074c82611807565b84546001600160e81b0319166001600160e81b038216178086556040519192506001600160a01b0388169189913391600080516020613454833981519152916107a491600160e81b90910462ffffff1690879061307b565b60405180910390a46000886001600160a01b03168460405160006040518083038185875af1925050503d80600081146107f9576040519150601f19603f3d011682016040523d82523d6000602084013e6107fe565b606091505b505080915050806108215760405162461bcd60e51b81526004016106bf90613099565b5050600160005550505050505050565b60006002600054036108555760405162461bcd60e51b81526004016106bf9061300d565b600260009081556001600160a01b038316808252600360209081526040808420878552825280842083855260068352818520888652835281852093855260058352818520888652909252909220815460ff16156108c45760405162461bcd60e51b81526004016106bf906130c4565b60006108d1848484611874565b3360009081526004602090815260408083206001600160a01b038b16845282528083208b845290915281209192508061090a83856118b6565b91509150886001600160a01b03168a336001600160a01b0316600080516020613454833981519152848660405161094292919061307b565b60405180910390a461095384611977565b87546001600160801b0391909116600160201b02600160201b600160a01b03199091161787556040516117cd60e21b81526001600160a01b038c81166004830152602482018c90528a811660448301523360648301527f00000000000000000000000000000000000000000000000000000000000000001690615f34906084016020604051808303816000875af11580156109f2573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a1691906130f5565b9750610a2288876119e0565b865460ff1615610a63576001600160a01b0389166000908152600260205260408120610a4f908b90611a2e565b9050610a5d8b868c84611a60565b50610a99565b8654610100900462ffffff16876001610a7b83613124565b91906101000a81548162ffffff021916908362ffffff160217905550505b5050505050505060016000559392505050565b610abf8233306315061e2760e21b611b17565b6001600160a01b03821660008181526003602090815260408083208784528252808320848452600683528184208885528352818420948452600583528184208885529092528220909291610b17878787878787611b6c565b604080517263757272656e74536574746c6564507269636560681b81526001600160801b03881660208201529192506001600160a01b0388169189917f1809fd1f08e6b0df08fd848757688435a0ab8520a51dcca23eba5a3c7f7280d6910160405180910390a38015610bbf57825460405161010090910462ffffff1681526001600160a01b0387169088906000805160206134348339815191529060200160405180910390a35b50505050505050565b610bd53385858585610fa0565b50505050565b600260005403610bfd5760405162461bcd60e51b81526004016106bf9061300d565b6002600055610c16828233306315061e2760e21b611d34565b6001600160a01b0381166000818152600360209081526040808320868452825280832084845260068352818420878552835281842085855260058452828520888652845282852095855260029093529083209093919290610c78908690611a2e565b9050600080610c8b888888888888611da4565b6040805177185d58dd1a5bdb94995d995b9d595cd0dbdb1b1958dd195960421b8152600160208201529294509092506001600160a01b038916918a917fbb5f9d4f49f83650956b76c40de0f082a06430bf0222e1b6b3f90a7a0f845c4d910160405180910390a38015610d66578554604080517263757272656e74536574746c6564507269636560681b8152600160201b9092046001600160801b031660208301526001600160a01b038916918a917f1809fd1f08e6b0df08fd848757688435a0ab8520a51dcca23eba5a3c7f7280d6910160405180910390a35b8115610da757845460405161010090910462ffffff1681526001600160a01b0388169089906000805160206134348339815191529060200160405180910390a35b50506001600055505050505050565b610dc9813330634ae2bafd60e11b611b17565b6001600160a01b03811660009081526003602090815260408083208584529091529020805460ff1615610e0e5760405162461bcd60e51b81526004016106bf90613146565b6001600160a01b03821660008181526005602090815260408083208784529091528082208290555185917f865169678476a498ca03f184818d6bd6217dd57b754577a944c19d6d75587c8091a3505050565b600061065b338484610831565b610e78838333611f4b565b6001600160a01b03821660009081526006602090815260408083208684529091529020610eaa90849084908490611f95565b60405162ffffff821681526001600160a01b0383169084906000805160206134348339815191529060200160405180910390a3505050565b610f157f0000000000000000000000000000000000000000000000000000000000000000333063b3fe472360e01b61201c565b60008111610f655760405162461bcd60e51b815260206004820152601d60248201527f48616c66206c696665206f66207a65726f206e6f7420616c6c6f77656400000060448201526064016106bf565b60018190556040518181527fdae7136b6b1f9f3031d9536e8bdd02f1d223eb793054446ff278143abeafa21b9060200160405180910390a150565b600260005403610fc25760405162461bcd60e51b81526004016106bf9061300d565b60026000556001600160a01b038516610fed5760405162461bcd60e51b81526004016106bf90613044565b828181146110385760405162461bcd60e51b8152602060048201526018602482015277082e4e4c2f240d8cadccee8d0e640daeae6e840dac2e8c6d60431b60448201526064016106bf565b6000805b828110156111705760008787838181106110585761105861317d565b90506020020135905060008686848181106110755761107561317d565b905060200201602081019061108a9190612c3c565b6001600160a01b03811660008181526003602090815260408083208784528252808320338452600483528184209484529382528083208784529091528120929350909190806110d9848461175c565b9150915060006110e882611807565b84546001600160e81b0319166001600160e81b038216178555905061110d838a613193565b9850856001600160a01b031687336001600160a01b031660008051602061345483398151915287600001601d9054906101000a900462ffffff168560405161115692919061307b565b60405180910390a48760010197505050505050505061103c565b506000876001600160a01b03168260405160006040518083038185875af1925050503d80600081146111be576040519150601f19603f3d011682016040523d82523d6000602084013e6111c3565b606091505b50508091505080610da75760405162461bcd60e51b81526004016106bf90613099565b6001600160a01b038116600090815260066020908152604080832085845290915281205460ff1661065b565b61121d828233611f4b565b60405162461bcd60e51b815260206004820152600f60248201526e139bdd081a5b5c1b195b595b9d1959608a1b60448201526064016106bf565b6001600160a01b038116600081815260036020908152604080832086845282528083208484526006835281842087855283528184209484526005835281842087855290925282208054600160501b90046001600160581b03161515936060928492909190866112c95760009550611301565b805464ffffffffff1642116112f1578054600160501b90046001600160581b03169550611301565b6112fe8989858585612071565b95505b6040518060400160405280600381526020016208aa8960eb1b81525094506000935050505092959194509250565b61133a33838361069d565b5050565b611349868633611f4b565b6001600160a01b03851660008181526005602090815260408083208a84528252808320938352600382528083208a8452909152902061138884826120b2565b6113d45760405162461bcd60e51b815260206004820152601f60248201527f4f6e6c79206d6f6e6f746f6e69632064656372656173696e672070726963650060448201526064016106bf565b600083116114225760405162461bcd60e51b815260206004820152601b60248201527a42617365207072696365206d757374206265206e6f6e2d7a65726f60281b60448201526064016106bf565b6001548564ffffffffff1610156114a15760405162461bcd60e51b815260206004820152603e60248201527f50726963652064656361792068616c66206c696665206d75737420626520677260448201527f6561746572207468616e206d696e20616c6c6f7761626c652076616c7565000060648201526084016106bf565b6114c08287876114b0886120e5565b6114b9886120e5565b600061214d565b866001600160a01b0316887f7fbd78481800c1705ba89e4be2e8c979412fb121f7f3cbace9d7f5c3dd85c44e888888886040516115009493929190612fe6565b60405180910390a36001600160a01b03871660009081526006602090815260408083208b84529091528120906115378a8a846122ea565b9050801561157a57815460405161010090910462ffffff1681526001600160a01b038a16908b906000805160206134348339815191529060200160405180910390a35b50505050505050505050565b60006001600160a01b0382166115d05760405162461bcd60e51b815260206004820152600f60248201526e4e6f207a65726f206164647265737360881b60448201526064016106bf565b6001600160a01b0380841660008181526003602090815260408083208984528252808320948716835260048252808320938352928152828220888352905220611619828261175c565b509695505050505050565b6040516000602482018190526044820181905290819060640160408051601f198184030181529181526020820180516001600160e01b0316638639415b60e01b1790525190915060009081906001600160a01b038616906116869085906131a6565b600060405180830381855afa9150503d80600081146116c1576040519150601f19603f3d011682016040523d82523d6000602084013e6116c6565b606091505b5091509150816116e85760405162461bcd60e51b81526004016106bf906131c2565b805160c08190036116ff5750600095945050505050565b80610100036117145750600195945050505050565b60405162461bcd60e51b815260206004820152601e60248201527f556e657870656374656420726576656e75652073706c6974206279746573000060448201526064016106bf565b80546000908190600160e81b900462ffffff16806117c65760405162461bcd60e51b815260206004820152602160248201527f4e6f20707572636861736573206d6164652062792074686973206164647265736044820152607360f81b60648201526084016106bf565b8454600160201b90046001600160801b03166117e28183613207565b85549093506117fb9084906001600160e81b031661321e565b935050505b9250929050565b60006001600160e81b038211156118705760405162461bcd60e51b815260206004820152602760248201527f53616665436173743a2076616c756520646f65736e27742066697420696e20326044820152663332206269747360c81b60648201526084016106bf565b5090565b815460009060ff16806118885750835460ff165b156118a557508254600160201b90046001600160801b031661065b565b6118ae8261237c565b949350505050565b815460009081906118da906118d59034906001600160e81b0316613193565b611807565b84549092506118f690600160e81b900462ffffff166001613231565b90506119078362ffffff8316613207565b826001600160e81b031610156119585760405162461bcd60e51b815260206004820152601660248201527526b4b7103b30b63ab2903a379036b4b73a103932b89760511b60448201526064016106bf565b62ffffff8116600160e81b026001600160e81b03831617909355929050565b60006001600160801b038211156118705760405162461bcd60e51b815260206004820152602760248201527f53616665436173743a2076616c756520646f65736e27742066697420696e20316044820152663238206269747360c81b60648201526084016106bf565b8054620f4240830660010190610100900462ffffff1680821115611a165760405162461bcd60e51b81526004016106bf906130c4565b808203610bd557825460ff1916600117835550505050565b8054600090610100900460ff1615611a4b5750805460ff16610697565b6000611a5784846124b7565b91506106979050565b3415610bd557600080611a73853461321e565b90508015611b035760405133908290600081818185875af1925050503d8060008114611abb576040519150601f19603f3d011682016040523d82523d6000602084013e611ac0565b606091505b50508092505081611b035760405162461bcd60e51b815260206004820152600d60248201526c1499599d5b990819985a5b1959609a1b60448201526064016106bf565b611b0f868686866125c7565b505050505050565b611b2384848484612992565b610bd55760405162461bcd60e51b815260206004820152601a60248201527913db9b1e4810dbdc994810591b5a5b9050d308185b1b1bddd95960321b60448201526064016106bf565b825460009060ff1615611b915760405162461bcd60e51b81526004016106bf90613146565b611b9c8787856122ea565b8254909150600160a81b90046001600160581b03166001600160801b0386161015611bff5760405162461bcd60e51b81526020600482015260136024820152724f6e6c7920677465206261736520707269636560681b60448201526064016106bf565b825460ff16611c4b5760405162461bcd60e51b815260206004820152601860248201527741756374696f6e206d75737420626520636f6d706c65746560401b60448201526064016106bf565b83546001600160801b03600160201b909104811690861610611caf5760405162461bcd60e51b815260206004820152601d60248201527f4d6179206f6e6c79207265647563652073656c6c6f757420707269636500000060448201526064016106bf565b6000856001600160801b031611611d025760405162461bcd60e51b815260206004820152601760248201527604f6e6c792073656c6c6f757420707269636573203e203604c1b60448201526064016106bf565b83546001600160801b03909516600160201b02600160201b600160a01b03199095169490941790925550909392505050565b611d3f858585612a1a565b80611d515750611d5184848484612992565b611d9d5760405162461bcd60e51b815260206004820152601d60248201527f4f6e6c7920417274697374206f7220436f72652041646d696e2041434c00000060448201526064016106bf565b5050505050565b8354600090819060ff1615611df85760405162461bcd60e51b815260206004820152601a60248201527914995d995b9d595cc8185b1c9958591e4818dbdb1b1958dd195960321b60448201526064016106bf565b611e038888876122ea565b91506000611e12878787611874565b8554909150600160a81b90046001600160581b03168114611e8357855460ff16611e7e5760405162461bcd60e51b815260206004820152601f60248201527f4163746976652061756374696f6e206e6f742079657420736f6c64206f75740060448201526064016106bf565b611f0b565b8454600160a81b90046001600160581b031680611ee15760405162461bcd60e51b815260206004820152601c60248201527b04f6e6c79206c617465737450757263686173655072696365203e20360241b60448201526064016106bf565b87546001600160801b03909116600160201b02600160201b600160a01b0319909116178755600191505b865460ff1916600117808855600090611f3090839062ffffff61010090910416613207565b9050611f3e8a828b886125c7565b5050965096945050505050565b611f56838383612a1a565b611f905760405162461bcd60e51b815260206004820152600b60248201526a13db9b1e48105c9d1a5cdd60aa1b60448201526064016106bf565b505050565b600080611fa28686612aa3565b91509150808462ffffff161115611fcb5760405162461bcd60e51b81526004016106bf9061326a565b818462ffffff161015611ff05760405162461bcd60e51b81526004016106bf9061326a565b50815460ff1962ffffff90941661010081029490941663ffffffff199091161792149190911790555050565b61202884848484612992565b610bd55760405162461bcd60e51b815260206004820152601a60248201527913db9b1e48135a5b9d195c919a5b1d195c8810591b5a5b9050d360321b60448201526064016106bf565b600061207e868685612b21565b1561209b57508254600160201b90046001600160801b03166120a9565b6120a6848484611874565b90505b95945050505050565b8054600090600160201b90046001600160801b0316158061065b57505054600160201b90046001600160801b0316101590565b60006001600160581b038211156118705760405162461bcd60e51b815260206004820152602660248201527f53616665436173743a2076616c756520646f65736e27742066697420696e203860448201526538206269747360d01b60648201526084016106bf565b855464ffffffffff1615806121695750855464ffffffffff1642105b806121715750805b6121bc5760405162461bcd60e51b815260206004820152601c60248201527b27379036b7b234b334b1b0ba34b7b7399036b4b216b0bab1ba34b7b760211b60448201526064016106bf565b8464ffffffffff1642106122095760405162461bcd60e51b81526020600482015260146024820152734f6e6c79206675747572652061756374696f6e7360601b60448201526064016106bf565b816001600160581b0316836001600160581b03161161228d5760405162461bcd60e51b815260206004820152603a60248201527f41756374696f6e207374617274207072696365206d7573742062652067726561604482015279746572207468616e2061756374696f6e20656e6420707269636560301b60648201526084016106bf565b50845464ffffffffff9485166001600160501b031990911617600160281b9390941692909202929092176001600160501b0316600160501b6001600160581b03938416026001600160a81b031617600160a81b9190921602179055565b60006122f582612b5f565b1561230f57612305848484612b7f565b506001905061065b565b60008061231c8686612aa3565b8554909350909150610100900462ffffff168281111561235f57845460ff1962ffffff8516610100021663ffffffff199091161782841417855560019350612372565b80821061237257845460ff191660011785555b5050509392505050565b805460009064ffffffffff80821691600160281b810490911690600160a81b90046001600160581b03164283106123ef5760405162461bcd60e51b8152602060048201526017602482015276105d58dd1a5bdb881b9bdd081e595d081cdd185c9d1959604a1b60448201526064016106bf565b6000821161243a5760405162461bcd60e51b81526020600482015260186024820152774f6e6c7920636f6e666967757265642061756374696f6e7360401b60448201526064016106bf565b8454600160501b90046001600160581b03164284900383818161245f5761245f613254565b0482901c915060028485838161247757612477613254565b0684028161248757612487613254565b048161249557612495613254565b0482039150828210156124ad57509095945050505050565b5095945050505050565b6040516000602482018190526044820181905290819060640160408051601f198184030181529181526020820180516001600160e01b0316638639415b60e01b1790525190915060009081906001600160a01b038716906125199085906131a6565b6000604051808303816000865af19150503d8060008114612556576040519150601f19603f3d011682016040523d82523d6000602084013e61255b565b606091505b50915091508161257d5760405162461bcd60e51b81526004016106bf906131c2565b805160c08190036125a3575050835461ffff191661010017845550600091506106979050565b8061010003611714575050835461ffff191661010117845550600191506106979050565b8215610bd5576000806000806000806000871561271857604051638639415b60e01b8152600481018c9052602481018b905260009081906001600160a01b038c1690638639415b9060440161010060405180830381865afa158015612630573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612654919061329b565b969e50949c50909a50985091965091945090925090508115612711576040516001600160a01b038216908390600081818185875af1925050503d80600081146126b9576040519150601f19603f3d011682016040523d82523d6000602084013e6126be565b606091505b505080995050886127115760405162461bcd60e51b815260206004820181905260248201527f506c6174666f726d2050726f7669646572207061796d656e74206661696c656460448201526064016106bf565b5050612798565b604051638639415b60e01b8152600481018c9052602481018b90526001600160a01b038a1690638639415b9060440160c060405180830381865afa158015612764573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906127889190613323565b949a509298509096509450925090505b851561283f576040516001600160a01b038616908790600081818185875af1925050503d80600081146127e7576040519150601f19603f3d011682016040523d82523d6000602084013e6127ec565b606091505b5050809750508661283f5760405162461bcd60e51b815260206004820152601e60248201527f52656e6465722050726f7669646572207061796d656e74206661696c6564000060448201526064016106bf565b83156128de576040516001600160a01b038416908590600081818185875af1925050503d806000811461288e576040519150601f19603f3d011682016040523d82523d6000602084013e612893565b606091505b505080975050866128de5760405162461bcd60e51b8152602060048201526015602482015274105c9d1a5cdd081c185e5b595b9d0819985a5b1959605a1b60448201526064016106bf565b8115612985576040516001600160a01b038216908390600081818185875af1925050503d806000811461292d576040519150601f19603f3d011682016040523d82523d6000602084013e612932565b606091505b505080975050866129855760405162461bcd60e51b815260206004820152601f60248201527f4164646974696f6e616c205061796565207061796d656e74206661696c65640060448201526064016106bf565b5050505050505050505050565b60405163230448b160e01b81526001600160a01b03848116600483015283811660248301526001600160e01b0319831660448301526000919086169063230448b1906064016020604051808303816000875af11580156129f6573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906120a9919061339c565b60405163a47d29cb60e01b8152600481018490526000906001600160a01b0384169063a47d29cb90602401602060405180830381865afa158015612a62573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612a8691906133b7565b6001600160a01b0316826001600160a01b03161490509392505050565b604051630ea5613f60e01b81526004810183905260009081906001600160a01b03841690630ea5613f9060240160c060405180830381865afa158015612aed573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612b1191906133d4565b5093989297509195505050505050565b6000806000612b308686612aa3565b85549193509150610100900462ffffff1681811115612b52575014905061065b565b9091101595945050505050565b8054600090610100900462ffffff161580156106975750505460ff161590565b6000806000846001600160a01b0316630ea5613f876040518263ffffffff1660e01b8152600401612bb291815260200190565b60c060405180830381865afa158015612bcf573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612bf391906133d4565b5050875493831463ffffffff1990941661010062ffffff85160260ff19161793909317909655979650505050505050565b6001600160a01b0381168114612c3957600080fd5b50565b600060208284031215612c4e57600080fd5b813561065b81612c24565b60008060408385031215612c6c57600080fd5b823591506020830135612c7e81612c24565b809150509250929050565b600080600060608486031215612c9e57600080fd5b8335612ca981612c24565b9250602084013591506040840135612cc081612c24565b809150509250925092565b600080600060608486031215612ce057600080fd5b833592506020840135612cf281612c24565b915060408401356001600160801b0381168114612cc057600080fd5b60008083601f840112612d2057600080fd5b5081356001600160401b03811115612d3757600080fd5b6020830191508360208260051b850101111561180057600080fd5b60008060008060408587031215612d6857600080fd5b84356001600160401b0380821115612d7f57600080fd5b612d8b88838901612d0e565b90965094506020870135915080821115612da457600080fd5b50612db187828801612d0e565b95989497509550505050565b600080600060608486031215612dd257600080fd5b833592506020840135612de481612c24565b9150604084013562ffffff81168114612cc057600080fd5b600060208284031215612e0e57600080fd5b5035919050565b600080600080600060608688031215612e2d57600080fd5b8535612e3881612c24565b945060208601356001600160401b0380821115612e5457600080fd5b612e6089838a01612d0e565b90965094506040880135915080821115612e7957600080fd5b50612e8688828901612d0e565b969995985093965092949392505050565b60005b83811015612eb2578181015183820152602001612e9a565b50506000910152565b60008151808452612ed3816020860160208601612e97565b601f01601f19169290920160200192915050565b60208152600061065b6020830184612ebb565b8415158152836020820152608060408201526000612f1b6080830185612ebb565b905060018060a01b038316606083015295945050505050565b803564ffffffffff81168114612f4957600080fd5b919050565b60008060008060008060c08789031215612f6757600080fd5b863595506020870135612f7981612c24565b9450612f8760408801612f34565b9350612f9560608801612f34565b92506080870135915060a087013590509295509295509295565b600080600060608486031215612fc457600080fd5b833592506020840135612fd681612c24565b91506040840135612cc081612c24565b64ffffffffff94851681529290931660208301526040820152606081019190915260800190565b6020808252601f908201527f5265656e7472616e637947756172643a207265656e7472616e742063616c6c00604082015260600190565b6020808252601f908201527f4e6f20636c61696d696e6720746f20746865207a65726f206164647265737300604082015260600190565b62ffffff9290921682526001600160e81b0316602082015260400190565b602080825260119082015270149958db185a5b5a5b99c819985a5b1959607a1b604082015260600190565b60208082526017908201527613585e081a5b9d9bd8d85d1a5bdb9cc81c995858da1959604a1b604082015260600190565b60006020828403121561310757600080fd5b5051919050565b634e487b7160e01b600052601160045260246000fd5b600062ffffff80831681810361313c5761313c61310e565b6001019392505050565b6020808252601e908201527f4f6e6c79206265666f726520726576656e75657320636f6c6c65637465640000604082015260600190565b634e487b7160e01b600052603260045260246000fd5b808201808211156106975761069761310e565b600082516131b8818460208701612e97565b9190910192915050565b60208082526025908201527f6765745072696d617279526576656e756553706c69747328292063616c6c2066604082015264185a5b195960da1b606082015260800190565b80820281158282048414176106975761069761310e565b818103818111156106975761069761310e565b62ffffff81811683821601908082111561324d5761324d61310e565b5092915050565b634e487b7160e01b600052601260045260246000fd5b602080825260179082015276496e76616c6964206d617820696e766f636174696f6e7360481b604082015260600190565b600080600080600080600080610100898b0312156132b857600080fd5b8851975060208901516132ca81612c24565b60408a015160608b015191985096506132e281612c24565b60808a015160a08b015191965094506132fa81612c24565b60c08a015160e08b0151919450925061331281612c24565b809150509295985092959890939650565b60008060008060008060c0878903121561333c57600080fd5b86519550602087015161334e81612c24565b60408801516060890151919650945061336681612c24565b608088015160a0890151919450925061337e81612c24565b809150509295509295509295565b80518015158114612f4957600080fd5b6000602082840312156133ae57600080fd5b61065b8261338c565b6000602082840312156133c957600080fd5b815161065b81612c24565b60008060008060008060c087890312156133ed57600080fd5b86519550602087015194506134046040880161338c565b93506134126060880161338c565b92506080870151915061342760a0880161338c565b9050929550929550929556fe1c3e74a6c6fefbaeee166b031cd2016349c6c863d5188b67c9bbd0b0dcb2e2373e587139a5e04472b0e74a6be0594ff90a9f1364a13fdc1897ad5bd3ab9ea5a6a26469706673582212207f3d79be72327ae09b9c06980e8b99087a857089fbe3510bf9938ee5886f575864736f6c63430008130033",
+  "deployedBytecode": "0x6080604052600436106101315760003560e01c806301000da7146101365780632b001e6c1461016b5780633c22f1d0146101995780634869f3df146101bb5780634e8d8787146102055780635418789c1461021857806367e6aad9146102385780636a9f62fc146102585780638fe8a90b146102a257806395c575fa146102c25780639a94488a146102e2578063ae77c2371461037a578063b000e3341461038d578063b3fe4723146103ad578063c0244587146103cd578063cce7c909146103ed578063cf6681ea1461040d578063d3ddabe614610423578063d9bffbce14610462578063d9eb16db14610482578063dd85582f146104b2578063e8af2b3b146104fe578063e9d1e8ac1461051e578063fdca4cb814610561578063fe676d2614610581578063fea1d7b4146105a1575b600080fd5b34801561014257600080fd5b50610156610151366004612c3c565b610621565b60405190151581526020015b60405180910390f35b34801561017757600080fd5b5061018b610186366004612c59565b610662565b604051908152602001610162565b3480156101a557600080fd5b506101b96101b4366004612c89565b61069d565b005b3480156101c757600080fd5b5061018b6101d6366004612c59565b6001600160a01b031660009081526006602090815260408083209383529290522054610100900462ffffff1690565b61018b610213366004612c89565b610831565b34801561022457600080fd5b506101b9610233366004612ccb565b610aac565b34801561024457600080fd5b506101b9610253366004612d52565b610bc8565b34801561026457600080fd5b5061018b610273366004612c59565b6001600160a01b031660009081526003602090815260408083209383529290522054610100900462ffffff1690565b3480156102ae57600080fd5b506101b96102bd366004612c59565b610bdb565b3480156102ce57600080fd5b506101b96102dd366004612c59565b610db6565b3480156102ee57600080fd5b506103586102fd366004612c59565b6040805180820190915260008082526020820152506001600160a01b031660009081526006602090815260408083209383529281529082902082518084019093525460ff811615158352610100900462ffffff169082015290565b6040805182511515815260209283015162ffffff169281019290925201610162565b61018b610388366004612c59565b610e60565b34801561039957600080fd5b506101b96103a8366004612dbd565b610e6d565b3480156103b957600080fd5b506101b96103c8366004612dfc565b610ee2565b3480156103d957600080fd5b506101b96103e8366004612e15565b610fa0565b3480156103f957600080fd5b50610156610408366004612c59565b6111e6565b34801561041957600080fd5b5061018b60015481565b34801561042f57600080fd5b5061045560405180604001604052806006815260200165076332e302e360d41b81525081565b6040516101629190612ee7565b34801561046e57600080fd5b506101b961047d366004612c59565b611212565b34801561048e57600080fd5b506104a261049d366004612c59565b611257565b6040516101629493929190612efa565b3480156104be57600080fd5b506104e67f000000000000000000000000000000000000000000000000000000000000000081565b6040516001600160a01b039091168152602001610162565b34801561050a57600080fd5b506101b9610519366004612c59565b61132f565b34801561052a57600080fd5b50610455604051806040016040528060178152602001764d696e7465724441457870536574746c656d656e74563360481b81525081565b34801561056d57600080fd5b506101b961057c366004612f4e565b61133e565b34801561058d57600080fd5b5061018b61059c366004612faf565b611586565b3480156105ad57600080fd5b506106116105bc366004612c59565b6001600160a01b03166000908152600560209081526040808320938352929052205464ffffffffff80821692600160281b8304909116916001600160581b03600160501b8204811692600160a81b9092041690565b6040516101629493929190612fe6565b6001600160a01b03811660009081526002602052604081208054610100900460ff1615610652575460ff1692915050565b61065b83611624565b9392505050565b6001600160a01b0381166000908152600360209081526040808320858452909152902054600160201b90046001600160801b03165b92915050565b6002600054036106c85760405162461bcd60e51b81526004016106bf9061300d565b60405180910390fd5b60026000556001600160a01b0383166106f35760405162461bcd60e51b81526004016106bf90613044565b6001600160a01b03811660008181526003602090815260408083208684528252808320338452600483528184209484529382528083208684529091528120908061073d848461175c565b91509150600061074c82611807565b84546001600160e81b0319166001600160e81b038216178086556040519192506001600160a01b0388169189913391600080516020613454833981519152916107a491600160e81b90910462ffffff1690879061307b565b60405180910390a46000886001600160a01b03168460405160006040518083038185875af1925050503d80600081146107f9576040519150601f19603f3d011682016040523d82523d6000602084013e6107fe565b606091505b505080915050806108215760405162461bcd60e51b81526004016106bf90613099565b5050600160005550505050505050565b60006002600054036108555760405162461bcd60e51b81526004016106bf9061300d565b600260009081556001600160a01b038316808252600360209081526040808420878552825280842083855260068352818520888652835281852093855260058352818520888652909252909220815460ff16156108c45760405162461bcd60e51b81526004016106bf906130c4565b60006108d1848484611874565b3360009081526004602090815260408083206001600160a01b038b16845282528083208b845290915281209192508061090a83856118b6565b91509150886001600160a01b03168a336001600160a01b0316600080516020613454833981519152848660405161094292919061307b565b60405180910390a461095384611977565b87546001600160801b0391909116600160201b02600160201b600160a01b03199091161787556040516117cd60e21b81526001600160a01b038c81166004830152602482018c90528a811660448301523360648301527f00000000000000000000000000000000000000000000000000000000000000001690615f34906084016020604051808303816000875af11580156109f2573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a1691906130f5565b9750610a2288876119e0565b865460ff1615610a63576001600160a01b0389166000908152600260205260408120610a4f908b90611a2e565b9050610a5d8b868c84611a60565b50610a99565b8654610100900462ffffff16876001610a7b83613124565b91906101000a81548162ffffff021916908362ffffff160217905550505b5050505050505060016000559392505050565b610abf8233306315061e2760e21b611b17565b6001600160a01b03821660008181526003602090815260408083208784528252808320848452600683528184208885528352818420948452600583528184208885529092528220909291610b17878787878787611b6c565b604080517263757272656e74536574746c6564507269636560681b81526001600160801b03881660208201529192506001600160a01b0388169189917f1809fd1f08e6b0df08fd848757688435a0ab8520a51dcca23eba5a3c7f7280d6910160405180910390a38015610bbf57825460405161010090910462ffffff1681526001600160a01b0387169088906000805160206134348339815191529060200160405180910390a35b50505050505050565b610bd53385858585610fa0565b50505050565b600260005403610bfd5760405162461bcd60e51b81526004016106bf9061300d565b6002600055610c16828233306315061e2760e21b611d34565b6001600160a01b0381166000818152600360209081526040808320868452825280832084845260068352818420878552835281842085855260058452828520888652845282852095855260029093529083209093919290610c78908690611a2e565b9050600080610c8b888888888888611da4565b6040805177185d58dd1a5bdb94995d995b9d595cd0dbdb1b1958dd195960421b8152600160208201529294509092506001600160a01b038916918a917fbb5f9d4f49f83650956b76c40de0f082a06430bf0222e1b6b3f90a7a0f845c4d910160405180910390a38015610d66578554604080517263757272656e74536574746c6564507269636560681b8152600160201b9092046001600160801b031660208301526001600160a01b038916918a917f1809fd1f08e6b0df08fd848757688435a0ab8520a51dcca23eba5a3c7f7280d6910160405180910390a35b8115610da757845460405161010090910462ffffff1681526001600160a01b0388169089906000805160206134348339815191529060200160405180910390a35b50506001600055505050505050565b610dc9813330634ae2bafd60e11b611b17565b6001600160a01b03811660009081526003602090815260408083208584529091529020805460ff1615610e0e5760405162461bcd60e51b81526004016106bf90613146565b6001600160a01b03821660008181526005602090815260408083208784529091528082208290555185917f865169678476a498ca03f184818d6bd6217dd57b754577a944c19d6d75587c8091a3505050565b600061065b338484610831565b610e78838333611f4b565b6001600160a01b03821660009081526006602090815260408083208684529091529020610eaa90849084908490611f95565b60405162ffffff821681526001600160a01b0383169084906000805160206134348339815191529060200160405180910390a3505050565b610f157f0000000000000000000000000000000000000000000000000000000000000000333063b3fe472360e01b61201c565b60008111610f655760405162461bcd60e51b815260206004820152601d60248201527f48616c66206c696665206f66207a65726f206e6f7420616c6c6f77656400000060448201526064016106bf565b60018190556040518181527fdae7136b6b1f9f3031d9536e8bdd02f1d223eb793054446ff278143abeafa21b9060200160405180910390a150565b600260005403610fc25760405162461bcd60e51b81526004016106bf9061300d565b60026000556001600160a01b038516610fed5760405162461bcd60e51b81526004016106bf90613044565b828181146110385760405162461bcd60e51b8152602060048201526018602482015277082e4e4c2f240d8cadccee8d0e640daeae6e840dac2e8c6d60431b60448201526064016106bf565b6000805b828110156111705760008787838181106110585761105861317d565b90506020020135905060008686848181106110755761107561317d565b905060200201602081019061108a9190612c3c565b6001600160a01b03811660008181526003602090815260408083208784528252808320338452600483528184209484529382528083208784529091528120929350909190806110d9848461175c565b9150915060006110e882611807565b84546001600160e81b0319166001600160e81b038216178555905061110d838a613193565b9850856001600160a01b031687336001600160a01b031660008051602061345483398151915287600001601d9054906101000a900462ffffff168560405161115692919061307b565b60405180910390a48760010197505050505050505061103c565b506000876001600160a01b03168260405160006040518083038185875af1925050503d80600081146111be576040519150601f19603f3d011682016040523d82523d6000602084013e6111c3565b606091505b50508091505080610da75760405162461bcd60e51b81526004016106bf90613099565b6001600160a01b038116600090815260066020908152604080832085845290915281205460ff1661065b565b61121d828233611f4b565b60405162461bcd60e51b815260206004820152600f60248201526e139bdd081a5b5c1b195b595b9d1959608a1b60448201526064016106bf565b6001600160a01b038116600081815260036020908152604080832086845282528083208484526006835281842087855283528184209484526005835281842087855290925282208054600160501b90046001600160581b03161515936060928492909190866112c95760009550611301565b805464ffffffffff1642116112f1578054600160501b90046001600160581b03169550611301565b6112fe8989858585612071565b95505b6040518060400160405280600381526020016208aa8960eb1b81525094506000935050505092959194509250565b61133a33838361069d565b5050565b611349868633611f4b565b6001600160a01b03851660008181526005602090815260408083208a84528252808320938352600382528083208a8452909152902061138884826120b2565b6113d45760405162461bcd60e51b815260206004820152601f60248201527f4f6e6c79206d6f6e6f746f6e69632064656372656173696e672070726963650060448201526064016106bf565b600083116114225760405162461bcd60e51b815260206004820152601b60248201527a42617365207072696365206d757374206265206e6f6e2d7a65726f60281b60448201526064016106bf565b6001548564ffffffffff1610156114a15760405162461bcd60e51b815260206004820152603e60248201527f50726963652064656361792068616c66206c696665206d75737420626520677260448201527f6561746572207468616e206d696e20616c6c6f7761626c652076616c7565000060648201526084016106bf565b6114c08287876114b0886120e5565b6114b9886120e5565b600061214d565b866001600160a01b0316887f7fbd78481800c1705ba89e4be2e8c979412fb121f7f3cbace9d7f5c3dd85c44e888888886040516115009493929190612fe6565b60405180910390a36001600160a01b03871660009081526006602090815260408083208b84529091528120906115378a8a846122ea565b9050801561157a57815460405161010090910462ffffff1681526001600160a01b038a16908b906000805160206134348339815191529060200160405180910390a35b50505050505050505050565b60006001600160a01b0382166115d05760405162461bcd60e51b815260206004820152600f60248201526e4e6f207a65726f206164647265737360881b60448201526064016106bf565b6001600160a01b0380841660008181526003602090815260408083208984528252808320948716835260048252808320938352928152828220888352905220611619828261175c565b509695505050505050565b6040516000602482018190526044820181905290819060640160408051601f198184030181529181526020820180516001600160e01b0316638639415b60e01b1790525190915060009081906001600160a01b038616906116869085906131a6565b600060405180830381855afa9150503d80600081146116c1576040519150601f19603f3d011682016040523d82523d6000602084013e6116c6565b606091505b5091509150816116e85760405162461bcd60e51b81526004016106bf906131c2565b805160c08190036116ff5750600095945050505050565b80610100036117145750600195945050505050565b60405162461bcd60e51b815260206004820152601e60248201527f556e657870656374656420726576656e75652073706c6974206279746573000060448201526064016106bf565b80546000908190600160e81b900462ffffff16806117c65760405162461bcd60e51b815260206004820152602160248201527f4e6f20707572636861736573206d6164652062792074686973206164647265736044820152607360f81b60648201526084016106bf565b8454600160201b90046001600160801b03166117e28183613207565b85549093506117fb9084906001600160e81b031661321e565b935050505b9250929050565b60006001600160e81b038211156118705760405162461bcd60e51b815260206004820152602760248201527f53616665436173743a2076616c756520646f65736e27742066697420696e20326044820152663332206269747360c81b60648201526084016106bf565b5090565b815460009060ff16806118885750835460ff165b156118a557508254600160201b90046001600160801b031661065b565b6118ae8261237c565b949350505050565b815460009081906118da906118d59034906001600160e81b0316613193565b611807565b84549092506118f690600160e81b900462ffffff166001613231565b90506119078362ffffff8316613207565b826001600160e81b031610156119585760405162461bcd60e51b815260206004820152601660248201527526b4b7103b30b63ab2903a379036b4b73a103932b89760511b60448201526064016106bf565b62ffffff8116600160e81b026001600160e81b03831617909355929050565b60006001600160801b038211156118705760405162461bcd60e51b815260206004820152602760248201527f53616665436173743a2076616c756520646f65736e27742066697420696e20316044820152663238206269747360c81b60648201526084016106bf565b8054620f4240830660010190610100900462ffffff1680821115611a165760405162461bcd60e51b81526004016106bf906130c4565b808203610bd557825460ff1916600117835550505050565b8054600090610100900460ff1615611a4b5750805460ff16610697565b6000611a5784846124b7565b91506106979050565b3415610bd557600080611a73853461321e565b90508015611b035760405133908290600081818185875af1925050503d8060008114611abb576040519150601f19603f3d011682016040523d82523d6000602084013e611ac0565b606091505b50508092505081611b035760405162461bcd60e51b815260206004820152600d60248201526c1499599d5b990819985a5b1959609a1b60448201526064016106bf565b611b0f868686866125c7565b505050505050565b611b2384848484612992565b610bd55760405162461bcd60e51b815260206004820152601a60248201527913db9b1e4810dbdc994810591b5a5b9050d308185b1b1bddd95960321b60448201526064016106bf565b825460009060ff1615611b915760405162461bcd60e51b81526004016106bf90613146565b611b9c8787856122ea565b8254909150600160a81b90046001600160581b03166001600160801b0386161015611bff5760405162461bcd60e51b81526020600482015260136024820152724f6e6c7920677465206261736520707269636560681b60448201526064016106bf565b825460ff16611c4b5760405162461bcd60e51b815260206004820152601860248201527741756374696f6e206d75737420626520636f6d706c65746560401b60448201526064016106bf565b83546001600160801b03600160201b909104811690861610611caf5760405162461bcd60e51b815260206004820152601d60248201527f4d6179206f6e6c79207265647563652073656c6c6f757420707269636500000060448201526064016106bf565b6000856001600160801b031611611d025760405162461bcd60e51b815260206004820152601760248201527604f6e6c792073656c6c6f757420707269636573203e203604c1b60448201526064016106bf565b83546001600160801b03909516600160201b02600160201b600160a01b03199095169490941790925550909392505050565b611d3f858585612a1a565b80611d515750611d5184848484612992565b611d9d5760405162461bcd60e51b815260206004820152601d60248201527f4f6e6c7920417274697374206f7220436f72652041646d696e2041434c00000060448201526064016106bf565b5050505050565b8354600090819060ff1615611df85760405162461bcd60e51b815260206004820152601a60248201527914995d995b9d595cc8185b1c9958591e4818dbdb1b1958dd195960321b60448201526064016106bf565b611e038888876122ea565b91506000611e12878787611874565b8554909150600160a81b90046001600160581b03168114611e8357855460ff16611e7e5760405162461bcd60e51b815260206004820152601f60248201527f4163746976652061756374696f6e206e6f742079657420736f6c64206f75740060448201526064016106bf565b611f0b565b8454600160a81b90046001600160581b031680611ee15760405162461bcd60e51b815260206004820152601c60248201527b04f6e6c79206c617465737450757263686173655072696365203e20360241b60448201526064016106bf565b87546001600160801b03909116600160201b02600160201b600160a01b0319909116178755600191505b865460ff1916600117808855600090611f3090839062ffffff61010090910416613207565b9050611f3e8a828b886125c7565b5050965096945050505050565b611f56838383612a1a565b611f905760405162461bcd60e51b815260206004820152600b60248201526a13db9b1e48105c9d1a5cdd60aa1b60448201526064016106bf565b505050565b600080611fa28686612aa3565b91509150808462ffffff161115611fcb5760405162461bcd60e51b81526004016106bf9061326a565b818462ffffff161015611ff05760405162461bcd60e51b81526004016106bf9061326a565b50815460ff1962ffffff90941661010081029490941663ffffffff199091161792149190911790555050565b61202884848484612992565b610bd55760405162461bcd60e51b815260206004820152601a60248201527913db9b1e48135a5b9d195c919a5b1d195c8810591b5a5b9050d360321b60448201526064016106bf565b600061207e868685612b21565b1561209b57508254600160201b90046001600160801b03166120a9565b6120a6848484611874565b90505b95945050505050565b8054600090600160201b90046001600160801b0316158061065b57505054600160201b90046001600160801b0316101590565b60006001600160581b038211156118705760405162461bcd60e51b815260206004820152602660248201527f53616665436173743a2076616c756520646f65736e27742066697420696e203860448201526538206269747360d01b60648201526084016106bf565b855464ffffffffff1615806121695750855464ffffffffff1642105b806121715750805b6121bc5760405162461bcd60e51b815260206004820152601c60248201527b27379036b7b234b334b1b0ba34b7b7399036b4b216b0bab1ba34b7b760211b60448201526064016106bf565b8464ffffffffff1642106122095760405162461bcd60e51b81526020600482015260146024820152734f6e6c79206675747572652061756374696f6e7360601b60448201526064016106bf565b816001600160581b0316836001600160581b03161161228d5760405162461bcd60e51b815260206004820152603a60248201527f41756374696f6e207374617274207072696365206d7573742062652067726561604482015279746572207468616e2061756374696f6e20656e6420707269636560301b60648201526084016106bf565b50845464ffffffffff9485166001600160501b031990911617600160281b9390941692909202929092176001600160501b0316600160501b6001600160581b03938416026001600160a81b031617600160a81b9190921602179055565b60006122f582612b5f565b1561230f57612305848484612b7f565b506001905061065b565b60008061231c8686612aa3565b8554909350909150610100900462ffffff168281111561235f57845460ff1962ffffff8516610100021663ffffffff199091161782841417855560019350612372565b80821061237257845460ff191660011785555b5050509392505050565b805460009064ffffffffff80821691600160281b810490911690600160a81b90046001600160581b03164283106123ef5760405162461bcd60e51b8152602060048201526017602482015276105d58dd1a5bdb881b9bdd081e595d081cdd185c9d1959604a1b60448201526064016106bf565b6000821161243a5760405162461bcd60e51b81526020600482015260186024820152774f6e6c7920636f6e666967757265642061756374696f6e7360401b60448201526064016106bf565b8454600160501b90046001600160581b03164284900383818161245f5761245f613254565b0482901c915060028485838161247757612477613254565b0684028161248757612487613254565b048161249557612495613254565b0482039150828210156124ad57509095945050505050565b5095945050505050565b6040516000602482018190526044820181905290819060640160408051601f198184030181529181526020820180516001600160e01b0316638639415b60e01b1790525190915060009081906001600160a01b038716906125199085906131a6565b6000604051808303816000865af19150503d8060008114612556576040519150601f19603f3d011682016040523d82523d6000602084013e61255b565b606091505b50915091508161257d5760405162461bcd60e51b81526004016106bf906131c2565b805160c08190036125a3575050835461ffff191661010017845550600091506106979050565b8061010003611714575050835461ffff191661010117845550600191506106979050565b8215610bd5576000806000806000806000871561271857604051638639415b60e01b8152600481018c9052602481018b905260009081906001600160a01b038c1690638639415b9060440161010060405180830381865afa158015612630573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612654919061329b565b969e50949c50909a50985091965091945090925090508115612711576040516001600160a01b038216908390600081818185875af1925050503d80600081146126b9576040519150601f19603f3d011682016040523d82523d6000602084013e6126be565b606091505b505080995050886127115760405162461bcd60e51b815260206004820181905260248201527f506c6174666f726d2050726f7669646572207061796d656e74206661696c656460448201526064016106bf565b5050612798565b604051638639415b60e01b8152600481018c9052602481018b90526001600160a01b038a1690638639415b9060440160c060405180830381865afa158015612764573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906127889190613323565b949a509298509096509450925090505b851561283f576040516001600160a01b038616908790600081818185875af1925050503d80600081146127e7576040519150601f19603f3d011682016040523d82523d6000602084013e6127ec565b606091505b5050809750508661283f5760405162461bcd60e51b815260206004820152601e60248201527f52656e6465722050726f7669646572207061796d656e74206661696c6564000060448201526064016106bf565b83156128de576040516001600160a01b038416908590600081818185875af1925050503d806000811461288e576040519150601f19603f3d011682016040523d82523d6000602084013e612893565b606091505b505080975050866128de5760405162461bcd60e51b8152602060048201526015602482015274105c9d1a5cdd081c185e5b595b9d0819985a5b1959605a1b60448201526064016106bf565b8115612985576040516001600160a01b038216908390600081818185875af1925050503d806000811461292d576040519150601f19603f3d011682016040523d82523d6000602084013e612932565b606091505b505080975050866129855760405162461bcd60e51b815260206004820152601f60248201527f4164646974696f6e616c205061796565207061796d656e74206661696c65640060448201526064016106bf565b5050505050505050505050565b60405163230448b160e01b81526001600160a01b03848116600483015283811660248301526001600160e01b0319831660448301526000919086169063230448b1906064016020604051808303816000875af11580156129f6573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906120a9919061339c565b60405163a47d29cb60e01b8152600481018490526000906001600160a01b0384169063a47d29cb90602401602060405180830381865afa158015612a62573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612a8691906133b7565b6001600160a01b0316826001600160a01b03161490509392505050565b604051630ea5613f60e01b81526004810183905260009081906001600160a01b03841690630ea5613f9060240160c060405180830381865afa158015612aed573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612b1191906133d4565b5093989297509195505050505050565b6000806000612b308686612aa3565b85549193509150610100900462ffffff1681811115612b52575014905061065b565b9091101595945050505050565b8054600090610100900462ffffff161580156106975750505460ff161590565b6000806000846001600160a01b0316630ea5613f876040518263ffffffff1660e01b8152600401612bb291815260200190565b60c060405180830381865afa158015612bcf573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612bf391906133d4565b5050875493831463ffffffff1990941661010062ffffff85160260ff19161793909317909655979650505050505050565b6001600160a01b0381168114612c3957600080fd5b50565b600060208284031215612c4e57600080fd5b813561065b81612c24565b60008060408385031215612c6c57600080fd5b823591506020830135612c7e81612c24565b809150509250929050565b600080600060608486031215612c9e57600080fd5b8335612ca981612c24565b9250602084013591506040840135612cc081612c24565b809150509250925092565b600080600060608486031215612ce057600080fd5b833592506020840135612cf281612c24565b915060408401356001600160801b0381168114612cc057600080fd5b60008083601f840112612d2057600080fd5b5081356001600160401b03811115612d3757600080fd5b6020830191508360208260051b850101111561180057600080fd5b60008060008060408587031215612d6857600080fd5b84356001600160401b0380821115612d7f57600080fd5b612d8b88838901612d0e565b90965094506020870135915080821115612da457600080fd5b50612db187828801612d0e565b95989497509550505050565b600080600060608486031215612dd257600080fd5b833592506020840135612de481612c24565b9150604084013562ffffff81168114612cc057600080fd5b600060208284031215612e0e57600080fd5b5035919050565b600080600080600060608688031215612e2d57600080fd5b8535612e3881612c24565b945060208601356001600160401b0380821115612e5457600080fd5b612e6089838a01612d0e565b90965094506040880135915080821115612e7957600080fd5b50612e8688828901612d0e565b969995985093965092949392505050565b60005b83811015612eb2578181015183820152602001612e9a565b50506000910152565b60008151808452612ed3816020860160208601612e97565b601f01601f19169290920160200192915050565b60208152600061065b6020830184612ebb565b8415158152836020820152608060408201526000612f1b6080830185612ebb565b905060018060a01b038316606083015295945050505050565b803564ffffffffff81168114612f4957600080fd5b919050565b60008060008060008060c08789031215612f6757600080fd5b863595506020870135612f7981612c24565b9450612f8760408801612f34565b9350612f9560608801612f34565b92506080870135915060a087013590509295509295509295565b600080600060608486031215612fc457600080fd5b833592506020840135612fd681612c24565b91506040840135612cc081612c24565b64ffffffffff94851681529290931660208301526040820152606081019190915260800190565b6020808252601f908201527f5265656e7472616e637947756172643a207265656e7472616e742063616c6c00604082015260600190565b6020808252601f908201527f4e6f20636c61696d696e6720746f20746865207a65726f206164647265737300604082015260600190565b62ffffff9290921682526001600160e81b0316602082015260400190565b602080825260119082015270149958db185a5b5a5b99c819985a5b1959607a1b604082015260600190565b60208082526017908201527613585e081a5b9d9bd8d85d1a5bdb9cc81c995858da1959604a1b604082015260600190565b60006020828403121561310757600080fd5b5051919050565b634e487b7160e01b600052601160045260246000fd5b600062ffffff80831681810361313c5761313c61310e565b6001019392505050565b6020808252601e908201527f4f6e6c79206265666f726520726576656e75657320636f6c6c65637465640000604082015260600190565b634e487b7160e01b600052603260045260246000fd5b808201808211156106975761069761310e565b600082516131b8818460208701612e97565b9190910192915050565b60208082526025908201527f6765745072696d617279526576656e756553706c69747328292063616c6c2066604082015264185a5b195960da1b606082015260800190565b80820281158282048414176106975761069761310e565b818103818111156106975761069761310e565b62ffffff81811683821601908082111561324d5761324d61310e565b5092915050565b634e487b7160e01b600052601260045260246000fd5b602080825260179082015276496e76616c6964206d617820696e766f636174696f6e7360481b604082015260600190565b600080600080600080600080610100898b0312156132b857600080fd5b8851975060208901516132ca81612c24565b60408a015160608b015191985096506132e281612c24565b60808a015160a08b015191965094506132fa81612c24565b60c08a015160e08b0151919450925061331281612c24565b809150509295985092959890939650565b60008060008060008060c0878903121561333c57600080fd5b86519550602087015161334e81612c24565b60408801516060890151919650945061336681612c24565b608088015160a0890151919450925061337e81612c24565b809150509295509295509295565b80518015158114612f4957600080fd5b6000602082840312156133ae57600080fd5b61065b8261338c565b6000602082840312156133c957600080fd5b815161065b81612c24565b60008060008060008060c087890312156133ed57600080fd5b86519550602087015194506134046040880161338c565b93506134126060880161338c565b92506080870151915061342760a0880161338c565b9050929550929550929556fe1c3e74a6c6fefbaeee166b031cd2016349c6c863d5188b67c9bbd0b0dcb2e2373e587139a5e04472b0e74a6be0594ff90a9f1364a13fdc1897ad5bd3ab9ea5a6a26469706673582212207f3d79be72327ae09b9c06980e8b99087a857089fbe3510bf9938ee5886f575864736f6c63430008130033",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/tests/e2e/seed/supplemental_abis/MinterDAExpSettlementV3.json
+++ b/tests/e2e/seed/supplemental_abis/MinterDAExpSettlementV3.json
@@ -1,0 +1,1146 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "MinterDAExpSettlementV3",
+  "sourceName": "contracts/minter-suite/Minters/MinterDAExpSettlementV3.sol",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_minterFilter",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_minimumPriceDecayHalfLifeSeconds",
+          "type": "uint256"
+        }
+      ],
+      "name": "AuctionMinHalfLifeSecondsUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ConfigKeyRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_value",
+          "type": "uint256"
+        }
+      ],
+      "name": "ConfigValueAddedToSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "_value",
+          "type": "address"
+        }
+      ],
+      "name": "ConfigValueAddedToSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_value",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ConfigValueAddedToSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_value",
+          "type": "uint256"
+        }
+      ],
+      "name": "ConfigValueRemovedFromSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "_value",
+          "type": "address"
+        }
+      ],
+      "name": "ConfigValueRemovedFromSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_value",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ConfigValueRemovedFromSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "_value",
+          "type": "bool"
+        }
+      ],
+      "name": "ConfigValueSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_value",
+          "type": "uint256"
+        }
+      ],
+      "name": "ConfigValueSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "_value",
+          "type": "address"
+        }
+      ],
+      "name": "ConfigValueSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_key",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_value",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ConfigValueSet",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_pricePerTokenInWei",
+          "type": "uint256"
+        }
+      ],
+      "name": "PricePerTokenInWeiUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_currencyAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "_currencySymbol",
+          "type": "string"
+        }
+      ],
+      "name": "ProjectCurrencyInfoUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_maxInvocations",
+          "type": "uint256"
+        }
+      ],
+      "name": "ProjectMaxInvocationsLimitUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_purchaser",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint24",
+          "name": "_numPurchased",
+          "type": "uint24"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_netPosted",
+          "type": "uint256"
+        }
+      ],
+      "name": "ReceiptUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "ResetAuctionDetails",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint40",
+          "name": "_auctionTimestampStart",
+          "type": "uint40"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint40",
+          "name": "_priceDecayHalfLifeSeconds",
+          "type": "uint40"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_startPrice",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_basePrice",
+          "type": "uint256"
+        }
+      ],
+      "name": "SetAuctionDetailsExp",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "internalType": "uint128",
+          "name": "_newSelloutPrice",
+          "type": "uint128"
+        }
+      ],
+      "name": "adminEmergencyReduceSelloutPrice",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "getNumSettleableInvocations",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "numSettleableInvocations",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "getPriceInfo",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "isConfigured",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tokenPriceInWei",
+          "type": "uint256"
+        },
+        {
+          "internalType": "string",
+          "name": "currencySymbol",
+          "type": "string"
+        },
+        {
+          "internalType": "address",
+          "name": "currencyAddress",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_walletAddress",
+          "type": "address"
+        }
+      ],
+      "name": "getProjectExcessSettlementFunds",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "excessSettlementFundsInWei",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "getProjectLatestPurchasePrice",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "latestPurchasePrice",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "isEngineView",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "internalType": "uint24",
+          "name": "_maxInvocations",
+          "type": "uint24"
+        }
+      ],
+      "name": "manuallyLimitProjectMaxInvocations",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "maxInvocationsProjectConfig",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bool",
+              "name": "maxHasBeenInvoked",
+              "type": "bool"
+            },
+            {
+              "internalType": "uint24",
+              "name": "maxInvocations",
+              "type": "uint24"
+            }
+          ],
+          "internalType": "struct MaxInvocationsLib.MaxInvocationsProjectConfig",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "minimumPriceDecayHalfLifeSeconds",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "minterFilterAddress",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "minterType",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "minterVersion",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "projectAuctionParameters",
+      "outputs": [
+        {
+          "internalType": "uint40",
+          "name": "timestampStart",
+          "type": "uint40"
+        },
+        {
+          "internalType": "uint40",
+          "name": "priceDecayHalfLifeSeconds",
+          "type": "uint40"
+        },
+        {
+          "internalType": "uint256",
+          "name": "startPrice",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "basePrice",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "projectMaxHasBeenInvoked",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "projectMaxInvocations",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "purchase",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "purchaseTo",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "reclaimProjectExcessSettlementFunds",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address payable",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "reclaimProjectExcessSettlementFundsTo",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "_projectIds",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "address[]",
+          "name": "_coreContracts",
+          "type": "address[]"
+        }
+      ],
+      "name": "reclaimProjectsExcessSettlementFunds",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address payable",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "_projectIds",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "address[]",
+          "name": "_coreContracts",
+          "type": "address[]"
+        }
+      ],
+      "name": "reclaimProjectsExcessSettlementFundsTo",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "resetAuctionDetails",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        },
+        {
+          "internalType": "uint40",
+          "name": "_auctionTimestampStart",
+          "type": "uint40"
+        },
+        {
+          "internalType": "uint40",
+          "name": "_priceDecayHalfLifeSeconds",
+          "type": "uint40"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_startPrice",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_basePrice",
+          "type": "uint256"
+        }
+      ],
+      "name": "setAuctionDetails",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_minimumPriceDecayHalfLifeSeconds",
+          "type": "uint256"
+        }
+      ],
+      "name": "setMinimumPriceDecayHalfLifeSeconds",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "syncProjectMaxInvocationsToCore",
+      "outputs": [],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_coreContract",
+          "type": "address"
+        }
+      ],
+      "name": "withdrawArtistAndAdminRevenues",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x60c0604052602d6001553480156200001657600080fd5b50604051620035953803806200359583398101604081905262000039916200008d565b600160008190556001600160a01b038216608081905260a052546040519081527fdae7136b6b1f9f3031d9536e8bdd02f1d223eb793054446ff278143abeafa21b9060200160405180910390a150620000bf565b600060208284031215620000a057600080fd5b81516001600160a01b0381168114620000b857600080fd5b9392505050565b60805160a0516134a9620000ec60003960006109ab0152600081816104c40152610ee701526134a96000f3fe6080604052600436106101315760003560e01c806301000da7146101365780632b001e6c1461016b5780633c22f1d0146101995780634869f3df146101bb5780634e8d8787146102055780635418789c1461021857806367e6aad9146102385780636a9f62fc146102585780638fe8a90b146102a257806395c575fa146102c25780639a94488a146102e2578063ae77c2371461037a578063b000e3341461038d578063b3fe4723146103ad578063c0244587146103cd578063cce7c909146103ed578063cf6681ea1461040d578063d3ddabe614610423578063d9bffbce14610462578063d9eb16db14610482578063dd85582f146104b2578063e8af2b3b146104fe578063e9d1e8ac1461051e578063fdca4cb814610561578063fe676d2614610581578063fea1d7b4146105a1575b600080fd5b34801561014257600080fd5b50610156610151366004612c3c565b610621565b60405190151581526020015b60405180910390f35b34801561017757600080fd5b5061018b610186366004612c59565b610662565b604051908152602001610162565b3480156101a557600080fd5b506101b96101b4366004612c89565b61069d565b005b3480156101c757600080fd5b5061018b6101d6366004612c59565b6001600160a01b031660009081526006602090815260408083209383529290522054610100900462ffffff1690565b61018b610213366004612c89565b610831565b34801561022457600080fd5b506101b9610233366004612ccb565b610aac565b34801561024457600080fd5b506101b9610253366004612d52565b610bc8565b34801561026457600080fd5b5061018b610273366004612c59565b6001600160a01b031660009081526003602090815260408083209383529290522054610100900462ffffff1690565b3480156102ae57600080fd5b506101b96102bd366004612c59565b610bdb565b3480156102ce57600080fd5b506101b96102dd366004612c59565b610db6565b3480156102ee57600080fd5b506103586102fd366004612c59565b6040805180820190915260008082526020820152506001600160a01b031660009081526006602090815260408083209383529281529082902082518084019093525460ff811615158352610100900462ffffff169082015290565b6040805182511515815260209283015162ffffff169281019290925201610162565b61018b610388366004612c59565b610e60565b34801561039957600080fd5b506101b96103a8366004612dbd565b610e6d565b3480156103b957600080fd5b506101b96103c8366004612dfc565b610ee2565b3480156103d957600080fd5b506101b96103e8366004612e15565b610fa0565b3480156103f957600080fd5b50610156610408366004612c59565b6111e6565b34801561041957600080fd5b5061018b60015481565b34801561042f57600080fd5b5061045560405180604001604052806006815260200165076332e302e360d41b81525081565b6040516101629190612ee7565b34801561046e57600080fd5b506101b961047d366004612c59565b611212565b34801561048e57600080fd5b506104a261049d366004612c59565b611257565b6040516101629493929190612efa565b3480156104be57600080fd5b506104e67f000000000000000000000000000000000000000000000000000000000000000081565b6040516001600160a01b039091168152602001610162565b34801561050a57600080fd5b506101b9610519366004612c59565b61132f565b34801561052a57600080fd5b50610455604051806040016040528060178152602001764d696e7465724441457870536574746c656d656e74563360481b81525081565b34801561056d57600080fd5b506101b961057c366004612f4e565b61133e565b34801561058d57600080fd5b5061018b61059c366004612faf565b611586565b3480156105ad57600080fd5b506106116105bc366004612c59565b6001600160a01b03166000908152600560209081526040808320938352929052205464ffffffffff80821692600160281b8304909116916001600160581b03600160501b8204811692600160a81b9092041690565b6040516101629493929190612fe6565b6001600160a01b03811660009081526002602052604081208054610100900460ff1615610652575460ff1692915050565b61065b83611624565b9392505050565b6001600160a01b0381166000908152600360209081526040808320858452909152902054600160201b90046001600160801b03165b92915050565b6002600054036106c85760405162461bcd60e51b81526004016106bf9061300d565b60405180910390fd5b60026000556001600160a01b0383166106f35760405162461bcd60e51b81526004016106bf90613044565b6001600160a01b03811660008181526003602090815260408083208684528252808320338452600483528184209484529382528083208684529091528120908061073d848461175c565b91509150600061074c82611807565b84546001600160e81b0319166001600160e81b038216178086556040519192506001600160a01b0388169189913391600080516020613454833981519152916107a491600160e81b90910462ffffff1690879061307b565b60405180910390a46000886001600160a01b03168460405160006040518083038185875af1925050503d80600081146107f9576040519150601f19603f3d011682016040523d82523d6000602084013e6107fe565b606091505b505080915050806108215760405162461bcd60e51b81526004016106bf90613099565b5050600160005550505050505050565b60006002600054036108555760405162461bcd60e51b81526004016106bf9061300d565b600260009081556001600160a01b038316808252600360209081526040808420878552825280842083855260068352818520888652835281852093855260058352818520888652909252909220815460ff16156108c45760405162461bcd60e51b81526004016106bf906130c4565b60006108d1848484611874565b3360009081526004602090815260408083206001600160a01b038b16845282528083208b845290915281209192508061090a83856118b6565b91509150886001600160a01b03168a336001600160a01b0316600080516020613454833981519152848660405161094292919061307b565b60405180910390a461095384611977565b87546001600160801b0391909116600160201b02600160201b600160a01b03199091161787556040516117cd60e21b81526001600160a01b038c81166004830152602482018c90528a811660448301523360648301527f00000000000000000000000000000000000000000000000000000000000000001690615f34906084016020604051808303816000875af11580156109f2573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a1691906130f5565b9750610a2288876119e0565b865460ff1615610a63576001600160a01b0389166000908152600260205260408120610a4f908b90611a2e565b9050610a5d8b868c84611a60565b50610a99565b8654610100900462ffffff16876001610a7b83613124565b91906101000a81548162ffffff021916908362ffffff160217905550505b5050505050505060016000559392505050565b610abf8233306315061e2760e21b611b17565b6001600160a01b03821660008181526003602090815260408083208784528252808320848452600683528184208885528352818420948452600583528184208885529092528220909291610b17878787878787611b6c565b604080517263757272656e74536574746c6564507269636560681b81526001600160801b03881660208201529192506001600160a01b0388169189917f1809fd1f08e6b0df08fd848757688435a0ab8520a51dcca23eba5a3c7f7280d6910160405180910390a38015610bbf57825460405161010090910462ffffff1681526001600160a01b0387169088906000805160206134348339815191529060200160405180910390a35b50505050505050565b610bd53385858585610fa0565b50505050565b600260005403610bfd5760405162461bcd60e51b81526004016106bf9061300d565b6002600055610c16828233306315061e2760e21b611d34565b6001600160a01b0381166000818152600360209081526040808320868452825280832084845260068352818420878552835281842085855260058452828520888652845282852095855260029093529083209093919290610c78908690611a2e565b9050600080610c8b888888888888611da4565b6040805177185d58dd1a5bdb94995d995b9d595cd0dbdb1b1958dd195960421b8152600160208201529294509092506001600160a01b038916918a917fbb5f9d4f49f83650956b76c40de0f082a06430bf0222e1b6b3f90a7a0f845c4d910160405180910390a38015610d66578554604080517263757272656e74536574746c6564507269636560681b8152600160201b9092046001600160801b031660208301526001600160a01b038916918a917f1809fd1f08e6b0df08fd848757688435a0ab8520a51dcca23eba5a3c7f7280d6910160405180910390a35b8115610da757845460405161010090910462ffffff1681526001600160a01b0388169089906000805160206134348339815191529060200160405180910390a35b50506001600055505050505050565b610dc9813330634ae2bafd60e11b611b17565b6001600160a01b03811660009081526003602090815260408083208584529091529020805460ff1615610e0e5760405162461bcd60e51b81526004016106bf90613146565b6001600160a01b03821660008181526005602090815260408083208784529091528082208290555185917f865169678476a498ca03f184818d6bd6217dd57b754577a944c19d6d75587c8091a3505050565b600061065b338484610831565b610e78838333611f4b565b6001600160a01b03821660009081526006602090815260408083208684529091529020610eaa90849084908490611f95565b60405162ffffff821681526001600160a01b0383169084906000805160206134348339815191529060200160405180910390a3505050565b610f157f0000000000000000000000000000000000000000000000000000000000000000333063b3fe472360e01b61201c565b60008111610f655760405162461bcd60e51b815260206004820152601d60248201527f48616c66206c696665206f66207a65726f206e6f7420616c6c6f77656400000060448201526064016106bf565b60018190556040518181527fdae7136b6b1f9f3031d9536e8bdd02f1d223eb793054446ff278143abeafa21b9060200160405180910390a150565b600260005403610fc25760405162461bcd60e51b81526004016106bf9061300d565b60026000556001600160a01b038516610fed5760405162461bcd60e51b81526004016106bf90613044565b828181146110385760405162461bcd60e51b8152602060048201526018602482015277082e4e4c2f240d8cadccee8d0e640daeae6e840dac2e8c6d60431b60448201526064016106bf565b6000805b828110156111705760008787838181106110585761105861317d565b90506020020135905060008686848181106110755761107561317d565b905060200201602081019061108a9190612c3c565b6001600160a01b03811660008181526003602090815260408083208784528252808320338452600483528184209484529382528083208784529091528120929350909190806110d9848461175c565b9150915060006110e882611807565b84546001600160e81b0319166001600160e81b038216178555905061110d838a613193565b9850856001600160a01b031687336001600160a01b031660008051602061345483398151915287600001601d9054906101000a900462ffffff168560405161115692919061307b565b60405180910390a48760010197505050505050505061103c565b506000876001600160a01b03168260405160006040518083038185875af1925050503d80600081146111be576040519150601f19603f3d011682016040523d82523d6000602084013e6111c3565b606091505b50508091505080610da75760405162461bcd60e51b81526004016106bf90613099565b6001600160a01b038116600090815260066020908152604080832085845290915281205460ff1661065b565b61121d828233611f4b565b60405162461bcd60e51b815260206004820152600f60248201526e139bdd081a5b5c1b195b595b9d1959608a1b60448201526064016106bf565b6001600160a01b038116600081815260036020908152604080832086845282528083208484526006835281842087855283528184209484526005835281842087855290925282208054600160501b90046001600160581b03161515936060928492909190866112c95760009550611301565b805464ffffffffff1642116112f1578054600160501b90046001600160581b03169550611301565b6112fe8989858585612071565b95505b6040518060400160405280600381526020016208aa8960eb1b81525094506000935050505092959194509250565b61133a33838361069d565b5050565b611349868633611f4b565b6001600160a01b03851660008181526005602090815260408083208a84528252808320938352600382528083208a8452909152902061138884826120b2565b6113d45760405162461bcd60e51b815260206004820152601f60248201527f4f6e6c79206d6f6e6f746f6e69632064656372656173696e672070726963650060448201526064016106bf565b600083116114225760405162461bcd60e51b815260206004820152601b60248201527a42617365207072696365206d757374206265206e6f6e2d7a65726f60281b60448201526064016106bf565b6001548564ffffffffff1610156114a15760405162461bcd60e51b815260206004820152603e60248201527f50726963652064656361792068616c66206c696665206d75737420626520677260448201527f6561746572207468616e206d696e20616c6c6f7761626c652076616c7565000060648201526084016106bf565b6114c08287876114b0886120e5565b6114b9886120e5565b600061214d565b866001600160a01b0316887f7fbd78481800c1705ba89e4be2e8c979412fb121f7f3cbace9d7f5c3dd85c44e888888886040516115009493929190612fe6565b60405180910390a36001600160a01b03871660009081526006602090815260408083208b84529091528120906115378a8a846122ea565b9050801561157a57815460405161010090910462ffffff1681526001600160a01b038a16908b906000805160206134348339815191529060200160405180910390a35b50505050505050505050565b60006001600160a01b0382166115d05760405162461bcd60e51b815260206004820152600f60248201526e4e6f207a65726f206164647265737360881b60448201526064016106bf565b6001600160a01b0380841660008181526003602090815260408083208984528252808320948716835260048252808320938352928152828220888352905220611619828261175c565b509695505050505050565b6040516000602482018190526044820181905290819060640160408051601f198184030181529181526020820180516001600160e01b0316638639415b60e01b1790525190915060009081906001600160a01b038616906116869085906131a6565b600060405180830381855afa9150503d80600081146116c1576040519150601f19603f3d011682016040523d82523d6000602084013e6116c6565b606091505b5091509150816116e85760405162461bcd60e51b81526004016106bf906131c2565b805160c08190036116ff5750600095945050505050565b80610100036117145750600195945050505050565b60405162461bcd60e51b815260206004820152601e60248201527f556e657870656374656420726576656e75652073706c6974206279746573000060448201526064016106bf565b80546000908190600160e81b900462ffffff16806117c65760405162461bcd60e51b815260206004820152602160248201527f4e6f20707572636861736573206d6164652062792074686973206164647265736044820152607360f81b60648201526084016106bf565b8454600160201b90046001600160801b03166117e28183613207565b85549093506117fb9084906001600160e81b031661321e565b935050505b9250929050565b60006001600160e81b038211156118705760405162461bcd60e51b815260206004820152602760248201527f53616665436173743a2076616c756520646f65736e27742066697420696e20326044820152663332206269747360c81b60648201526084016106bf565b5090565b815460009060ff16806118885750835460ff165b156118a557508254600160201b90046001600160801b031661065b565b6118ae8261237c565b949350505050565b815460009081906118da906118d59034906001600160e81b0316613193565b611807565b84549092506118f690600160e81b900462ffffff166001613231565b90506119078362ffffff8316613207565b826001600160e81b031610156119585760405162461bcd60e51b815260206004820152601660248201527526b4b7103b30b63ab2903a379036b4b73a103932b89760511b60448201526064016106bf565b62ffffff8116600160e81b026001600160e81b03831617909355929050565b60006001600160801b038211156118705760405162461bcd60e51b815260206004820152602760248201527f53616665436173743a2076616c756520646f65736e27742066697420696e20316044820152663238206269747360c81b60648201526084016106bf565b8054620f4240830660010190610100900462ffffff1680821115611a165760405162461bcd60e51b81526004016106bf906130c4565b808203610bd557825460ff1916600117835550505050565b8054600090610100900460ff1615611a4b5750805460ff16610697565b6000611a5784846124b7565b91506106979050565b3415610bd557600080611a73853461321e565b90508015611b035760405133908290600081818185875af1925050503d8060008114611abb576040519150601f19603f3d011682016040523d82523d6000602084013e611ac0565b606091505b50508092505081611b035760405162461bcd60e51b815260206004820152600d60248201526c1499599d5b990819985a5b1959609a1b60448201526064016106bf565b611b0f868686866125c7565b505050505050565b611b2384848484612992565b610bd55760405162461bcd60e51b815260206004820152601a60248201527913db9b1e4810dbdc994810591b5a5b9050d308185b1b1bddd95960321b60448201526064016106bf565b825460009060ff1615611b915760405162461bcd60e51b81526004016106bf90613146565b611b9c8787856122ea565b8254909150600160a81b90046001600160581b03166001600160801b0386161015611bff5760405162461bcd60e51b81526020600482015260136024820152724f6e6c7920677465206261736520707269636560681b60448201526064016106bf565b825460ff16611c4b5760405162461bcd60e51b815260206004820152601860248201527741756374696f6e206d75737420626520636f6d706c65746560401b60448201526064016106bf565b83546001600160801b03600160201b909104811690861610611caf5760405162461bcd60e51b815260206004820152601d60248201527f4d6179206f6e6c79207265647563652073656c6c6f757420707269636500000060448201526064016106bf565b6000856001600160801b031611611d025760405162461bcd60e51b815260206004820152601760248201527604f6e6c792073656c6c6f757420707269636573203e203604c1b60448201526064016106bf565b83546001600160801b03909516600160201b02600160201b600160a01b03199095169490941790925550909392505050565b611d3f858585612a1a565b80611d515750611d5184848484612992565b611d9d5760405162461bcd60e51b815260206004820152601d60248201527f4f6e6c7920417274697374206f7220436f72652041646d696e2041434c00000060448201526064016106bf565b5050505050565b8354600090819060ff1615611df85760405162461bcd60e51b815260206004820152601a60248201527914995d995b9d595cc8185b1c9958591e4818dbdb1b1958dd195960321b60448201526064016106bf565b611e038888876122ea565b91506000611e12878787611874565b8554909150600160a81b90046001600160581b03168114611e8357855460ff16611e7e5760405162461bcd60e51b815260206004820152601f60248201527f4163746976652061756374696f6e206e6f742079657420736f6c64206f75740060448201526064016106bf565b611f0b565b8454600160a81b90046001600160581b031680611ee15760405162461bcd60e51b815260206004820152601c60248201527b04f6e6c79206c617465737450757263686173655072696365203e20360241b60448201526064016106bf565b87546001600160801b03909116600160201b02600160201b600160a01b0319909116178755600191505b865460ff1916600117808855600090611f3090839062ffffff61010090910416613207565b9050611f3e8a828b886125c7565b5050965096945050505050565b611f56838383612a1a565b611f905760405162461bcd60e51b815260206004820152600b60248201526a13db9b1e48105c9d1a5cdd60aa1b60448201526064016106bf565b505050565b600080611fa28686612aa3565b91509150808462ffffff161115611fcb5760405162461bcd60e51b81526004016106bf9061326a565b818462ffffff161015611ff05760405162461bcd60e51b81526004016106bf9061326a565b50815460ff1962ffffff90941661010081029490941663ffffffff199091161792149190911790555050565b61202884848484612992565b610bd55760405162461bcd60e51b815260206004820152601a60248201527913db9b1e48135a5b9d195c919a5b1d195c8810591b5a5b9050d360321b60448201526064016106bf565b600061207e868685612b21565b1561209b57508254600160201b90046001600160801b03166120a9565b6120a6848484611874565b90505b95945050505050565b8054600090600160201b90046001600160801b0316158061065b57505054600160201b90046001600160801b0316101590565b60006001600160581b038211156118705760405162461bcd60e51b815260206004820152602660248201527f53616665436173743a2076616c756520646f65736e27742066697420696e203860448201526538206269747360d01b60648201526084016106bf565b855464ffffffffff1615806121695750855464ffffffffff1642105b806121715750805b6121bc5760405162461bcd60e51b815260206004820152601c60248201527b27379036b7b234b334b1b0ba34b7b7399036b4b216b0bab1ba34b7b760211b60448201526064016106bf565b8464ffffffffff1642106122095760405162461bcd60e51b81526020600482015260146024820152734f6e6c79206675747572652061756374696f6e7360601b60448201526064016106bf565b816001600160581b0316836001600160581b03161161228d5760405162461bcd60e51b815260206004820152603a60248201527f41756374696f6e207374617274207072696365206d7573742062652067726561604482015279746572207468616e2061756374696f6e20656e6420707269636560301b60648201526084016106bf565b50845464ffffffffff9485166001600160501b031990911617600160281b9390941692909202929092176001600160501b0316600160501b6001600160581b03938416026001600160a81b031617600160a81b9190921602179055565b60006122f582612b5f565b1561230f57612305848484612b7f565b506001905061065b565b60008061231c8686612aa3565b8554909350909150610100900462ffffff168281111561235f57845460ff1962ffffff8516610100021663ffffffff199091161782841417855560019350612372565b80821061237257845460ff191660011785555b5050509392505050565b805460009064ffffffffff80821691600160281b810490911690600160a81b90046001600160581b03164283106123ef5760405162461bcd60e51b8152602060048201526017602482015276105d58dd1a5bdb881b9bdd081e595d081cdd185c9d1959604a1b60448201526064016106bf565b6000821161243a5760405162461bcd60e51b81526020600482015260186024820152774f6e6c7920636f6e666967757265642061756374696f6e7360401b60448201526064016106bf565b8454600160501b90046001600160581b03164284900383818161245f5761245f613254565b0482901c915060028485838161247757612477613254565b0684028161248757612487613254565b048161249557612495613254565b0482039150828210156124ad57509095945050505050565b5095945050505050565b6040516000602482018190526044820181905290819060640160408051601f198184030181529181526020820180516001600160e01b0316638639415b60e01b1790525190915060009081906001600160a01b038716906125199085906131a6565b6000604051808303816000865af19150503d8060008114612556576040519150601f19603f3d011682016040523d82523d6000602084013e61255b565b606091505b50915091508161257d5760405162461bcd60e51b81526004016106bf906131c2565b805160c08190036125a3575050835461ffff191661010017845550600091506106979050565b8061010003611714575050835461ffff191661010117845550600191506106979050565b8215610bd5576000806000806000806000871561271857604051638639415b60e01b8152600481018c9052602481018b905260009081906001600160a01b038c1690638639415b9060440161010060405180830381865afa158015612630573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612654919061329b565b969e50949c50909a50985091965091945090925090508115612711576040516001600160a01b038216908390600081818185875af1925050503d80600081146126b9576040519150601f19603f3d011682016040523d82523d6000602084013e6126be565b606091505b505080995050886127115760405162461bcd60e51b815260206004820181905260248201527f506c6174666f726d2050726f7669646572207061796d656e74206661696c656460448201526064016106bf565b5050612798565b604051638639415b60e01b8152600481018c9052602481018b90526001600160a01b038a1690638639415b9060440160c060405180830381865afa158015612764573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906127889190613323565b949a509298509096509450925090505b851561283f576040516001600160a01b038616908790600081818185875af1925050503d80600081146127e7576040519150601f19603f3d011682016040523d82523d6000602084013e6127ec565b606091505b5050809750508661283f5760405162461bcd60e51b815260206004820152601e60248201527f52656e6465722050726f7669646572207061796d656e74206661696c6564000060448201526064016106bf565b83156128de576040516001600160a01b038416908590600081818185875af1925050503d806000811461288e576040519150601f19603f3d011682016040523d82523d6000602084013e612893565b606091505b505080975050866128de5760405162461bcd60e51b8152602060048201526015602482015274105c9d1a5cdd081c185e5b595b9d0819985a5b1959605a1b60448201526064016106bf565b8115612985576040516001600160a01b038216908390600081818185875af1925050503d806000811461292d576040519150601f19603f3d011682016040523d82523d6000602084013e612932565b606091505b505080975050866129855760405162461bcd60e51b815260206004820152601f60248201527f4164646974696f6e616c205061796565207061796d656e74206661696c65640060448201526064016106bf565b5050505050505050505050565b60405163230448b160e01b81526001600160a01b03848116600483015283811660248301526001600160e01b0319831660448301526000919086169063230448b1906064016020604051808303816000875af11580156129f6573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906120a9919061339c565b60405163a47d29cb60e01b8152600481018490526000906001600160a01b0384169063a47d29cb90602401602060405180830381865afa158015612a62573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612a8691906133b7565b6001600160a01b0316826001600160a01b03161490509392505050565b604051630ea5613f60e01b81526004810183905260009081906001600160a01b03841690630ea5613f9060240160c060405180830381865afa158015612aed573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612b1191906133d4565b5093989297509195505050505050565b6000806000612b308686612aa3565b85549193509150610100900462ffffff1681811115612b52575014905061065b565b9091101595945050505050565b8054600090610100900462ffffff161580156106975750505460ff161590565b6000806000846001600160a01b0316630ea5613f876040518263ffffffff1660e01b8152600401612bb291815260200190565b60c060405180830381865afa158015612bcf573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612bf391906133d4565b5050875493831463ffffffff1990941661010062ffffff85160260ff19161793909317909655979650505050505050565b6001600160a01b0381168114612c3957600080fd5b50565b600060208284031215612c4e57600080fd5b813561065b81612c24565b60008060408385031215612c6c57600080fd5b823591506020830135612c7e81612c24565b809150509250929050565b600080600060608486031215612c9e57600080fd5b8335612ca981612c24565b9250602084013591506040840135612cc081612c24565b809150509250925092565b600080600060608486031215612ce057600080fd5b833592506020840135612cf281612c24565b915060408401356001600160801b0381168114612cc057600080fd5b60008083601f840112612d2057600080fd5b5081356001600160401b03811115612d3757600080fd5b6020830191508360208260051b850101111561180057600080fd5b60008060008060408587031215612d6857600080fd5b84356001600160401b0380821115612d7f57600080fd5b612d8b88838901612d0e565b90965094506020870135915080821115612da457600080fd5b50612db187828801612d0e565b95989497509550505050565b600080600060608486031215612dd257600080fd5b833592506020840135612de481612c24565b9150604084013562ffffff81168114612cc057600080fd5b600060208284031215612e0e57600080fd5b5035919050565b600080600080600060608688031215612e2d57600080fd5b8535612e3881612c24565b945060208601356001600160401b0380821115612e5457600080fd5b612e6089838a01612d0e565b90965094506040880135915080821115612e7957600080fd5b50612e8688828901612d0e565b969995985093965092949392505050565b60005b83811015612eb2578181015183820152602001612e9a565b50506000910152565b60008151808452612ed3816020860160208601612e97565b601f01601f19169290920160200192915050565b60208152600061065b6020830184612ebb565b8415158152836020820152608060408201526000612f1b6080830185612ebb565b905060018060a01b038316606083015295945050505050565b803564ffffffffff81168114612f4957600080fd5b919050565b60008060008060008060c08789031215612f6757600080fd5b863595506020870135612f7981612c24565b9450612f8760408801612f34565b9350612f9560608801612f34565b92506080870135915060a087013590509295509295509295565b600080600060608486031215612fc457600080fd5b833592506020840135612fd681612c24565b91506040840135612cc081612c24565b64ffffffffff94851681529290931660208301526040820152606081019190915260800190565b6020808252601f908201527f5265656e7472616e637947756172643a207265656e7472616e742063616c6c00604082015260600190565b6020808252601f908201527f4e6f20636c61696d696e6720746f20746865207a65726f206164647265737300604082015260600190565b62ffffff9290921682526001600160e81b0316602082015260400190565b602080825260119082015270149958db185a5b5a5b99c819985a5b1959607a1b604082015260600190565b60208082526017908201527613585e081a5b9d9bd8d85d1a5bdb9cc81c995858da1959604a1b604082015260600190565b60006020828403121561310757600080fd5b5051919050565b634e487b7160e01b600052601160045260246000fd5b600062ffffff80831681810361313c5761313c61310e565b6001019392505050565b6020808252601e908201527f4f6e6c79206265666f726520726576656e75657320636f6c6c65637465640000604082015260600190565b634e487b7160e01b600052603260045260246000fd5b808201808211156106975761069761310e565b600082516131b8818460208701612e97565b9190910192915050565b60208082526025908201527f6765745072696d617279526576656e756553706c69747328292063616c6c2066604082015264185a5b195960da1b606082015260800190565b80820281158282048414176106975761069761310e565b818103818111156106975761069761310e565b62ffffff81811683821601908082111561324d5761324d61310e565b5092915050565b634e487b7160e01b600052601260045260246000fd5b602080825260179082015276496e76616c6964206d617820696e766f636174696f6e7360481b604082015260600190565b600080600080600080600080610100898b0312156132b857600080fd5b8851975060208901516132ca81612c24565b60408a015160608b015191985096506132e281612c24565b60808a015160a08b015191965094506132fa81612c24565b60c08a015160e08b0151919450925061331281612c24565b809150509295985092959890939650565b60008060008060008060c0878903121561333c57600080fd5b86519550602087015161334e81612c24565b60408801516060890151919650945061336681612c24565b608088015160a0890151919450925061337e81612c24565b809150509295509295509295565b80518015158114612f4957600080fd5b6000602082840312156133ae57600080fd5b61065b8261338c565b6000602082840312156133c957600080fd5b815161065b81612c24565b60008060008060008060c087890312156133ed57600080fd5b86519550602087015194506134046040880161338c565b93506134126060880161338c565b92506080870151915061342760a0880161338c565b9050929550929550929556fe1c3e74a6c6fefbaeee166b031cd2016349c6c863d5188b67c9bbd0b0dcb2e2373e587139a5e04472b0e74a6be0594ff90a9f1364a13fdc1897ad5bd3ab9ea5a6a26469706673582212207f3d79be72327ae09b9c06980e8b99087a857089fbe3510bf9938ee5886f575864736f6c63430008130033",
+  "deployedBytecode": "0x6080604052600436106101315760003560e01c806301000da7146101365780632b001e6c1461016b5780633c22f1d0146101995780634869f3df146101bb5780634e8d8787146102055780635418789c1461021857806367e6aad9146102385780636a9f62fc146102585780638fe8a90b146102a257806395c575fa146102c25780639a94488a146102e2578063ae77c2371461037a578063b000e3341461038d578063b3fe4723146103ad578063c0244587146103cd578063cce7c909146103ed578063cf6681ea1461040d578063d3ddabe614610423578063d9bffbce14610462578063d9eb16db14610482578063dd85582f146104b2578063e8af2b3b146104fe578063e9d1e8ac1461051e578063fdca4cb814610561578063fe676d2614610581578063fea1d7b4146105a1575b600080fd5b34801561014257600080fd5b50610156610151366004612c3c565b610621565b60405190151581526020015b60405180910390f35b34801561017757600080fd5b5061018b610186366004612c59565b610662565b604051908152602001610162565b3480156101a557600080fd5b506101b96101b4366004612c89565b61069d565b005b3480156101c757600080fd5b5061018b6101d6366004612c59565b6001600160a01b031660009081526006602090815260408083209383529290522054610100900462ffffff1690565b61018b610213366004612c89565b610831565b34801561022457600080fd5b506101b9610233366004612ccb565b610aac565b34801561024457600080fd5b506101b9610253366004612d52565b610bc8565b34801561026457600080fd5b5061018b610273366004612c59565b6001600160a01b031660009081526003602090815260408083209383529290522054610100900462ffffff1690565b3480156102ae57600080fd5b506101b96102bd366004612c59565b610bdb565b3480156102ce57600080fd5b506101b96102dd366004612c59565b610db6565b3480156102ee57600080fd5b506103586102fd366004612c59565b6040805180820190915260008082526020820152506001600160a01b031660009081526006602090815260408083209383529281529082902082518084019093525460ff811615158352610100900462ffffff169082015290565b6040805182511515815260209283015162ffffff169281019290925201610162565b61018b610388366004612c59565b610e60565b34801561039957600080fd5b506101b96103a8366004612dbd565b610e6d565b3480156103b957600080fd5b506101b96103c8366004612dfc565b610ee2565b3480156103d957600080fd5b506101b96103e8366004612e15565b610fa0565b3480156103f957600080fd5b50610156610408366004612c59565b6111e6565b34801561041957600080fd5b5061018b60015481565b34801561042f57600080fd5b5061045560405180604001604052806006815260200165076332e302e360d41b81525081565b6040516101629190612ee7565b34801561046e57600080fd5b506101b961047d366004612c59565b611212565b34801561048e57600080fd5b506104a261049d366004612c59565b611257565b6040516101629493929190612efa565b3480156104be57600080fd5b506104e67f000000000000000000000000000000000000000000000000000000000000000081565b6040516001600160a01b039091168152602001610162565b34801561050a57600080fd5b506101b9610519366004612c59565b61132f565b34801561052a57600080fd5b50610455604051806040016040528060178152602001764d696e7465724441457870536574746c656d656e74563360481b81525081565b34801561056d57600080fd5b506101b961057c366004612f4e565b61133e565b34801561058d57600080fd5b5061018b61059c366004612faf565b611586565b3480156105ad57600080fd5b506106116105bc366004612c59565b6001600160a01b03166000908152600560209081526040808320938352929052205464ffffffffff80821692600160281b8304909116916001600160581b03600160501b8204811692600160a81b9092041690565b6040516101629493929190612fe6565b6001600160a01b03811660009081526002602052604081208054610100900460ff1615610652575460ff1692915050565b61065b83611624565b9392505050565b6001600160a01b0381166000908152600360209081526040808320858452909152902054600160201b90046001600160801b03165b92915050565b6002600054036106c85760405162461bcd60e51b81526004016106bf9061300d565b60405180910390fd5b60026000556001600160a01b0383166106f35760405162461bcd60e51b81526004016106bf90613044565b6001600160a01b03811660008181526003602090815260408083208684528252808320338452600483528184209484529382528083208684529091528120908061073d848461175c565b91509150600061074c82611807565b84546001600160e81b0319166001600160e81b038216178086556040519192506001600160a01b0388169189913391600080516020613454833981519152916107a491600160e81b90910462ffffff1690879061307b565b60405180910390a46000886001600160a01b03168460405160006040518083038185875af1925050503d80600081146107f9576040519150601f19603f3d011682016040523d82523d6000602084013e6107fe565b606091505b505080915050806108215760405162461bcd60e51b81526004016106bf90613099565b5050600160005550505050505050565b60006002600054036108555760405162461bcd60e51b81526004016106bf9061300d565b600260009081556001600160a01b038316808252600360209081526040808420878552825280842083855260068352818520888652835281852093855260058352818520888652909252909220815460ff16156108c45760405162461bcd60e51b81526004016106bf906130c4565b60006108d1848484611874565b3360009081526004602090815260408083206001600160a01b038b16845282528083208b845290915281209192508061090a83856118b6565b91509150886001600160a01b03168a336001600160a01b0316600080516020613454833981519152848660405161094292919061307b565b60405180910390a461095384611977565b87546001600160801b0391909116600160201b02600160201b600160a01b03199091161787556040516117cd60e21b81526001600160a01b038c81166004830152602482018c90528a811660448301523360648301527f00000000000000000000000000000000000000000000000000000000000000001690615f34906084016020604051808303816000875af11580156109f2573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610a1691906130f5565b9750610a2288876119e0565b865460ff1615610a63576001600160a01b0389166000908152600260205260408120610a4f908b90611a2e565b9050610a5d8b868c84611a60565b50610a99565b8654610100900462ffffff16876001610a7b83613124565b91906101000a81548162ffffff021916908362ffffff160217905550505b5050505050505060016000559392505050565b610abf8233306315061e2760e21b611b17565b6001600160a01b03821660008181526003602090815260408083208784528252808320848452600683528184208885528352818420948452600583528184208885529092528220909291610b17878787878787611b6c565b604080517263757272656e74536574746c6564507269636560681b81526001600160801b03881660208201529192506001600160a01b0388169189917f1809fd1f08e6b0df08fd848757688435a0ab8520a51dcca23eba5a3c7f7280d6910160405180910390a38015610bbf57825460405161010090910462ffffff1681526001600160a01b0387169088906000805160206134348339815191529060200160405180910390a35b50505050505050565b610bd53385858585610fa0565b50505050565b600260005403610bfd5760405162461bcd60e51b81526004016106bf9061300d565b6002600055610c16828233306315061e2760e21b611d34565b6001600160a01b0381166000818152600360209081526040808320868452825280832084845260068352818420878552835281842085855260058452828520888652845282852095855260029093529083209093919290610c78908690611a2e565b9050600080610c8b888888888888611da4565b6040805177185d58dd1a5bdb94995d995b9d595cd0dbdb1b1958dd195960421b8152600160208201529294509092506001600160a01b038916918a917fbb5f9d4f49f83650956b76c40de0f082a06430bf0222e1b6b3f90a7a0f845c4d910160405180910390a38015610d66578554604080517263757272656e74536574746c6564507269636560681b8152600160201b9092046001600160801b031660208301526001600160a01b038916918a917f1809fd1f08e6b0df08fd848757688435a0ab8520a51dcca23eba5a3c7f7280d6910160405180910390a35b8115610da757845460405161010090910462ffffff1681526001600160a01b0388169089906000805160206134348339815191529060200160405180910390a35b50506001600055505050505050565b610dc9813330634ae2bafd60e11b611b17565b6001600160a01b03811660009081526003602090815260408083208584529091529020805460ff1615610e0e5760405162461bcd60e51b81526004016106bf90613146565b6001600160a01b03821660008181526005602090815260408083208784529091528082208290555185917f865169678476a498ca03f184818d6bd6217dd57b754577a944c19d6d75587c8091a3505050565b600061065b338484610831565b610e78838333611f4b565b6001600160a01b03821660009081526006602090815260408083208684529091529020610eaa90849084908490611f95565b60405162ffffff821681526001600160a01b0383169084906000805160206134348339815191529060200160405180910390a3505050565b610f157f0000000000000000000000000000000000000000000000000000000000000000333063b3fe472360e01b61201c565b60008111610f655760405162461bcd60e51b815260206004820152601d60248201527f48616c66206c696665206f66207a65726f206e6f7420616c6c6f77656400000060448201526064016106bf565b60018190556040518181527fdae7136b6b1f9f3031d9536e8bdd02f1d223eb793054446ff278143abeafa21b9060200160405180910390a150565b600260005403610fc25760405162461bcd60e51b81526004016106bf9061300d565b60026000556001600160a01b038516610fed5760405162461bcd60e51b81526004016106bf90613044565b828181146110385760405162461bcd60e51b8152602060048201526018602482015277082e4e4c2f240d8cadccee8d0e640daeae6e840dac2e8c6d60431b60448201526064016106bf565b6000805b828110156111705760008787838181106110585761105861317d565b90506020020135905060008686848181106110755761107561317d565b905060200201602081019061108a9190612c3c565b6001600160a01b03811660008181526003602090815260408083208784528252808320338452600483528184209484529382528083208784529091528120929350909190806110d9848461175c565b9150915060006110e882611807565b84546001600160e81b0319166001600160e81b038216178555905061110d838a613193565b9850856001600160a01b031687336001600160a01b031660008051602061345483398151915287600001601d9054906101000a900462ffffff168560405161115692919061307b565b60405180910390a48760010197505050505050505061103c565b506000876001600160a01b03168260405160006040518083038185875af1925050503d80600081146111be576040519150601f19603f3d011682016040523d82523d6000602084013e6111c3565b606091505b50508091505080610da75760405162461bcd60e51b81526004016106bf90613099565b6001600160a01b038116600090815260066020908152604080832085845290915281205460ff1661065b565b61121d828233611f4b565b60405162461bcd60e51b815260206004820152600f60248201526e139bdd081a5b5c1b195b595b9d1959608a1b60448201526064016106bf565b6001600160a01b038116600081815260036020908152604080832086845282528083208484526006835281842087855283528184209484526005835281842087855290925282208054600160501b90046001600160581b03161515936060928492909190866112c95760009550611301565b805464ffffffffff1642116112f1578054600160501b90046001600160581b03169550611301565b6112fe8989858585612071565b95505b6040518060400160405280600381526020016208aa8960eb1b81525094506000935050505092959194509250565b61133a33838361069d565b5050565b611349868633611f4b565b6001600160a01b03851660008181526005602090815260408083208a84528252808320938352600382528083208a8452909152902061138884826120b2565b6113d45760405162461bcd60e51b815260206004820152601f60248201527f4f6e6c79206d6f6e6f746f6e69632064656372656173696e672070726963650060448201526064016106bf565b600083116114225760405162461bcd60e51b815260206004820152601b60248201527a42617365207072696365206d757374206265206e6f6e2d7a65726f60281b60448201526064016106bf565b6001548564ffffffffff1610156114a15760405162461bcd60e51b815260206004820152603e60248201527f50726963652064656361792068616c66206c696665206d75737420626520677260448201527f6561746572207468616e206d696e20616c6c6f7761626c652076616c7565000060648201526084016106bf565b6114c08287876114b0886120e5565b6114b9886120e5565b600061214d565b866001600160a01b0316887f7fbd78481800c1705ba89e4be2e8c979412fb121f7f3cbace9d7f5c3dd85c44e888888886040516115009493929190612fe6565b60405180910390a36001600160a01b03871660009081526006602090815260408083208b84529091528120906115378a8a846122ea565b9050801561157a57815460405161010090910462ffffff1681526001600160a01b038a16908b906000805160206134348339815191529060200160405180910390a35b50505050505050505050565b60006001600160a01b0382166115d05760405162461bcd60e51b815260206004820152600f60248201526e4e6f207a65726f206164647265737360881b60448201526064016106bf565b6001600160a01b0380841660008181526003602090815260408083208984528252808320948716835260048252808320938352928152828220888352905220611619828261175c565b509695505050505050565b6040516000602482018190526044820181905290819060640160408051601f198184030181529181526020820180516001600160e01b0316638639415b60e01b1790525190915060009081906001600160a01b038616906116869085906131a6565b600060405180830381855afa9150503d80600081146116c1576040519150601f19603f3d011682016040523d82523d6000602084013e6116c6565b606091505b5091509150816116e85760405162461bcd60e51b81526004016106bf906131c2565b805160c08190036116ff5750600095945050505050565b80610100036117145750600195945050505050565b60405162461bcd60e51b815260206004820152601e60248201527f556e657870656374656420726576656e75652073706c6974206279746573000060448201526064016106bf565b80546000908190600160e81b900462ffffff16806117c65760405162461bcd60e51b815260206004820152602160248201527f4e6f20707572636861736573206d6164652062792074686973206164647265736044820152607360f81b60648201526084016106bf565b8454600160201b90046001600160801b03166117e28183613207565b85549093506117fb9084906001600160e81b031661321e565b935050505b9250929050565b60006001600160e81b038211156118705760405162461bcd60e51b815260206004820152602760248201527f53616665436173743a2076616c756520646f65736e27742066697420696e20326044820152663332206269747360c81b60648201526084016106bf565b5090565b815460009060ff16806118885750835460ff165b156118a557508254600160201b90046001600160801b031661065b565b6118ae8261237c565b949350505050565b815460009081906118da906118d59034906001600160e81b0316613193565b611807565b84549092506118f690600160e81b900462ffffff166001613231565b90506119078362ffffff8316613207565b826001600160e81b031610156119585760405162461bcd60e51b815260206004820152601660248201527526b4b7103b30b63ab2903a379036b4b73a103932b89760511b60448201526064016106bf565b62ffffff8116600160e81b026001600160e81b03831617909355929050565b60006001600160801b038211156118705760405162461bcd60e51b815260206004820152602760248201527f53616665436173743a2076616c756520646f65736e27742066697420696e20316044820152663238206269747360c81b60648201526084016106bf565b8054620f4240830660010190610100900462ffffff1680821115611a165760405162461bcd60e51b81526004016106bf906130c4565b808203610bd557825460ff1916600117835550505050565b8054600090610100900460ff1615611a4b5750805460ff16610697565b6000611a5784846124b7565b91506106979050565b3415610bd557600080611a73853461321e565b90508015611b035760405133908290600081818185875af1925050503d8060008114611abb576040519150601f19603f3d011682016040523d82523d6000602084013e611ac0565b606091505b50508092505081611b035760405162461bcd60e51b815260206004820152600d60248201526c1499599d5b990819985a5b1959609a1b60448201526064016106bf565b611b0f868686866125c7565b505050505050565b611b2384848484612992565b610bd55760405162461bcd60e51b815260206004820152601a60248201527913db9b1e4810dbdc994810591b5a5b9050d308185b1b1bddd95960321b60448201526064016106bf565b825460009060ff1615611b915760405162461bcd60e51b81526004016106bf90613146565b611b9c8787856122ea565b8254909150600160a81b90046001600160581b03166001600160801b0386161015611bff5760405162461bcd60e51b81526020600482015260136024820152724f6e6c7920677465206261736520707269636560681b60448201526064016106bf565b825460ff16611c4b5760405162461bcd60e51b815260206004820152601860248201527741756374696f6e206d75737420626520636f6d706c65746560401b60448201526064016106bf565b83546001600160801b03600160201b909104811690861610611caf5760405162461bcd60e51b815260206004820152601d60248201527f4d6179206f6e6c79207265647563652073656c6c6f757420707269636500000060448201526064016106bf565b6000856001600160801b031611611d025760405162461bcd60e51b815260206004820152601760248201527604f6e6c792073656c6c6f757420707269636573203e203604c1b60448201526064016106bf565b83546001600160801b03909516600160201b02600160201b600160a01b03199095169490941790925550909392505050565b611d3f858585612a1a565b80611d515750611d5184848484612992565b611d9d5760405162461bcd60e51b815260206004820152601d60248201527f4f6e6c7920417274697374206f7220436f72652041646d696e2041434c00000060448201526064016106bf565b5050505050565b8354600090819060ff1615611df85760405162461bcd60e51b815260206004820152601a60248201527914995d995b9d595cc8185b1c9958591e4818dbdb1b1958dd195960321b60448201526064016106bf565b611e038888876122ea565b91506000611e12878787611874565b8554909150600160a81b90046001600160581b03168114611e8357855460ff16611e7e5760405162461bcd60e51b815260206004820152601f60248201527f4163746976652061756374696f6e206e6f742079657420736f6c64206f75740060448201526064016106bf565b611f0b565b8454600160a81b90046001600160581b031680611ee15760405162461bcd60e51b815260206004820152601c60248201527b04f6e6c79206c617465737450757263686173655072696365203e20360241b60448201526064016106bf565b87546001600160801b03909116600160201b02600160201b600160a01b0319909116178755600191505b865460ff1916600117808855600090611f3090839062ffffff61010090910416613207565b9050611f3e8a828b886125c7565b5050965096945050505050565b611f56838383612a1a565b611f905760405162461bcd60e51b815260206004820152600b60248201526a13db9b1e48105c9d1a5cdd60aa1b60448201526064016106bf565b505050565b600080611fa28686612aa3565b91509150808462ffffff161115611fcb5760405162461bcd60e51b81526004016106bf9061326a565b818462ffffff161015611ff05760405162461bcd60e51b81526004016106bf9061326a565b50815460ff1962ffffff90941661010081029490941663ffffffff199091161792149190911790555050565b61202884848484612992565b610bd55760405162461bcd60e51b815260206004820152601a60248201527913db9b1e48135a5b9d195c919a5b1d195c8810591b5a5b9050d360321b60448201526064016106bf565b600061207e868685612b21565b1561209b57508254600160201b90046001600160801b03166120a9565b6120a6848484611874565b90505b95945050505050565b8054600090600160201b90046001600160801b0316158061065b57505054600160201b90046001600160801b0316101590565b60006001600160581b038211156118705760405162461bcd60e51b815260206004820152602660248201527f53616665436173743a2076616c756520646f65736e27742066697420696e203860448201526538206269747360d01b60648201526084016106bf565b855464ffffffffff1615806121695750855464ffffffffff1642105b806121715750805b6121bc5760405162461bcd60e51b815260206004820152601c60248201527b27379036b7b234b334b1b0ba34b7b7399036b4b216b0bab1ba34b7b760211b60448201526064016106bf565b8464ffffffffff1642106122095760405162461bcd60e51b81526020600482015260146024820152734f6e6c79206675747572652061756374696f6e7360601b60448201526064016106bf565b816001600160581b0316836001600160581b03161161228d5760405162461bcd60e51b815260206004820152603a60248201527f41756374696f6e207374617274207072696365206d7573742062652067726561604482015279746572207468616e2061756374696f6e20656e6420707269636560301b60648201526084016106bf565b50845464ffffffffff9485166001600160501b031990911617600160281b9390941692909202929092176001600160501b0316600160501b6001600160581b03938416026001600160a81b031617600160a81b9190921602179055565b60006122f582612b5f565b1561230f57612305848484612b7f565b506001905061065b565b60008061231c8686612aa3565b8554909350909150610100900462ffffff168281111561235f57845460ff1962ffffff8516610100021663ffffffff199091161782841417855560019350612372565b80821061237257845460ff191660011785555b5050509392505050565b805460009064ffffffffff80821691600160281b810490911690600160a81b90046001600160581b03164283106123ef5760405162461bcd60e51b8152602060048201526017602482015276105d58dd1a5bdb881b9bdd081e595d081cdd185c9d1959604a1b60448201526064016106bf565b6000821161243a5760405162461bcd60e51b81526020600482015260186024820152774f6e6c7920636f6e666967757265642061756374696f6e7360401b60448201526064016106bf565b8454600160501b90046001600160581b03164284900383818161245f5761245f613254565b0482901c915060028485838161247757612477613254565b0684028161248757612487613254565b048161249557612495613254565b0482039150828210156124ad57509095945050505050565b5095945050505050565b6040516000602482018190526044820181905290819060640160408051601f198184030181529181526020820180516001600160e01b0316638639415b60e01b1790525190915060009081906001600160a01b038716906125199085906131a6565b6000604051808303816000865af19150503d8060008114612556576040519150601f19603f3d011682016040523d82523d6000602084013e61255b565b606091505b50915091508161257d5760405162461bcd60e51b81526004016106bf906131c2565b805160c08190036125a3575050835461ffff191661010017845550600091506106979050565b8061010003611714575050835461ffff191661010117845550600191506106979050565b8215610bd5576000806000806000806000871561271857604051638639415b60e01b8152600481018c9052602481018b905260009081906001600160a01b038c1690638639415b9060440161010060405180830381865afa158015612630573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612654919061329b565b969e50949c50909a50985091965091945090925090508115612711576040516001600160a01b038216908390600081818185875af1925050503d80600081146126b9576040519150601f19603f3d011682016040523d82523d6000602084013e6126be565b606091505b505080995050886127115760405162461bcd60e51b815260206004820181905260248201527f506c6174666f726d2050726f7669646572207061796d656e74206661696c656460448201526064016106bf565b5050612798565b604051638639415b60e01b8152600481018c9052602481018b90526001600160a01b038a1690638639415b9060440160c060405180830381865afa158015612764573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906127889190613323565b949a509298509096509450925090505b851561283f576040516001600160a01b038616908790600081818185875af1925050503d80600081146127e7576040519150601f19603f3d011682016040523d82523d6000602084013e6127ec565b606091505b5050809750508661283f5760405162461bcd60e51b815260206004820152601e60248201527f52656e6465722050726f7669646572207061796d656e74206661696c6564000060448201526064016106bf565b83156128de576040516001600160a01b038416908590600081818185875af1925050503d806000811461288e576040519150601f19603f3d011682016040523d82523d6000602084013e612893565b606091505b505080975050866128de5760405162461bcd60e51b8152602060048201526015602482015274105c9d1a5cdd081c185e5b595b9d0819985a5b1959605a1b60448201526064016106bf565b8115612985576040516001600160a01b038216908390600081818185875af1925050503d806000811461292d576040519150601f19603f3d011682016040523d82523d6000602084013e612932565b606091505b505080975050866129855760405162461bcd60e51b815260206004820152601f60248201527f4164646974696f6e616c205061796565207061796d656e74206661696c65640060448201526064016106bf565b5050505050505050505050565b60405163230448b160e01b81526001600160a01b03848116600483015283811660248301526001600160e01b0319831660448301526000919086169063230448b1906064016020604051808303816000875af11580156129f6573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906120a9919061339c565b60405163a47d29cb60e01b8152600481018490526000906001600160a01b0384169063a47d29cb90602401602060405180830381865afa158015612a62573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612a8691906133b7565b6001600160a01b0316826001600160a01b03161490509392505050565b604051630ea5613f60e01b81526004810183905260009081906001600160a01b03841690630ea5613f9060240160c060405180830381865afa158015612aed573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612b1191906133d4565b5093989297509195505050505050565b6000806000612b308686612aa3565b85549193509150610100900462ffffff1681811115612b52575014905061065b565b9091101595945050505050565b8054600090610100900462ffffff161580156106975750505460ff161590565b6000806000846001600160a01b0316630ea5613f876040518263ffffffff1660e01b8152600401612bb291815260200190565b60c060405180830381865afa158015612bcf573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190612bf391906133d4565b5050875493831463ffffffff1990941661010062ffffff85160260ff19161793909317909655979650505050505050565b6001600160a01b0381168114612c3957600080fd5b50565b600060208284031215612c4e57600080fd5b813561065b81612c24565b60008060408385031215612c6c57600080fd5b823591506020830135612c7e81612c24565b809150509250929050565b600080600060608486031215612c9e57600080fd5b8335612ca981612c24565b9250602084013591506040840135612cc081612c24565b809150509250925092565b600080600060608486031215612ce057600080fd5b833592506020840135612cf281612c24565b915060408401356001600160801b0381168114612cc057600080fd5b60008083601f840112612d2057600080fd5b5081356001600160401b03811115612d3757600080fd5b6020830191508360208260051b850101111561180057600080fd5b60008060008060408587031215612d6857600080fd5b84356001600160401b0380821115612d7f57600080fd5b612d8b88838901612d0e565b90965094506020870135915080821115612da457600080fd5b50612db187828801612d0e565b95989497509550505050565b600080600060608486031215612dd257600080fd5b833592506020840135612de481612c24565b9150604084013562ffffff81168114612cc057600080fd5b600060208284031215612e0e57600080fd5b5035919050565b600080600080600060608688031215612e2d57600080fd5b8535612e3881612c24565b945060208601356001600160401b0380821115612e5457600080fd5b612e6089838a01612d0e565b90965094506040880135915080821115612e7957600080fd5b50612e8688828901612d0e565b969995985093965092949392505050565b60005b83811015612eb2578181015183820152602001612e9a565b50506000910152565b60008151808452612ed3816020860160208601612e97565b601f01601f19169290920160200192915050565b60208152600061065b6020830184612ebb565b8415158152836020820152608060408201526000612f1b6080830185612ebb565b905060018060a01b038316606083015295945050505050565b803564ffffffffff81168114612f4957600080fd5b919050565b60008060008060008060c08789031215612f6757600080fd5b863595506020870135612f7981612c24565b9450612f8760408801612f34565b9350612f9560608801612f34565b92506080870135915060a087013590509295509295509295565b600080600060608486031215612fc457600080fd5b833592506020840135612fd681612c24565b91506040840135612cc081612c24565b64ffffffffff94851681529290931660208301526040820152606081019190915260800190565b6020808252601f908201527f5265656e7472616e637947756172643a207265656e7472616e742063616c6c00604082015260600190565b6020808252601f908201527f4e6f20636c61696d696e6720746f20746865207a65726f206164647265737300604082015260600190565b62ffffff9290921682526001600160e81b0316602082015260400190565b602080825260119082015270149958db185a5b5a5b99c819985a5b1959607a1b604082015260600190565b60208082526017908201527613585e081a5b9d9bd8d85d1a5bdb9cc81c995858da1959604a1b604082015260600190565b60006020828403121561310757600080fd5b5051919050565b634e487b7160e01b600052601160045260246000fd5b600062ffffff80831681810361313c5761313c61310e565b6001019392505050565b6020808252601e908201527f4f6e6c79206265666f726520726576656e75657320636f6c6c65637465640000604082015260600190565b634e487b7160e01b600052603260045260246000fd5b808201808211156106975761069761310e565b600082516131b8818460208701612e97565b9190910192915050565b60208082526025908201527f6765745072696d617279526576656e756553706c69747328292063616c6c2066604082015264185a5b195960da1b606082015260800190565b80820281158282048414176106975761069761310e565b818103818111156106975761069761310e565b62ffffff81811683821601908082111561324d5761324d61310e565b5092915050565b634e487b7160e01b600052601260045260246000fd5b602080825260179082015276496e76616c6964206d617820696e766f636174696f6e7360481b604082015260600190565b600080600080600080600080610100898b0312156132b857600080fd5b8851975060208901516132ca81612c24565b60408a015160608b015191985096506132e281612c24565b60808a015160a08b015191965094506132fa81612c24565b60c08a015160e08b0151919450925061331281612c24565b809150509295985092959890939650565b60008060008060008060c0878903121561333c57600080fd5b86519550602087015161334e81612c24565b60408801516060890151919650945061336681612c24565b608088015160a0890151919450925061337e81612c24565b809150509295509295509295565b80518015158114612f4957600080fd5b6000602082840312156133ae57600080fd5b61065b8261338c565b6000602082840312156133c957600080fd5b815161065b81612c24565b60008060008060008060c087890312156133ed57600080fd5b86519550602087015194506134046040880161338c565b93506134126060880161338c565b92506080870151915061342760a0880161338c565b9050929550929550929556fe1c3e74a6c6fefbaeee166b031cd2016349c6c863d5188b67c9bbd0b0dcb2e2373e587139a5e04472b0e74a6be0594ff90a9f1364a13fdc1897ad5bd3ab9ea5a6a26469706673582212207f3d79be72327ae09b9c06980e8b99087a857089fbe3510bf9938ee5886f575864736f6c63430008130033",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}


### PR DESCRIPTION
## Description of the change

Update generic minter event handlers to convert BigInt prices to strings. (also fix bug where num settleable invocations is converted from BigInt to string)

Currently, we always convert prices stored in `extraMinterDetails` json fields to strings. This ensures that we do not encounter numeric overflow when loading the json field's data in our frontend, because javascript's max number value is less than common ETH prices (1e18+).

For the new minter suite, for the DA Settlement V3 minter, a generic event is emitted that updates latest purchase price in extra minter details. This is the first instance of a price being updated via generic event in our subgraph. It causes a bug where the price is stored as a number instead of a string, because the generic event indeed communicates the price as a number. This throws a wrench in our downstream systems, including Hasura's calculation of available excess settlement funds.

The fix proposed in this PR is to convert any generic number values whose key contains substring "price" or "Price" to a string. This fixes the issue described above, because the key is named `"currentSettledPrice"`.

In addition to to `currentSettledPrice`, `numSettleableInvocations` was incorrectly being stored as a string by our handler, which is inconsistent with behavior on legacy settlement minters. This is also fixed as part of this PR.

## Alternatives considered

A different heuristic could be used to determine if a generic event's value should be converted to a string, and a few were considered:
- Value-based: BigInt values greater than a certain value could be converted to a string. Issue with this is that low prices are possible, and having uncertainty downstream as to what a key's value type will be is not a good state.
- List of keys to be converted: Instead of looking for the phrase "price" in key name, we could check against an array of keys and convert if the key is in the array. This seems like a valid solution, but seemed a little more complex than the selected implementation. Open to feedback here for sure though!

## Test

- e2e test logic was added to expose this issue with a test failure prior to implementing the fix
- the updated handler logic allows the e2e tests to pass ✅ 

## Other

Supplemental ABIs are added for e2e testing, because the latest contracts npm package release has a V3 minter that doesn't emit a proper event for `currentSettledPrice` in this exact situation 🤣 