### PR TITLE
Add shared minter suite to Goerli staging

### DIFF
--- a/config/goerli-staging.json
+++ b/config/goerli-staging.json
@@ -195,6 +195,167 @@
       "startBlock": 8608211
     }
   ],
+  "sharedMinterFilterContracts": [
+    {
+      "address": "0xcF5FD12fec18D4A714Fe701345cefD3Aafb71559",
+      "name": "Goerli staging shared minter filter contract",
+      "startBlock": 9676302
+    }
+  ],
+  "iSharedMinterV0Contracts": [
+    {
+      "address": "0x1F3DF1E177B419bC46705F8138809893497aAadF",
+      "name": "Goerli staging shared minter: MinterSetPriceV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0xED081222a01d33ff751F656aD45342F08089776c",
+      "name": "Goerli staging shared minter: MinterSetPriceERC20V5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x8Ade3fF97302BaEBE15C540e5de1abD6427A5243",
+      "name": "Goerli staging shared minter: MinterSetPriceHolderV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x6e762e7Cb478b8C2C6424d8bBfb30F782b4A445d",
+      "name": "Goerli staging shared minter: MinterSetPriceMerkleV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x802e6209C6Acb7B0F87aFb687E61543E3fB57DcA",
+      "name": "Goerli staging shared minter: MinterSetPricePolyptychV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x3CB4674f510966E1105eBe5d6c5F0b7a744F3272",
+      "name": "Goerli staging shared minter: MinterSetPricePolyptychERC20V5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x431BCE8b28Bdd25c0a8843aC4a15F4E78537C1b4",
+      "name": "Goerli staging shared minter: MinterDAExpV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x6DF4DcdF43023C882287afA78aDd00672e69BCbA",
+      "name": "Goerli staging shared minter: MinterDALinV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0xD56B16436B551d9a4b28d2f9A288688d7801f316",
+      "name": "Goerli staging shared minter: MinterDAExpSettlementV3",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x448b4F7a0981beCd5e3079088413c8E48D6DF39b",
+      "name": "Goerli staging shared minter: MinterDAExpHolderV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x2054C63D49EF5b77739E4DC2e978c5506Ae1b883",
+      "name": "Goerli staging shared minter: MinterDALinHolderV5",
+      "startBlock": 9676302
+    }
+  ],
+  "iSharedMerkleContracts": [
+    {
+      "address": "0x6e762e7Cb478b8C2C6424d8bBfb30F782b4A445d",
+      "name": "Goerli staging shared minter: MinterSetPriceMerkleV5",
+      "startBlock": 9676302
+    }
+  ],
+  "iSharedHolderContracts": [
+    {
+      "address": "0x8Ade3fF97302BaEBE15C540e5de1abD6427A5243",
+      "name": "Goerli staging shared minter: MinterSetPriceHolderV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x802e6209C6Acb7B0F87aFb687E61543E3fB57DcA",
+      "name": "Goerli staging shared minter: MinterSetPricePolyptychV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x3CB4674f510966E1105eBe5d6c5F0b7a744F3272",
+      "name": "Goerli staging shared minter: MinterSetPricePolyptychERC20V5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x448b4F7a0981beCd5e3079088413c8E48D6DF39b",
+      "name": "Goerli staging shared minter: MinterDAExpHolderV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x2054C63D49EF5b77739E4DC2e978c5506Ae1b883",
+      "name": "Goerli staging shared minter: MinterDALinHolderV5",
+      "startBlock": 9676302
+    }
+  ],
+  "iSharedDAContracts": [
+    {
+      "address": "0x431BCE8b28Bdd25c0a8843aC4a15F4E78537C1b4",
+      "name": "Goerli staging shared minter: MinterDAExpV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x6DF4DcdF43023C882287afA78aDd00672e69BCbA",
+      "name": "Goerli staging shared minter: MinterDALinV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0xD56B16436B551d9a4b28d2f9A288688d7801f316",
+      "name": "Goerli staging shared minter: MinterDAExpSettlementV3",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x448b4F7a0981beCd5e3079088413c8E48D6DF39b",
+      "name": "Goerli staging shared minter: MinterDAExpHolderV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x2054C63D49EF5b77739E4DC2e978c5506Ae1b883",
+      "name": "Goerli staging shared minter: MinterDALinHolderV5",
+      "startBlock": 9676302
+    }
+  ],
+  "iSharedDAExpContracts": [
+    {
+      "address": "0x431BCE8b28Bdd25c0a8843aC4a15F4E78537C1b4",
+      "name": "Goerli staging shared minter: MinterDAExpV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0xD56B16436B551d9a4b28d2f9A288688d7801f316",
+      "name": "Goerli staging shared minter: MinterDAExpSettlementV3",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x448b4F7a0981beCd5e3079088413c8E48D6DF39b",
+      "name": "Goerli staging shared minter: MinterDAExpHolderV5",
+      "startBlock": 9676302
+    }
+  ],
+  "iSharedDALinContracts": [
+    {
+      "address": "0x6DF4DcdF43023C882287afA78aDd00672e69BCbA",
+      "name": "Goerli staging shared minter: MinterDALinV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x2054C63D49EF5b77739E4DC2e978c5506Ae1b883",
+      "name": "Goerli staging shared minter: MinterDALinHolderV5",
+      "startBlock": 9676302
+    }
+  ],
+  "iSharedDAExpSettlementContracts": [
+    {
+      "address": "0xD56B16436B551d9a4b28d2f9A288688d7801f316",
+      "name": "Goerli staging shared minter: MinterDAExpSettlementV3",
+      "startBlock": 9676302
+    }
+  ],
   "minterFilterV0Contracts": [
     {
       "address": "0xdB2f4B10Bb32D1E0cfD9468bE48C1C8c63Bc0DDD",
@@ -455,6 +616,11 @@
       "address": "0xEa698596b6009A622C3eD00dD5a8b5d1CAE4fC36",
       "name": "Goerli staging engine registry contract",
       "startBlock": 8178162
+    },
+    {
+      "address": "0xddFfc62A975f7EBA75A877a0535755ceA18232C9",
+      "name": "Shared Goerli staging engine registry contract",
+      "startBlock": 9676302
     }
   ],
   "startBlock": 7011002


### PR DESCRIPTION
Do not merge until #247 is merged into main.

## Description of the change

Add new shared minter suite to goerli staging subgraph config.

These are going to be actively used for initial testing of the shared minter suite on staging, now that dev testing has concluded. Note that the smart contracts have not yet been audited, so mainnet deployments will have to wait.

related to: https://github.com/ArtBlocks/artblocks-contracts/pull/1026