### PR TITLE
Snapshot settlement withdrawal data

### DIFF
--- a/src/i-shared-da-exp-settlement-mapping.ts
+++ b/src/i-shared-da-exp-settlement-mapping.ts
@@ -28,6 +28,9 @@ import { Receipt } from "../generated/schema";
 
 // project-level configuration events
 
+// note: state at the time of updating auctionRevenuesCollected to true is performed
+// in an after-update hook in the handler for the generic event
+
 /**
  * Handles the event that updates the Receipt of a collector on a project.
  * @param event The event carrying the updated Receipt data.

--- a/src/legacy-minter-suite-mapping.ts
+++ b/src/legacy-minter-suite-mapping.ts
@@ -51,7 +51,6 @@ import {
 } from "../generated/MinterDAExpSettlement/IFilteredMinterDAExpSettlementV1";
 
 import {
-  Minter,
   Project,
   ProjectMinterConfiguration,
   Receipt
@@ -66,7 +65,8 @@ import {
   loadOrCreateReceipt,
   generateProjectIdNumberFromTokenIdNumber,
   getMinterExtraMinterDetailsTypedMap,
-  getCoreContractAddressFromLegacyMinter
+  getCoreContractAddressFromLegacyMinter,
+  snapshotStateAtSettlementRevenueWithdrawal
 } from "./helpers";
 
 import {
@@ -1113,6 +1113,13 @@ export function handleArtistAndAdminRevenuesWithdrawn(
     "auctionRevenuesCollected",
     true,
     minterProjectAndConfig.projectMinterConfiguration
+  );
+
+  // snapshot important state at time of revenue withdrawal
+  snapshotStateAtSettlementRevenueWithdrawal(
+    minterProjectAndConfig.projectMinterConfiguration,
+    minterProjectAndConfig.project,
+    event.transaction.hash.toHexString()
   );
 
   minterProjectAndConfig.project.updatedAt = event.block.timestamp;

--- a/tests/e2e/runner/__tests__/minter-suite-v2/i-filtered-shared-da-exp-settlement.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/i-filtered-shared-da-exp-settlement.test.ts
@@ -201,8 +201,6 @@ describe("iSharedMinterDAExpSettlement event handling", () => {
         targetBasePrice.toString()
       );
       // snapshot of relevant state at time of withdrawal should be available
-      // TODO remove logging
-      console.log(extraMinterDetails2);
       expect(
         extraMinterDetails2.revenueWithdrawalSnapshot_widthdrawalTxHash
       ).toBe(withdrawalTx.hash);

--- a/tests/e2e/runner/__tests__/minter-suite-v2/i-filtered-shared-da-exp-settlement.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/i-filtered-shared-da-exp-settlement.test.ts
@@ -182,7 +182,7 @@ describe("iSharedMinterDAExpSettlement event handling", () => {
 
       // PART 2: Artist withdraws revenues, and settled price is updated, remains a string
       await new Promise((f) => setTimeout(f, 22500)); // wait the length of the auction, 22.5 seconds
-      await minterDAExpSettlementV3Contract
+      const withdrawalTx = await minterDAExpSettlementV3Contract
         .connect(artist)
         .withdrawArtistAndAdminRevenues(
           currentProjectNumber,
@@ -200,6 +200,37 @@ describe("iSharedMinterDAExpSettlement event handling", () => {
       expect(extraMinterDetails2.currentSettledPrice).toBe(
         targetBasePrice.toString()
       );
+      // snapshot of relevant state at time of withdrawal should be available
+      // TODO remove logging
+      console.log(extraMinterDetails2);
+      expect(
+        extraMinterDetails2.revenueWithdrawalSnapshot_widthdrawalTxHash
+      ).toBe(withdrawalTx.hash);
+      expect(
+        extraMinterDetails2.revenueWithdrawalSnapshot_renderProviderAddress
+      ).toBe(deployer.address.toLowerCase());
+      expect(
+        extraMinterDetails2.revenueWithdrawalSnapshot_renderProviderPercentage
+      ).toBe(10);
+      // expect no platform provider info because tested core is a Flagship (not Engine)
+      expect(
+        extraMinterDetails2.revenueWithdrawalSnapshot_platformProviderAddress
+      ).toBeUndefined();
+      expect(
+        extraMinterDetails2.revenueWithdrawalSnapshot_platformProviderPercentage
+      ).toBeUndefined();
+      expect(extraMinterDetails2.revenueWithdrawalSnapshot_artistAddress).toBe(
+        artist.address.toLowerCase()
+      );
+      // expect no additional payee address because artist never configured it
+      expect(
+        extraMinterDetails2.revenueWithdrawalSnapshot_additionalPayeeAddress
+      ).toBeUndefined();
+      // expect additional payee percentage to always be defined, zero in this case
+      // because artist never configured it
+      expect(
+        extraMinterDetails2.revenueWithdrawalSnapshot_additionalPayeePercentage
+      ).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Description of the change

Snapshot Settlement minter withdrawal data into subgraph's extraMinterDetails to meet data team requirements.

This updates legacy and shared Settlement minter handlers to snapshot the following data at the point in time that the revenue withdrawal transaction is observed:
- `revenueWithdrawalSnapshot_widthdrawalTxHash`: withdrawal transaction hash
- `revenueWithdrawalSnapshot_renderProviderAddress`: render provider address
- `revenueWithdrawalSnapshot_renderProviderPercentage`: render provider percentage
- `revenueWithdrawalSnapshot_platformProviderAddress`: platform provider address (only populated if engine contract)
- `revenueWithdrawalSnapshot_platformProviderPercentage`: platform provider percentage (only populated if engine contract)
- `revenueWithdrawalSnapshot_artistAddress`: artist address
- `revenueWithdrawalSnapshot_additionalPayeeAddress`: additional payee address (only populated if an additional payee address is defined for the project)
- `revenueWithdrawalSnapshot_additionalPayeePercentage`: additional payee's percentage of artist revenues. Always populated, and between 0 and 100, in percent.

## Tests
- e2e test logic is added to check that this is WAI for the new shared minter suite
- Legacy tests are not added for this functionality
  - spot-checks may be performed when this is deployed to dev
  - a common helper function is being used, so coverage of helper function logic is obtained in the added e2e test


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205452553386821