### PR TITLE
Changes from shared minter suite review

### DIFF
--- a/abis-supplemental/IDependencyRegistryV0.json
+++ b/abis-supplemental/IDependencyRegistryV0.json
@@ -1,0 +1,350 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "IDependencyRegistryV0",
+  "sourceName": "contracts/interfaces/v0.8.x/IDependencyRegistryV0.sol",
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_dependencyType",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "_preferredCDN",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "_preferredRepository",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "_referenceWebsite",
+          "type": "string"
+        }
+      ],
+      "name": "DependencyAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_dependencyType",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_additionalCDNIndex",
+          "type": "uint256"
+        }
+      ],
+      "name": "DependencyAdditionalCDNRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_dependencyType",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "_additionalCDN",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_additionalCDNIndex",
+          "type": "uint256"
+        }
+      ],
+      "name": "DependencyAdditionalCDNUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_dependencyType",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_additionalRepositoryIndex",
+          "type": "uint256"
+        }
+      ],
+      "name": "DependencyAdditionalRepositoryRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_dependencyType",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "_additionalRepository",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_additionalRepositoryIndex",
+          "type": "uint256"
+        }
+      ],
+      "name": "DependencyAdditionalRepositoryUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_dependencyType",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "_preferredCDN",
+          "type": "string"
+        }
+      ],
+      "name": "DependencyPreferredCDNUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_dependencyType",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "_preferredRepository",
+          "type": "string"
+        }
+      ],
+      "name": "DependencyPreferredRepositoryUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_dependencyType",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "_referenceWebsite",
+          "type": "string"
+        }
+      ],
+      "name": "DependencyReferenceWebsiteUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_dependencyType",
+          "type": "bytes32"
+        }
+      ],
+      "name": "DependencyRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_dependencyType",
+          "type": "bytes32"
+        }
+      ],
+      "name": "DependencyScriptUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContractAddress",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_dependencyType",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ProjectDependencyTypeOverrideAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContractAddress",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "ProjectDependencyTypeOverrideRemoved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContractAddress",
+          "type": "address"
+        }
+      ],
+      "name": "SupportedCoreContractAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_coreContractAddress",
+          "type": "address"
+        }
+      ],
+      "name": "SupportedCoreContractRemoved",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_dependencyType",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_index",
+          "type": "uint256"
+        }
+      ],
+      "name": "getDependencyScript",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_dependencyType",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_index",
+          "type": "uint256"
+        }
+      ],
+      "name": "getDependencyScriptBytecodeAddress",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "_dependencyType",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getDependencyScriptCount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x",
+  "deployedBytecode": "0x",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/abis/_include-artblocks-abis.txt
+++ b/abis/_include-artblocks-abis.txt
@@ -37,3 +37,15 @@ ISharedMinterHolderV0
 ISharedMinterMerkleV0
 ISharedMinterSEAV0
 ISharedMinterV0
+DAExpLib
+DALib
+DALinLib
+GenericMinterEventsLib
+MaxInvocationsLib
+MerkleLib
+PolyptychLib
+SEALib
+SetPriceLib
+SettlementExpLib
+SplitFundsLib
+TokenHolderLib

--- a/config/generic.json
+++ b/config/generic.json
@@ -60,42 +60,57 @@
       "address": ""
     }
   ],
-  "iSharedMinterV0Contracts": [
+  "genericMinterEventsLibContracts": [
     {
       "address": ""
     }
   ],
-  "iSharedMerkleContracts": [
+  "splitFundsLibContracts": [
     {
       "address": ""
     }
   ],
-  "iSharedHolderContracts": [
+  "setPriceLibContracts": [
     {
       "address": ""
     }
   ],
-  "iSharedSEAContracts": [
+  "maxInvocationsLibContracts": [
     {
       "address": ""
     }
   ],
-  "iSharedDAContracts": [
+  "merkleLibContracts": [
     {
       "address": ""
     }
   ],
-  "iSharedDAExpContracts": [
+  "holderLibContracts": [
     {
       "address": ""
     }
   ],
-  "iSharedDALinContracts": [
+  "SEALibContracts": [
     {
       "address": ""
     }
   ],
-  "iSharedDAExpSettlementContracts": [
+  "DALibContracts": [
+    {
+      "address": ""
+    }
+  ],
+  "DAExpLibContracts": [
+    {
+      "address": ""
+    }
+  ],
+  "DALinLibContracts": [
+    {
+      "address": ""
+    }
+  ],
+  "settlementExpLibContracts": [
     {
       "address": ""
     }

--- a/config/goerli-dev.json
+++ b/config/goerli-dev.json
@@ -86,7 +86,7 @@
       "startBlock": 9602240
     }
   ],
-  "iSharedMinterV0Contracts": [
+  "genericMinterEventsLibContracts": [
     {
       "address": "0x12b87e163aDDA0E3A08F6181eE7F95fb6CA7A558",
       "name": "Goerli dev shared minter: MinterSetPriceV5",
@@ -148,14 +148,120 @@
       "startBlock": 9602240
     }
   ],
-  "iSharedMerkleContracts": [
+  "splitFundsLibContracts": [
+    {
+      "address": "0x5e16d4493f70568dE483F80d47f33ae1cDbD1b78",
+      "name": "Goerli dev shared minter: MinterSetPriceERC20V5",
+      "startBlock": 9602240
+    },
+    {
+      "address": "0xD4c85aa7beE5B5A4541ba5c873A54879140F9A2c",
+      "name": "Goerli dev shared minter: MinterSetPricePolyptychERC20V5",
+      "startBlock": 9602240
+    }
+  ],
+  "setPriceLibContracts": [
+    {
+      "address": "0x12b87e163aDDA0E3A08F6181eE7F95fb6CA7A558",
+      "name": "Goerli dev shared minter: MinterSetPriceV5",
+      "startBlock": 9602240
+    },
+    {
+      "address": "0x5e16d4493f70568dE483F80d47f33ae1cDbD1b78",
+      "name": "Goerli dev shared minter: MinterSetPriceERC20V5",
+      "startBlock": 9602240
+    },
+    {
+      "address": "0x8FF22d210Db7304214Ec99225fBab325bb0Aaf91",
+      "name": "Goerli dev shared minter: MinterSetPriceHolderV5",
+      "startBlock": 9602240
+    },
+    {
+      "address": "0x6cc81bAF5f9a2266B0BE1334588e246C3A79996A",
+      "name": "Goerli dev shared minter: MinterSetPriceMerkleV5",
+      "startBlock": 9602240
+    },
+    {
+      "address": "0xB6A24AFAE90bd3A61F0a15De030092a662B4BEd4",
+      "name": "Goerli dev shared minter: MinterSetPricePolyptychV5",
+      "startBlock": 9602240
+    },
+    {
+      "address": "0xD4c85aa7beE5B5A4541ba5c873A54879140F9A2c",
+      "name": "Goerli dev shared minter: MinterSetPricePolyptychERC20V5",
+      "startBlock": 9602240
+    }
+  ],
+  "maxInvocationsLibContracts": [
+    {
+      "address": "0x12b87e163aDDA0E3A08F6181eE7F95fb6CA7A558",
+      "name": "Goerli dev shared minter: MinterSetPriceV5",
+      "startBlock": 9602240
+    },
+    {
+      "address": "0x5e16d4493f70568dE483F80d47f33ae1cDbD1b78",
+      "name": "Goerli dev shared minter: MinterSetPriceERC20V5",
+      "startBlock": 9602240
+    },
+    {
+      "address": "0x8FF22d210Db7304214Ec99225fBab325bb0Aaf91",
+      "name": "Goerli dev shared minter: MinterSetPriceHolderV5",
+      "startBlock": 9602240
+    },
+    {
+      "address": "0x6cc81bAF5f9a2266B0BE1334588e246C3A79996A",
+      "name": "Goerli dev shared minter: MinterSetPriceMerkleV5",
+      "startBlock": 9602240
+    },
+    {
+      "address": "0xB6A24AFAE90bd3A61F0a15De030092a662B4BEd4",
+      "name": "Goerli dev shared minter: MinterSetPricePolyptychV5",
+      "startBlock": 9602240
+    },
+    {
+      "address": "0xD4c85aa7beE5B5A4541ba5c873A54879140F9A2c",
+      "name": "Goerli dev shared minter: MinterSetPricePolyptychERC20V5",
+      "startBlock": 9602240
+    },
+    {
+      "address": "0x35e5D5D74a7347989D4C1BA444b980FacA06EFeA",
+      "name": "Goerli dev shared minter: MinterDAExpV5",
+      "startBlock": 9602240
+    },
+    {
+      "address": "0x18bcD7F2b3c6904e6D2EAf0da3CC94C4E2ACb52c",
+      "name": "Goerli dev shared minter: MinterDALinV5",
+      "startBlock": 9602240
+    },
+    {
+      "address": "0xe3002BB7Bfd2ff61Ea1e9823e4723e4163C6BE72",
+      "name": "[bugged] Goerli dev shared minter: MinterDAExpSettlementV3",
+      "startBlock": 9602240
+    },
+    {
+      "address": "0xffFf56434Eb696f51775eDC7c9472A4046053c97",
+      "name": "Goerli dev shared minter: MinterDAExpSettlementV3",
+      "startBlock": 9615257
+    },
+    {
+      "address": "0xc0a94bE251af03db788dced955C534467e90EdB1",
+      "name": "Goerli dev shared minter: MinterDAExpHolderV5",
+      "startBlock": 9602240
+    },
+    {
+      "address": "0x2D9B947c1f1E36d7f881D415A44598Ed9ff15b65",
+      "name": "Goerli dev shared minter: MinterDALinHolderV5",
+      "startBlock": 9602240
+    }
+  ],
+  "merkleLibContracts": [
     {
       "address": "0x6cc81bAF5f9a2266B0BE1334588e246C3A79996A",
       "name": "Goerli dev shared minter: MinterSetPriceMerkleV5",
       "startBlock": 9602240
     }
   ],
-  "iSharedHolderContracts": [
+  "holderLibContracts": [
     {
       "address": "0x8FF22d210Db7304214Ec99225fBab325bb0Aaf91",
       "name": "Goerli dev shared minter: MinterSetPriceHolderV5",
@@ -182,7 +288,7 @@
       "startBlock": 9602240
     }
   ],
-  "iSharedDAContracts": [
+  "DALibContracts": [
     {
       "address": "0x35e5D5D74a7347989D4C1BA444b980FacA06EFeA",
       "name": "Goerli dev shared minter: MinterDAExpV5",
@@ -214,7 +320,7 @@
       "startBlock": 9602240
     }
   ],
-  "iSharedDAExpContracts": [
+  "DAExpLibContracts": [
     {
       "address": "0x35e5D5D74a7347989D4C1BA444b980FacA06EFeA",
       "name": "Goerli dev shared minter: MinterDAExpV5",
@@ -236,7 +342,7 @@
       "startBlock": 9602240
     }
   ],
-  "iSharedDALinContracts": [
+  "DALinLibContracts": [
     {
       "address": "0x18bcD7F2b3c6904e6D2EAf0da3CC94C4E2ACb52c",
       "name": "Goerli dev shared minter: MinterDALinV5",
@@ -248,7 +354,7 @@
       "startBlock": 9602240
     }
   ],
-  "iSharedDAExpSettlementContracts": [
+  "settlementExpLibContracts": [
     {
       "address": "0xe3002BB7Bfd2ff61Ea1e9823e4723e4163C6BE72",
       "name": "[bugged] Goerli dev shared minter: MinterDAExpSettlementV3",

--- a/config/goerli-staging.json
+++ b/config/goerli-staging.json
@@ -202,7 +202,7 @@
       "startBlock": 9676302
     }
   ],
-  "iSharedMinterV0Contracts": [
+  "genericMinterEventsLibContracts": [
     {
       "address": "0x1F3DF1E177B419bC46705F8138809893497aAadF",
       "name": "Goerli staging shared minter: MinterSetPriceV5",
@@ -259,14 +259,115 @@
       "startBlock": 9676302
     }
   ],
-  "iSharedMerkleContracts": [
+  "splitFundsLibContracts": [
+    {
+      "address": "0xED081222a01d33ff751F656aD45342F08089776c",
+      "name": "Goerli staging shared minter: MinterSetPriceERC20V5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x3CB4674f510966E1105eBe5d6c5F0b7a744F3272",
+      "name": "Goerli staging shared minter: MinterSetPricePolyptychERC20V5",
+      "startBlock": 9676302
+    }
+  ],
+  "setPriceLibContracts": [
+    {
+      "address": "0x1F3DF1E177B419bC46705F8138809893497aAadF",
+      "name": "Goerli staging shared minter: MinterSetPriceV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0xED081222a01d33ff751F656aD45342F08089776c",
+      "name": "Goerli staging shared minter: MinterSetPriceERC20V5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x8Ade3fF97302BaEBE15C540e5de1abD6427A5243",
+      "name": "Goerli staging shared minter: MinterSetPriceHolderV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x6e762e7Cb478b8C2C6424d8bBfb30F782b4A445d",
+      "name": "Goerli staging shared minter: MinterSetPriceMerkleV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x802e6209C6Acb7B0F87aFb687E61543E3fB57DcA",
+      "name": "Goerli staging shared minter: MinterSetPricePolyptychV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x3CB4674f510966E1105eBe5d6c5F0b7a744F3272",
+      "name": "Goerli staging shared minter: MinterSetPricePolyptychERC20V5",
+      "startBlock": 9676302
+    }
+  ],
+  "maxInvocationsLibContracts": [
+    {
+      "address": "0x1F3DF1E177B419bC46705F8138809893497aAadF",
+      "name": "Goerli staging shared minter: MinterSetPriceV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0xED081222a01d33ff751F656aD45342F08089776c",
+      "name": "Goerli staging shared minter: MinterSetPriceERC20V5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x8Ade3fF97302BaEBE15C540e5de1abD6427A5243",
+      "name": "Goerli staging shared minter: MinterSetPriceHolderV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x6e762e7Cb478b8C2C6424d8bBfb30F782b4A445d",
+      "name": "Goerli staging shared minter: MinterSetPriceMerkleV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x802e6209C6Acb7B0F87aFb687E61543E3fB57DcA",
+      "name": "Goerli staging shared minter: MinterSetPricePolyptychV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x3CB4674f510966E1105eBe5d6c5F0b7a744F3272",
+      "name": "Goerli staging shared minter: MinterSetPricePolyptychERC20V5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x431BCE8b28Bdd25c0a8843aC4a15F4E78537C1b4",
+      "name": "Goerli staging shared minter: MinterDAExpV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x6DF4DcdF43023C882287afA78aDd00672e69BCbA",
+      "name": "Goerli staging shared minter: MinterDALinV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0xD56B16436B551d9a4b28d2f9A288688d7801f316",
+      "name": "Goerli staging shared minter: MinterDAExpSettlementV3",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x448b4F7a0981beCd5e3079088413c8E48D6DF39b",
+      "name": "Goerli staging shared minter: MinterDAExpHolderV5",
+      "startBlock": 9676302
+    },
+    {
+      "address": "0x2054C63D49EF5b77739E4DC2e978c5506Ae1b883",
+      "name": "Goerli staging shared minter: MinterDALinHolderV5",
+      "startBlock": 9676302
+    }
+  ],
+  "merkleLibContracts": [
     {
       "address": "0x6e762e7Cb478b8C2C6424d8bBfb30F782b4A445d",
       "name": "Goerli staging shared minter: MinterSetPriceMerkleV5",
       "startBlock": 9676302
     }
   ],
-  "iSharedHolderContracts": [
+  "holderLibContracts": [
     {
       "address": "0x8Ade3fF97302BaEBE15C540e5de1abD6427A5243",
       "name": "Goerli staging shared minter: MinterSetPriceHolderV5",
@@ -293,7 +394,7 @@
       "startBlock": 9676302
     }
   ],
-  "iSharedDAContracts": [
+  "DALibContracts": [
     {
       "address": "0x431BCE8b28Bdd25c0a8843aC4a15F4E78537C1b4",
       "name": "Goerli staging shared minter: MinterDAExpV5",
@@ -320,7 +421,7 @@
       "startBlock": 9676302
     }
   ],
-  "iSharedDAExpContracts": [
+  "DAExpLibContracts": [
     {
       "address": "0x431BCE8b28Bdd25c0a8843aC4a15F4E78537C1b4",
       "name": "Goerli staging shared minter: MinterDAExpV5",
@@ -337,7 +438,7 @@
       "startBlock": 9676302
     }
   ],
-  "iSharedDALinContracts": [
+  "DALinLibContracts": [
     {
       "address": "0x6DF4DcdF43023C882287afA78aDd00672e69BCbA",
       "name": "Goerli staging shared minter: MinterDALinV5",
@@ -349,7 +450,7 @@
       "startBlock": 9676302
     }
   ],
-  "iSharedDAExpSettlementContracts": [
+  "settlementExpLibContracts": [
     {
       "address": "0xD56B16436B551d9a4b28d2f9A288688d7801f316",
       "name": "Goerli staging shared minter: MinterDAExpSettlementV3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "generate:abis": "cd ./abis && ./_generate-abis.sh && cd ../"
   },
   "dependencies": {
-    "@artblocks/contracts": "1.0.4",
+    "@artblocks/contracts": "../artblocks-contracts/packages/contracts/",
     "@assemblyscript/loader": "^0.19.22",
     "@graphprotocol/graph-cli": "^0.56.0",
     "@graphprotocol/graph-ts": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "generate:abis": "cd ./abis && ./_generate-abis.sh && cd ../"
   },
   "dependencies": {
-    "@artblocks/contracts": "../artblocks-contracts/packages/contracts/",
+    "@artblocks/contracts": "1.1.0",
     "@assemblyscript/loader": "^0.19.22",
     "@graphprotocol/graph-cli": "^0.56.0",
     "@graphprotocol/graph-ts": "^0.27.0",

--- a/src/da-lib-mapping.ts
+++ b/src/da-lib-mapping.ts
@@ -1,6 +1,6 @@
-import { ResetAuctionDetails } from "../generated/ISharedDA/ISharedMinterDAV0";
+import { ResetAuctionDetails } from "../generated/DALib/DALib";
 
-import { loadOrCreateMinterProjectAndConfigIfProject } from "./i-shared-minter-mapping";
+import { loadOrCreateMinterProjectAndConfigIfProject } from "./generic-minter-events-lib-mapping";
 
 import { updateProjectIfMinterConfigIsActive } from "./helpers";
 
@@ -19,8 +19,8 @@ import { removeProjectMinterConfigExtraMinterDetailsEntry } from "./extra-minter
 export function handleResetAuctionDetails(event: ResetAuctionDetails): void {
   const minterProjectAndConfig = loadOrCreateMinterProjectAndConfigIfProject(
     event.address, // minter
-    event.params._coreContract,
-    event.params._projectId,
+    event.params.coreContract,
+    event.params.projectId,
     event.block.timestamp
   );
   if (!minterProjectAndConfig) {

--- a/src/max-invocations-lib-mapping.ts
+++ b/src/max-invocations-lib-mapping.ts
@@ -1,0 +1,41 @@
+import { BigInt, log, Address } from "@graphprotocol/graph-ts";
+import { Project } from "../generated/schema";
+
+import { ProjectMaxInvocationsLimitUpdated } from "../generated/MaxInvocationsLib/MaxInvocationsLib";
+
+import { updateProjectIfMinterConfigIsActive } from "./helpers";
+
+import { loadOrCreateMinterProjectAndConfigIfProject } from "./generic-minter-events-lib-mapping";
+
+///////////////////////////////////////////////////////////////////////////////
+// EVENT HANDLERS start here
+///////////////////////////////////////////////////////////////////////////////
+
+export function handleProjectMaxInvocationsLimitUpdated(
+  event: ProjectMaxInvocationsLimitUpdated
+): void {
+  const minterProjectAndConfig = loadOrCreateMinterProjectAndConfigIfProject(
+    event.address, // minter
+    event.params.coreContract,
+    event.params.projectId,
+    event.block.timestamp
+  );
+  if (!minterProjectAndConfig) {
+    // project wasn't found, warning already logged in helper function
+    return;
+  }
+  const projectMinterConfig = minterProjectAndConfig.projectMinterConfiguration;
+  projectMinterConfig.maxInvocations = event.params.maxInvocations;
+  projectMinterConfig.save();
+
+  // induce sync if the project minter configuration is the active one
+  updateProjectIfMinterConfigIsActive(
+    minterProjectAndConfig.project,
+    projectMinterConfig,
+    event.block.timestamp
+  );
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// EVENT HANDLERS end here
+///////////////////////////////////////////////////////////////////////////////

--- a/src/merkle-lib-mapping.ts
+++ b/src/merkle-lib-mapping.ts
@@ -1,7 +1,7 @@
 import {
   DefaultMaxInvocationsPerAddress,
   DelegationRegistryUpdated
-} from "../generated/ISharedMerkle/ISharedMinterMerkleV0";
+} from "../generated/MerkleLib/MerkleLib";
 
 import { loadOrCreateMinter } from "./helpers";
 
@@ -12,7 +12,7 @@ import { setMinterExtraMinterDetailsValue } from "./extra-minter-details-helpers
 ///////////////////////////////////////////////////////////////////////////////
 
 /**
- * Handles the event that updates the default max invocations per address. 
+ * Handles the event that updates the default max invocations per address.
  * Loads or creates the minter, updates the minter's details, and refreshes
  * the minter's timestamp to induce a sync.
  * @param event The event containing the updated max invocations per address.
@@ -36,7 +36,7 @@ export function handleDefaultMaxInvocationsPerAddress(
 }
 
 /**
- * Handles the event that updates the delegation registry address. 
+ * Handles the event that updates the delegation registry address.
  * Loads or creates the minter, updates the minter's details, and refreshes
  * the minter's timestamp to induce a sync.
  * @param event The event containing the updated delegation registry address.

--- a/src/sea-lib-mapping.ts
+++ b/src/sea-lib-mapping.ts
@@ -11,9 +11,9 @@ import {
   ResetAuctionDetails,
   ProjectNextTokenUpdated,
   ProjectNextTokenEjected
-} from "../generated/ISharedSEA/ISharedMinterSEAV0";
+} from "../generated/SEALib/SEALib";
 
-import { loadOrCreateMinterProjectAndConfigIfProject } from "./i-shared-minter-mapping";
+import { loadOrCreateMinterProjectAndConfigIfProject } from "./generic-minter-events-lib-mapping";
 
 import {
   loadOrCreateMinter,

--- a/src/set-price-lib-mapping.ts
+++ b/src/set-price-lib-mapping.ts
@@ -1,0 +1,62 @@
+import { BigInt, log, Address } from "@graphprotocol/graph-ts";
+import { Project } from "../generated/schema";
+
+import { PricePerTokenUpdated } from "../generated/SetPriceLib/SetPriceLib";
+
+import {
+  loadOrCreateMinter,
+  loadOrCreateProjectMinterConfiguration,
+  updateProjectIfMinterConfigIsActive
+} from "./helpers";
+
+import { loadProjectByCoreAddressAndProjectNumber } from "./generic-minter-events-lib-mapping";
+
+///////////////////////////////////////////////////////////////////////////////
+// EVENT HANDLERS start here
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Handles the update of price per token in wei. Attempts to load associated project and
+ * its minter configuration, then updates base price in the configuration.
+ * @param event The event carrying new price per token in wei
+ */
+export function handlePricePerTokenUpdated(event: PricePerTokenUpdated): void {
+  // attempt to load project, if it doesn't exist, log a warning and return
+  // @dev we don't support or allow minters to pre-configure projects that do
+  // not yet exist
+  const project = loadProjectByCoreAddressAndProjectNumber(
+    event.params.coreContract,
+    event.params.projectId
+  );
+  if (!project) {
+    log.warning("Project {} not found for core contract {}", [
+      event.params.projectId.toString(),
+      event.params.coreContract.toHexString()
+    ]);
+    return;
+  }
+
+  // load minter
+  const minter = loadOrCreateMinter(event.address, event.block.timestamp);
+
+  // load or create project minter configuration
+  const projectMinterConfig = loadOrCreateProjectMinterConfiguration(
+    project,
+    minter
+  );
+
+  projectMinterConfig.basePrice = event.params.pricePerToken;
+  projectMinterConfig.priceIsConfigured = true;
+  projectMinterConfig.save();
+
+  // induce sync if the project minter configuration is the active one
+  updateProjectIfMinterConfigIsActive(
+    project,
+    projectMinterConfig,
+    event.block.timestamp
+  );
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// EVENT HANDLERS end here
+///////////////////////////////////////////////////////////////////////////////

--- a/src/set-price-lib-mapping.ts
+++ b/src/set-price-lib-mapping.ts
@@ -16,9 +16,9 @@ import { loadProjectByCoreAddressAndProjectNumber } from "./generic-minter-event
 ///////////////////////////////////////////////////////////////////////////////
 
 /**
- * Handles the update of price per token in wei. Attempts to load associated project and
+ * Handles the update of price per token. Attempts to load associated project and
  * its minter configuration, then updates base price in the configuration.
- * @param event The event carrying new price per token in wei
+ * @param event The event carrying new price per token (no decimals)
  */
 export function handlePricePerTokenUpdated(event: PricePerTokenUpdated): void {
   // attempt to load project, if it doesn't exist, log a warning and return
@@ -47,6 +47,49 @@ export function handlePricePerTokenUpdated(event: PricePerTokenUpdated): void {
 
   projectMinterConfig.basePrice = event.params.pricePerToken;
   projectMinterConfig.priceIsConfigured = true;
+  projectMinterConfig.save();
+
+  // induce sync if the project minter configuration is the active one
+  updateProjectIfMinterConfigIsActive(
+    project,
+    projectMinterConfig,
+    event.block.timestamp
+  );
+}
+
+/**
+ * Handles the reset of price per token. Attempts to load associated project and
+ * its minter configuration, then resets base price in the configuration,
+ * marking its price as not configured and setting price to 0.
+ * @param event The event carrying which project was reset
+ */
+export function handlePricePerTokenReset(event: PricePerTokenUpdated): void {
+  // attempt to load project, if it doesn't exist, log a warning and return
+  // @dev we don't support or allow minters to pre-configure projects that do
+  // not yet exist
+  const project = loadProjectByCoreAddressAndProjectNumber(
+    event.params.coreContract,
+    event.params.projectId
+  );
+  if (!project) {
+    log.warning("Project {} not found for core contract {}", [
+      event.params.projectId.toString(),
+      event.params.coreContract.toHexString()
+    ]);
+    return;
+  }
+
+  // load minter
+  const minter = loadOrCreateMinter(event.address, event.block.timestamp);
+
+  // load or create project minter configuration
+  const projectMinterConfig = loadOrCreateProjectMinterConfiguration(
+    project,
+    minter
+  );
+
+  projectMinterConfig.basePrice = BigInt.fromI32(0);
+  projectMinterConfig.priceIsConfigured = false;
   projectMinterConfig.save();
 
   // induce sync if the project minter configuration is the active one

--- a/src/settlement-exp-lib-mapping.ts
+++ b/src/settlement-exp-lib-mapping.ts
@@ -1,10 +1,8 @@
 import { Address, BigInt, log, ethereum } from "@graphprotocol/graph-ts";
-import {
-  ReceiptUpdated,
-  ISharedMinterDAExpSettlementV0
-} from "../generated/ISharedDAExpSettlement/ISharedMinterDAExpSettlementV0";
+import { ReceiptUpdated } from "../generated/SettlementExpLib/SettlementExpLib";
+import { ISharedMinterDAExpSettlementV0 } from "../generated/SettlementExpLib/ISharedMinterDAExpSettlementV0";
 
-import { loadOrCreateMinterProjectAndConfigIfProject } from "./i-shared-minter-mapping";
+import { loadOrCreateMinterProjectAndConfigIfProject } from "./generic-minter-events-lib-mapping";
 
 import {
   loadOrCreateMinter,
@@ -38,8 +36,8 @@ import { Receipt } from "../generated/schema";
 export function handleReceiptUpdated(event: ReceiptUpdated): void {
   const minterProjectAndConfig = loadOrCreateMinterProjectAndConfigIfProject(
     event.address, // minter
-    event.params._coreContract,
-    event.params._projectId,
+    event.params.coreContract,
+    event.params.projectId,
     event.block.timestamp
   );
   if (!minterProjectAndConfig) {
@@ -49,18 +47,18 @@ export function handleReceiptUpdated(event: ReceiptUpdated): void {
 
   // load or create receipt
   let projectId = generateContractSpecificId(
-    event.params._coreContract,
-    event.params._projectId
+    event.params.coreContract,
+    event.params.projectId
   );
   let receipt: Receipt = loadOrCreateReceipt(
     minterProjectAndConfig.minter.id,
     projectId,
-    event.params._purchaser,
+    event.params.purchaser,
     event.block.timestamp
   );
   // update receipt state
-  receipt.netPosted = event.params._netPosted;
-  receipt.numPurchased = BigInt.fromI32(event.params._numPurchased);
+  receipt.netPosted = event.params.netPosted;
+  receipt.numPurchased = BigInt.fromI32(event.params.numPurchased);
   receipt.updatedAt = event.block.timestamp;
   receipt.save();
 

--- a/src/split-funds-lib-mapping.ts
+++ b/src/split-funds-lib-mapping.ts
@@ -1,0 +1,48 @@
+import { BigInt, log, Address } from "@graphprotocol/graph-ts";
+import { Project } from "../generated/schema";
+
+import { ProjectCurrencyInfoUpdated } from "../generated/SplitFundsLib/SplitFundsLib";
+
+import { updateProjectIfMinterConfigIsActive } from "./helpers";
+
+import { loadOrCreateMinterProjectAndConfigIfProject } from "./generic-minter-events-lib-mapping";
+
+///////////////////////////////////////////////////////////////////////////////
+// EVENT HANDLERS start here
+///////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Handles the update of a project's currency information. Attempts to load associated
+ * project and its minter configuration, then updates currency address and symbol.
+ * @param event The event carrying updated currency information
+ */
+export function handleProjectCurrencyInfoUpdated(
+  event: ProjectCurrencyInfoUpdated
+): void {
+  const minterProjectAndConfig = loadOrCreateMinterProjectAndConfigIfProject(
+    event.address, // minter
+    event.params.coreContract,
+    event.params.projectId,
+    event.block.timestamp
+  );
+  if (!minterProjectAndConfig) {
+    // project wasn't found, warning already logged in helper function
+    return;
+  }
+
+  const projectMinterConfig = minterProjectAndConfig.projectMinterConfiguration;
+  projectMinterConfig.currencyAddress = event.params.currencyAddress;
+  projectMinterConfig.currencySymbol = event.params.currencySymbol;
+  projectMinterConfig.save();
+
+  // induce sync if the project minter configuration is the active one
+  updateProjectIfMinterConfigIsActive(
+    minterProjectAndConfig.project,
+    projectMinterConfig,
+    event.block.timestamp
+  );
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// EVENT HANDLERS end here
+///////////////////////////////////////////////////////////////////////////////

--- a/src/token-holder-lib-mapping.ts
+++ b/src/token-holder-lib-mapping.ts
@@ -4,9 +4,9 @@ import {
   DelegationRegistryUpdated,
   AllowedHoldersOfProjects,
   RemovedHoldersOfProjects
-} from "../generated/ISharedHolder/ISharedMinterHolderV0";
+} from "../generated/TokenHolderLib/TokenHolderLib";
 
-import { loadOrCreateMinterProjectAndConfigIfProject } from "./i-shared-minter-mapping";
+import { loadOrCreateMinterProjectAndConfigIfProject } from "./generic-minter-events-lib-mapping";
 
 import {
   loadOrCreateMinter,
@@ -71,8 +71,8 @@ function handleHoldersOfProjectsGeneric<EventType>(event: EventType): void {
   // load projectMinterConfiguration
   let minterProjectAndConfig = loadOrCreateMinterProjectAndConfigIfProject(
     event.address, // minter
-    event.params._coreContract,
-    event.params._projectId,
+    event.params.coreContract,
+    event.params.projectId,
     event.block.timestamp
   );
   if (!minterProjectAndConfig) {
@@ -81,9 +81,9 @@ function handleHoldersOfProjectsGeneric<EventType>(event: EventType): void {
   }
 
   const projectMinterConfig = minterProjectAndConfig.projectMinterConfiguration;
-  for (let i = 0; i < event.params._ownedNFTAddresses.length; i++) {
-    let address = event.params._ownedNFTAddresses[i].toHexString();
-    let holderProjectId = event.params._ownedNFTProjectIds[i].toString();
+  for (let i = 0; i < event.params.ownedNFTAddresses.length; i++) {
+    let address = event.params.ownedNFTAddresses[i].toHexString();
+    let holderProjectId = event.params.ownedNFTProjectIds[i].toString();
     let bytesValueCombined = Bytes.fromUTF8(address + "-" + holderProjectId);
 
     if (event instanceof AllowedHoldersOfProjects) {

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -1156,6 +1156,8 @@ dataSources:
       eventHandlers:
         - event: PricePerTokenUpdated(indexed uint256,indexed address,indexed uint256)
           handler: handlePricePerTokenUpdated
+        - event: PricePerTokenReset(indexed uint256,indexed address)
+          handler: handlePricePerTokenReset
       file: ./src/set-price-lib-mapping.ts
   {{/setPriceLibContracts}}
   {{#maxInvocationsLibContracts}}

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -991,13 +991,13 @@ dataSources:
           handler: handleCoreRegistryUpdated
       file: ./src/shared-minter-filter-mapping.ts
   {{/sharedMinterFilterContracts}}
-  {{#iSharedMinterV0Contracts}}
+  {{#genericMinterEventsLibContracts}}
   - kind: ethereum/contract
-    name: 'ISharedMinterV0{{#address}}-{{address}}{{/address}}'
+    name: 'GenericMinterEventsLib{{#address}}-{{address}}{{/address}}'
     network: {{network}}
     source:
       address: "{{#address}}{{address}}{{/address}}{{^address}}0x0000000000000000000000000000000000000000{{/address}}"
-      abi: ISharedMinterV0
+      abi: GenericMinterEventsLib
       {{#startBlock}}startBlock: {{startBlock}}{{/startBlock}}
     mapping:
       kind: ethereum/events
@@ -1015,6 +1015,8 @@ dataSources:
         - Minter
         - ProjectMinterConfiguration
       abis:
+        - name: GenericMinterEventsLib
+          file: ./abis/GenericMinterEventsLib.json
         - name: ISharedMinterV0
           file: ./abis/ISharedMinterV0.json
         - name: IFilteredMinterV2
@@ -1034,12 +1036,6 @@ dataSources:
         - name: IFilteredMinterSEAV0
           file: ./abis/IFilteredMinterSEAV0.json
       eventHandlers:
-        - event: PricePerTokenInWeiUpdated(indexed uint256,indexed address,indexed uint256)
-          handler: handlePricePerTokenInWeiUpdated
-        - event: ProjectCurrencyInfoUpdated(indexed uint256,indexed address,indexed address,string)
-          handler: handleProjectCurrencyInfoUpdated
-        - event: ProjectMaxInvocationsLimitUpdated(indexed uint256,indexed address,uint256)
-          handler: handleProjectMaxInvocationsLimitUpdated
         - event: ConfigValueSet(indexed uint256,indexed address,bytes32,bytes32)
           handler: handleConfigValueSetBytes
         - event: ConfigValueSet(indexed uint256,indexed address,bytes32,bool)
@@ -1062,15 +1058,15 @@ dataSources:
           handler: handleConfigValueRemovedFromSetBigInt
         - event: ConfigValueRemovedFromSet(indexed uint256,indexed address,bytes32,address)
           handler: handleConfigValueRemovedFromSetAddress
-      file: ./src/i-shared-minter-mapping.ts
-  {{/iSharedMinterV0Contracts}}
-  {{#iSharedMerkleContracts}}
+      file: ./src/generic-minter-events-lib-mapping.ts
+  {{/genericMinterEventsLibContracts}}
+  {{#splitFundsLibContracts}}
   - kind: ethereum/contract
-    name: 'ISharedMerkle{{#address}}-{{address}}{{/address}}'
+    name: 'SplitFundsLib{{#address}}-{{address}}{{/address}}'
     network: {{network}}
     source:
       address: "{{#address}}{{address}}{{/address}}{{^address}}0x0000000000000000000000000000000000000000{{/address}}"
-      abi: ISharedMinterMerkleV0
+      abi: SplitFundsLib
       {{#startBlock}}startBlock: {{startBlock}}{{/startBlock}}
     mapping:
       kind: ethereum/events
@@ -1088,6 +1084,155 @@ dataSources:
         - Minter
         - ProjectMinterConfiguration
       abis:
+        - name: SplitFundsLib
+          file: ./abis/SplitFundsLib.json
+        - name: ISharedMinterV0
+          file: ./abis/ISharedMinterV0.json
+        - name: IFilteredMinterV2
+          file: ./abis/IFilteredMinterV2.json
+        - name: IFilteredMinterDALinV1
+          file: ./abis/IFilteredMinterDALinV1.json
+        - name: IFilteredMinterDAExpV1
+          file: ./abis/IFilteredMinterDAExpV1.json
+        - name: IFilteredMinterDAExpSettlementV1
+          file: ./abis/IFilteredMinterDAExpSettlementV1.json
+        - name: IFilteredMinterV2
+          file: ./abis/IFilteredMinterV2.json
+        - name: IFilteredMinterHolderV2
+          file: ./abis/IFilteredMinterHolderV2.json
+        - name: IFilteredMinterMerkleV2
+          file: ./abis/IFilteredMinterMerkleV2.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
+      eventHandlers:
+        - event: ProjectCurrencyInfoUpdated(indexed uint256,indexed address,indexed address,string)
+          handler: handleProjectCurrencyInfoUpdated
+      file: ./src/split-funds-lib-mapping.ts
+  {{/splitFundsLibContracts}}
+  {{#setPriceLibContracts}}
+  - kind: ethereum/contract
+    name: 'SetPriceLib{{#address}}-{{address}}{{/address}}'
+    network: {{network}}
+    source:
+      address: "{{#address}}{{address}}{{/address}}{{^address}}0x0000000000000000000000000000000000000000{{/address}}"
+      abi: SetPriceLib
+      {{#startBlock}}startBlock: {{startBlock}}{{/startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      entities:
+        - Project
+        - ProjectScript
+        - Token
+        - Contract
+        - Account
+        - AccountProject
+        - Whitelisting
+        - MinterFilter
+        - Minter
+        - ProjectMinterConfiguration
+      abis:
+        - name: SetPriceLib
+          file: ./abis/SetPriceLib.json
+        - name: ISharedMinterV0
+          file: ./abis/ISharedMinterV0.json
+        - name: IFilteredMinterV2
+          file: ./abis/IFilteredMinterV2.json
+        - name: IFilteredMinterDALinV1
+          file: ./abis/IFilteredMinterDALinV1.json
+        - name: IFilteredMinterDAExpV1
+          file: ./abis/IFilteredMinterDAExpV1.json
+        - name: IFilteredMinterDAExpSettlementV1
+          file: ./abis/IFilteredMinterDAExpSettlementV1.json
+        - name: IFilteredMinterV2
+          file: ./abis/IFilteredMinterV2.json
+        - name: IFilteredMinterHolderV2
+          file: ./abis/IFilteredMinterHolderV2.json
+        - name: IFilteredMinterMerkleV2
+          file: ./abis/IFilteredMinterMerkleV2.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
+      eventHandlers:
+        - event: PricePerTokenUpdated(indexed uint256,indexed address,indexed uint256)
+          handler: handlePricePerTokenUpdated
+      file: ./src/set-price-lib-mapping.ts
+  {{/setPriceLibContracts}}
+  {{#maxInvocationsLibContracts}}
+  - kind: ethereum/contract
+    name: 'MaxInvocationsLib{{#address}}-{{address}}{{/address}}'
+    network: {{network}}
+    source:
+      address: "{{#address}}{{address}}{{/address}}{{^address}}0x0000000000000000000000000000000000000000{{/address}}"
+      abi: MaxInvocationsLib
+      {{#startBlock}}startBlock: {{startBlock}}{{/startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      entities:
+        - Project
+        - ProjectScript
+        - Token
+        - Contract
+        - Account
+        - AccountProject
+        - Whitelisting
+        - MinterFilter
+        - Minter
+        - ProjectMinterConfiguration
+      abis:
+        - name: MaxInvocationsLib
+          file: ./abis/MaxInvocationsLib.json
+        - name: ISharedMinterV0
+          file: ./abis/ISharedMinterV0.json
+        - name: IFilteredMinterV2
+          file: ./abis/IFilteredMinterV2.json
+        - name: IFilteredMinterDALinV1
+          file: ./abis/IFilteredMinterDALinV1.json
+        - name: IFilteredMinterDAExpV1
+          file: ./abis/IFilteredMinterDAExpV1.json
+        - name: IFilteredMinterDAExpSettlementV1
+          file: ./abis/IFilteredMinterDAExpSettlementV1.json
+        - name: IFilteredMinterV2
+          file: ./abis/IFilteredMinterV2.json
+        - name: IFilteredMinterHolderV2
+          file: ./abis/IFilteredMinterHolderV2.json
+        - name: IFilteredMinterMerkleV2
+          file: ./abis/IFilteredMinterMerkleV2.json
+        - name: IFilteredMinterSEAV0
+          file: ./abis/IFilteredMinterSEAV0.json
+      eventHandlers:
+        - event: ProjectMaxInvocationsLimitUpdated(indexed uint256,indexed address,uint256)
+          handler: handleProjectMaxInvocationsLimitUpdated
+      file: ./src/max-invocations-lib-mapping.ts
+  {{/maxInvocationsLibContracts}}
+  {{#merkleLibContracts}}
+  - kind: ethereum/contract
+    name: 'MerkleLib{{#address}}-{{address}}{{/address}}'
+    network: {{network}}
+    source:
+      address: "{{#address}}{{address}}{{/address}}{{^address}}0x0000000000000000000000000000000000000000{{/address}}"
+      abi: MerkleLib
+      {{#startBlock}}startBlock: {{startBlock}}{{/startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      entities:
+        - Project
+        - ProjectScript
+        - Token
+        - Contract
+        - Account
+        - AccountProject
+        - Whitelisting
+        - MinterFilter
+        - Minter
+        - ProjectMinterConfiguration
+      abis:
+        - name: MerkleLib
+          file: ./abis/MerkleLib.json
         - name: ISharedMinterMerkleV0
           file: ./abis/ISharedMinterMerkleV0.json
         - name: ISharedMinterV0
@@ -1113,15 +1258,15 @@ dataSources:
           handler: handleDefaultMaxInvocationsPerAddress
         - event: DelegationRegistryUpdated(address)
           handler: handleDelegationRegistryUpdated
-      file: ./src/i-shared-merkle-mapping.ts
-  {{/iSharedMerkleContracts}}
-  {{#iSharedHolderContracts}}
+      file: ./src/merkle-lib-mapping.ts
+  {{/merkleLibContracts}}
+  {{#holderLibContracts}}
   - kind: ethereum/contract
-    name: 'ISharedHolder{{#address}}-{{address}}{{/address}}'
+    name: 'TokenHolderLib{{#address}}-{{address}}{{/address}}'
     network: {{network}}
     source:
       address: "{{#address}}{{address}}{{/address}}{{^address}}0x0000000000000000000000000000000000000000{{/address}}"
-      abi: ISharedMinterHolderV0
+      abi: TokenHolderLib
       {{#startBlock}}startBlock: {{startBlock}}{{/startBlock}}
     mapping:
       kind: ethereum/events
@@ -1139,6 +1284,8 @@ dataSources:
         - Minter
         - ProjectMinterConfiguration
       abis:
+        - name: TokenHolderLib
+          file: ./abis/TokenHolderLib.json
         - name: ISharedMinterHolderV0
           file: ./abis/ISharedMinterHolderV0.json
         - name: ISharedMinterV0
@@ -1166,15 +1313,15 @@ dataSources:
           handler: handleAllowedHoldersOfProjects
         - event: RemovedHoldersOfProjects(indexed uint256,indexed address,address[],uint256[])
           handler: handleRemovedHoldersOfProjects
-      file: ./src/i-shared-holder-mapping.ts
-  {{/iSharedHolderContracts}}
-  {{#iSharedSEAContracts}}
+      file: ./src/token-holder-lib-mapping.ts
+  {{/holderLibContracts}}
+  {{#SEALibContracts}}
   - kind: ethereum/contract
-    name: 'ISharedSEA{{#address}}-{{address}}{{/address}}'
+    name: 'SEALib{{#address}}-{{address}}{{/address}}'
     network: {{network}}
     source:
       address: "{{#address}}{{address}}{{/address}}{{^address}}0x0000000000000000000000000000000000000000{{/address}}"
-      abi: ISharedMinterSEAV0
+      abi: SEALib
       {{#startBlock}}startBlock: {{startBlock}}{{/startBlock}}
     mapping:
       kind: ethereum/events
@@ -1192,6 +1339,8 @@ dataSources:
         - Minter
         - ProjectMinterConfiguration
       abis:
+        - name: SEALib
+          file: ./abis/SEALib.json
         - name: ISharedMinterSEAV0
           file: ./abis/ISharedMinterSEAV0.json
         - name: ISharedMinterV0
@@ -1233,15 +1382,15 @@ dataSources:
           handler: handleProjectNextTokenUpdated
         - event: ProjectNextTokenEjected(indexed uint256,indexed address)
           handler: handleProjectNextTokenEjected
-      file: ./src/i-shared-sea-mapping.ts
-  {{/iSharedSEAContracts}}
-  {{#iSharedDAContracts}}
+      file: ./src/sea-lib-mapping.ts
+  {{/SEALibContracts}}
+  {{#DALibContracts}}
   - kind: ethereum/contract
-    name: 'ISharedDA{{#address}}-{{address}}{{/address}}'
+    name: 'DALib{{#address}}-{{address}}{{/address}}'
     network: {{network}}
     source:
       address: "{{#address}}{{address}}{{/address}}{{^address}}0x0000000000000000000000000000000000000000{{/address}}"
-      abi: ISharedMinterDAV0
+      abi: DALib
       {{#startBlock}}startBlock: {{startBlock}}{{/startBlock}}
     mapping:
       kind: ethereum/events
@@ -1259,6 +1408,8 @@ dataSources:
         - Minter
         - ProjectMinterConfiguration
       abis:
+        - name: DALib
+          file: ./abis/DALib.json
         - name: ISharedMinterDAV0
           file: ./abis/ISharedMinterDAV0.json
         - name: ISharedMinterV0
@@ -1282,15 +1433,15 @@ dataSources:
       eventHandlers:
         - event: ResetAuctionDetails(indexed uint256,indexed address)
           handler: handleResetAuctionDetails
-      file: ./src/i-shared-da-mapping.ts
-  {{/iSharedDAContracts}}
-  {{#iSharedDAExpContracts}}
+      file: ./src/da-lib-mapping.ts
+  {{/DALibContracts}}
+  {{#DAExpLibContracts}}
   - kind: ethereum/contract
-    name: 'ISharedDAExp{{#address}}-{{address}}{{/address}}'
+    name: 'DAExpLib{{#address}}-{{address}}{{/address}}'
     network: {{network}}
     source:
       address: "{{#address}}{{address}}{{/address}}{{^address}}0x0000000000000000000000000000000000000000{{/address}}"
-      abi: ISharedMinterDAExpV0
+      abi: DAExpLib
       {{#startBlock}}startBlock: {{startBlock}}{{/startBlock}}
     mapping:
       kind: ethereum/events
@@ -1308,6 +1459,8 @@ dataSources:
         - Minter
         - ProjectMinterConfiguration
       abis:
+        - name: DAExpLib
+          file: ./abis/DAExpLib.json
         - name: ISharedMinterDAExpV0
           file: ./abis/ISharedMinterDAExpV0.json
         - name: ISharedMinterDAV0
@@ -1335,15 +1488,15 @@ dataSources:
           handler: handleSetAuctionDetailsExp
         - event: AuctionMinHalfLifeSecondsUpdated(uint256)
           handler: handleAuctionMinHalfLifeSecondsUpdated
-      file: ./src/i-shared-da-exp-mapping.ts
-  {{/iSharedDAExpContracts}}
-  {{#iSharedDALinContracts}}
+      file: ./src/da-exp-lib-mapping.ts
+  {{/DAExpLibContracts}}
+  {{#DALinLibContracts}}
   - kind: ethereum/contract
-    name: 'ISharedDALin{{#address}}-{{address}}{{/address}}'
+    name: 'DALinLib{{#address}}-{{address}}{{/address}}'
     network: {{network}}
     source:
       address: "{{#address}}{{address}}{{/address}}{{^address}}0x0000000000000000000000000000000000000000{{/address}}"
-      abi: ISharedMinterDALinV0
+      abi: DALinLib
       {{#startBlock}}startBlock: {{startBlock}}{{/startBlock}}
     mapping:
       kind: ethereum/events
@@ -1361,6 +1514,8 @@ dataSources:
         - Minter
         - ProjectMinterConfiguration
       abis:
+        - name: DALinLib
+          file: ./abis/DALinLib.json
         - name: ISharedMinterDALinV0
           file: ./abis/ISharedMinterDALinV0.json
         - name: ISharedMinterDAV0
@@ -1388,15 +1543,15 @@ dataSources:
           handler: handleSetAuctionDetailsLin
         - event: AuctionMinimumLengthSecondsUpdated(uint256)
           handler: handleAuctionMinimumLengthSecondsUpdated
-      file: ./src/i-shared-da-lin-mapping.ts
-  {{/iSharedDALinContracts}}
-  {{#iSharedDAExpSettlementContracts}}
+      file: ./src/da-lin-lib-mapping.ts
+  {{/DALinLibContracts}}
+  {{#settlementExpLibContracts}}
   - kind: ethereum/contract
-    name: 'ISharedDAExpSettlement{{#address}}-{{address}}{{/address}}'
+    name: 'SettlementExpLib{{#address}}-{{address}}{{/address}}'
     network: {{network}}
     source:
       address: "{{#address}}{{address}}{{/address}}{{^address}}0x0000000000000000000000000000000000000000{{/address}}"
-      abi: ISharedMinterDAExpSettlementV0
+      abi: SettlementExpLib
       {{#startBlock}}startBlock: {{startBlock}}{{/startBlock}}
     mapping:
       kind: ethereum/events
@@ -1414,6 +1569,8 @@ dataSources:
         - Minter
         - ProjectMinterConfiguration
       abis:
+        - name: SettlementExpLib
+          file: ./abis/SettlementExpLib.json
         - name: ISharedMinterDAExpSettlementV0
           file: ./abis/ISharedMinterDAExpSettlementV0.json
         - name: ISharedMinterDAExpV0
@@ -1441,8 +1598,8 @@ dataSources:
       eventHandlers:
         - event: ReceiptUpdated(indexed address,indexed uint256,indexed address,uint24,uint256)
           handler: handleReceiptUpdated
-      file: ./src/i-shared-da-exp-settlement-mapping.ts
-  {{/iSharedDAExpSettlementContracts}}
+      file: ./src/settlement-exp-lib-mapping.ts
+  {{/settlementExpLibContracts}}
   {{#minterSetPriceContracts}}
   - kind: ethereum/contract
     name: 'MinterSetPrice{{#address}}-{{address}}{{/address}}'

--- a/tests/e2e/runner/__tests__/minter-suite-v2/da-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/da-lib.test.ts
@@ -51,24 +51,24 @@ const genArt721CoreAddress =
   config.iGenArt721CoreContractV3_BaseContracts[0].address;
 
 // get MinterDAExp contract from the subgraph config
-if (!config.iSharedDAExpContracts) {
-  throw new Error("No iSharedDAExpContracts in config");
+if (!config.DAExpLibContracts) {
+  throw new Error("No DAExpLibContracts in config");
 }
-const minterDAExpV5Address = config.iSharedDAExpContracts[0].address;
+const minterDAExpV5Address = config.DAExpLibContracts[0].address;
 const minterDAExpV5Contract = new MinterDAExpV5__factory(deployer).attach(
   minterDAExpV5Address
 );
 
 // get MinterDALin contract from the subgraph config
-if (!config.iSharedDALinContracts) {
-  throw new Error("No iSharedDALinContracts in config");
+if (!config.DALinLibContracts) {
+  throw new Error("No DALinLibContracts in config");
 }
-const minterDALinV5Address = config.iSharedDALinContracts[0].address;
+const minterDALinV5Address = config.DALinLibContracts[0].address;
 const minterDALinV5Contract = new MinterDALinV5__factory(deployer).attach(
   minterDALinV5Address
 );
 
-describe("iFilteredSharedDA event handling", () => {
+describe("DALib event handling", () => {
   beforeAll(async () => {
     await waitUntilSubgraphIsSynced(client);
   });
@@ -187,6 +187,7 @@ describe("iFilteredSharedDA event handling", () => {
       expect(minterConfigRes.basePrice).toBeDefined();
       // validate extraMinterDetails
       const extraMinterDetails = JSON.parse(minterConfigRes.extraMinterDetails);
+      console.log(extraMinterDetails);
       expect(extraMinterDetails.startPrice).toBeDefined();
       expect(extraMinterDetails.startTime).toBeDefined();
       expect(extraMinterDetails.endTime).toBeDefined();

--- a/tests/e2e/runner/__tests__/minter-suite-v2/da-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/da-lib.test.ts
@@ -187,7 +187,6 @@ describe("DALib event handling", () => {
       expect(minterConfigRes.basePrice).toBeDefined();
       // validate extraMinterDetails
       const extraMinterDetails = JSON.parse(minterConfigRes.extraMinterDetails);
-      console.log(extraMinterDetails);
       expect(extraMinterDetails.startPrice).toBeDefined();
       expect(extraMinterDetails.startTime).toBeDefined();
       expect(extraMinterDetails.endTime).toBeDefined();

--- a/tests/e2e/runner/__tests__/minter-suite-v2/da-lin-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/da-lin-lib.test.ts
@@ -9,7 +9,7 @@ import {
 } from "../utils/helpers";
 
 import { MinterFilterV2__factory } from "../../contracts/factories/MinterFilterV2__factory";
-import { MinterDAExpV5__factory } from "../../contracts/factories/MinterDAExpV5__factory";
+import { MinterDALinV5__factory } from "../../contracts/factories/MinterDALinV5__factory";
 
 import { ethers } from "ethers";
 // hide nuisance logs about event overloading
@@ -49,78 +49,54 @@ if (!config.iGenArt721CoreContractV3_BaseContracts) {
 const genArt721CoreAddress =
   config.iGenArt721CoreContractV3_BaseContracts[0].address;
 
-// get MinterDAExp contract from the subgraph config
-if (!config.iSharedDAExpContracts) {
-  throw new Error("No iSharedDAExpContracts in config");
+// get MinterDALin contract from the subgraph config
+if (!config.DALinLibContracts) {
+  throw new Error("No DALinLibContracts in config");
 }
-const minterDAExpV5Address = config.iSharedDAExpContracts[0].address;
-const minterDAExpV5Contract = new MinterDAExpV5__factory(deployer).attach(
-  minterDAExpV5Address
+const minterDALinV5Address = config.DALinLibContracts[0].address;
+const minterDALinV5Contract = new MinterDALinV5__factory(deployer).attach(
+  minterDALinV5Address
 );
 
-// helper function to calculate approximate DAExp length
-function getApproxDAExpLength(
-  startPrice: ethers.BigNumber,
-  basePrice: ethers.BigNumber,
-  halfLifeSeconds: number
-): number {
-  const EXTRA_DECIMALS = 10 ** 5;
-  // const startPriceFloatingPoint = ethers.utils.parseUnits(startPrice);
-  // const basePriceFloatingPoint = basePrice.toBigDecimal();
-  const priceRatio =
-    startPrice.mul(EXTRA_DECIMALS).div(basePrice).toNumber() / EXTRA_DECIMALS;
-  const completedHalfLives = Math.floor(Math.log(priceRatio) / Math.log(2));
-  const x1 = completedHalfLives * halfLifeSeconds;
-  const x2 = x1 + halfLifeSeconds;
-  const y1 = startPrice.div(2 ** completedHalfLives);
-  const y2 = y1.div(2);
-  const totalAuctionTime =
-    x1 +
-    (x2 - x1) *
-      (basePrice.sub(y1).mul(EXTRA_DECIMALS).div(y2.sub(y1)).toNumber() /
-        EXTRA_DECIMALS);
-  return totalAuctionTime;
-}
-
-describe("iFilteredSharedDAExp event handling", () => {
+describe("DALinLib event handling", () => {
   beforeAll(async () => {
     await waitUntilSubgraphIsSynced(client);
   });
 
   describe("Indexed after setup", () => {
     test("created new Minter during deployment and allowlisting", async () => {
-      const targetId = minterDAExpV5Address.toLowerCase();
+      const targetId = minterDALinV5Address.toLowerCase();
       const minterRes = await getMinterDetails(client, targetId);
       expect(minterRes.id).toBe(targetId);
     });
   });
 
-  describe("AuctionMinHalfLifeSecondsUpdated", () => {
+  describe("AuctionMinimumLengthSecondsUpdated", () => {
     // @dev no need to reset the affected value after each test
     test("updated after admin configures", async () => {
       // query public constant for the expected value (>0)
       const initialValue =
-        await minterDAExpV5Contract.minimumPriceDecayHalfLifeSeconds();
+        await minterDALinV5Contract.minimumAuctionLengthSeconds();
       const newTargetValue = initialValue.add(1);
       // update the minter value
-      await minterDAExpV5Contract
+      await minterDALinV5Contract
         .connect(deployer)
-        .setMinimumPriceDecayHalfLifeSeconds(newTargetValue);
+        .setMinimumAuctionLengthSeconds(newTargetValue);
       // validate minter's extraMinterDetails in subgraph
       await waitUntilSubgraphIsSynced(client);
-      const targetId = minterDAExpV5Address.toLowerCase();
+      const targetId = minterDALinV5Address.toLowerCase();
       const minterRes = await getMinterDetails(client, targetId);
       const extraMinterDetails = JSON.parse(minterRes.extraMinterDetails);
-      expect(extraMinterDetails.minimumHalfLifeInSeconds).toBe(
+      expect(extraMinterDetails.minimumAuctionLengthInSeconds).toBe(
         newTargetValue.toNumber()
       );
     });
   });
 
-  describe("SetAuctionDetailsExp", () => {
+  describe("SetAuctionDetailsLin", () => {
     afterEach(async () => {
       // clear the auction details for the project
-      await minterDAExpV5Contract
+      await minterDALinV5Contract
         .connect(deployer)
         .resetAuctionDetails(0, genArt721CoreAddress);
       // clear the current minter for the project
@@ -143,23 +119,24 @@ describe("iFilteredSharedDAExp event handling", () => {
       await sharedMinterFilterContract.connect(artist).setMinterForProject(
         0, // _projectId
         genArt721CoreAddress, // _coreContract
-        minterDAExpV5Address // _minter
+        minterDALinV5Address // _minter
       );
       const latestBlock = await deployer.provider.getBlock("latest");
       const targetAuctionStart = latestBlock.timestamp + 3600;
+      const targetAuctionEnd = targetAuctionStart + 3600;
       const targetStartPrice = ethers.utils.parseEther("1");
       const targetBasePrice = ethers.utils.parseEther("0.1");
-      await minterDAExpV5Contract.connect(artist).setAuctionDetails(
+      await minterDALinV5Contract.connect(artist).setAuctionDetails(
         0, // _projectId
         genArt721CoreAddress, // _coreContract
-        targetAuctionStart, // _timestampStart
-        600, // _priceDecayHalfLifeSeconds
+        targetAuctionStart, // _auctionTimestampStart
+        targetAuctionEnd, // _auctionTimestampEnd
         targetStartPrice, // _startPrice
         targetBasePrice // _basePrice
       );
       // validate project minter config in subgraph
       await waitUntilSubgraphIsSynced(client);
-      const targetId = `${minterDAExpV5Address.toLowerCase()}-${genArt721CoreAddress.toLowerCase()}-0`;
+      const targetId = `${minterDALinV5Address.toLowerCase()}-${genArt721CoreAddress.toLowerCase()}-0`;
       const minterConfigRes = await getProjectMinterConfigurationDetails(
         client,
         targetId
@@ -171,15 +148,7 @@ describe("iFilteredSharedDAExp event handling", () => {
       const extraMinterDetails = JSON.parse(minterConfigRes.extraMinterDetails);
       expect(extraMinterDetails.startPrice).toBe(targetStartPrice.toString());
       expect(extraMinterDetails.startTime).toBe(targetAuctionStart);
-      expect(extraMinterDetails.halfLifeSeconds).toBe(600);
-      const approxDALength = getApproxDAExpLength(
-        targetStartPrice,
-        targetBasePrice,
-        600
-      );
-      expect(extraMinterDetails.approximateDAExpEndTime).toBe(
-        targetAuctionStart + approxDALength
-      );
+      expect(extraMinterDetails.endTime).toBe(targetAuctionEnd);
     });
   });
 });

--- a/tests/e2e/runner/__tests__/minter-suite-v2/generic-minter-events-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/generic-minter-events-lib.test.ts
@@ -41,15 +41,15 @@ const genArt721CoreAddress =
   config.iGenArt721CoreContractV3_BaseContracts[0].address;
 
 // get MinterSetPriceMerkleV5 contract from the subgraph config
-if (!config.iSharedMerkleContracts) {
-  throw new Error("No iSharedMerkleContracts in config");
+if (!config.merkleLibContracts) {
+  throw new Error("No merkleLibContracts in config");
 }
-const minterSetPriceMerkleV5Address = config.iSharedMerkleContracts[0].address;
+const minterSetPriceMerkleV5Address = config.merkleLibContracts[0].address;
 const minterSetPriceMerkleV5Contract = new MinterSetPriceMerkleV5__factory(
   deployer
 ).attach(minterSetPriceMerkleV5Address);
 
-describe("iSharedMinterV0 event handling - generic handlers", () => {
+describe("GenericMinterEventsLib event handling - generic handlers", () => {
   // NOTE: this test suite is not exhaustive, because not all generic events are currently used by
   // the current set of minters.
   // Tests for specific generic events should be added here as they are implemented in the minters.

--- a/tests/e2e/runner/__tests__/minter-suite-v2/holder-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/holder-lib.test.ts
@@ -49,15 +49,15 @@ const genArt721CoreAddress =
   config.iGenArt721CoreContractV3_BaseContracts[0].address;
 
 // get MinterSetPriceHolderV5 contract from the subgraph config
-if (!config.iSharedHolderContracts) {
-  throw new Error("No iSharedHolderContracts in config");
+if (!config.holderLibContracts) {
+  throw new Error("No holderLibContracts in config");
 }
-const minterSetPriceHolderV5Address = config.iSharedHolderContracts[0].address;
+const minterSetPriceHolderV5Address = config.holderLibContracts[0].address;
 const minterSetPriceHolderV5Contract = new MinterSetPriceHolderV5__factory(
   deployer
 ).attach(minterSetPriceHolderV5Address);
 
-describe("iFilteredSharedMerkle event handling", () => {
+describe("HolderLib event handling", () => {
   beforeAll(async () => {
     await waitUntilSubgraphIsSynced(client);
   });

--- a/tests/e2e/runner/__tests__/minter-suite-v2/i-shared-minter-v0.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/i-shared-minter-v0.test.ts
@@ -65,17 +65,19 @@ const genArt721CoreContract = new GenArt721CoreV3__factory(
 
 // get MinterSetPriceV5
 // @dev this is minter at index 0 in the subgraph config
-if (!config.iSharedMinterV0Contracts) {
-  throw new Error("No iSharedMinterV0Contracts in config");
+if (!config.genericMinterEventsLibContracts) {
+  throw new Error("No genericMinterEventsLibContracts in config");
 }
-const minterSetPriceV5Address = config.iSharedMinterV0Contracts[0].address;
+const minterSetPriceV5Address =
+  config.genericMinterEventsLibContracts[0].address;
 const minterSetPriceV5Contract = new MinterSetPriceV5__factory(deployer).attach(
   minterSetPriceV5Address
 );
 
 // get MinterSetPriceERC20V5
 // @dev this is minter at index 1 in the subgraph config
-const minterSetPriceERC20V5Address = config.iSharedMinterV0Contracts[1].address;
+const minterSetPriceERC20V5Address =
+  config.genericMinterEventsLibContracts[1].address;
 const minterSetPriceERC20V5Contract = new MinterSetPriceERC20V5__factory(
   deployer
 ).attach(minterSetPriceERC20V5Address);
@@ -93,7 +95,7 @@ describe("iSharedMinterV0 event handling", () => {
     });
   });
 
-  describe("PricePerTokenInWeiUpdated", () => {
+  describe("PricePerTokenUpdated", () => {
     afterEach(async () => {
       // clear the minter for project zero
       // @dev call success depends on test state, so use a try/catch block
@@ -170,7 +172,6 @@ describe("iSharedMinterV0 event handling", () => {
           minterSetPriceERC20V5Address
         );
       // update currency info
-      const newPrice = ethers.utils.parseEther(Math.random().toString());
       await minterSetPriceERC20V5Contract
         .connect(artist)
         .updateProjectCurrencyInfo(
@@ -190,6 +191,8 @@ describe("iSharedMinterV0 event handling", () => {
       expect(minterConfigRes.currencyAddress).toBe(
         newCurrency.address.toLowerCase()
       );
+      // TODO - also add test for PricePerTokenReset
+      const newPrice = ethers.utils.parseEther(Math.random().toString());
     });
   });
 

--- a/tests/e2e/runner/__tests__/minter-suite-v2/max-invocations-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/max-invocations-lib.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, expect } from "@jest/globals";
+import {
+  getSubgraphConfig,
+  getAccounts,
+  createSubgraphClient,
+  waitUntilSubgraphIsSynced,
+  getMinterDetails,
+  getProjectMinterConfigurationDetails,
+} from "../utils/helpers";
+
+import {
+  GenArt721CoreV3__factory,
+  GenArt721CoreV3LibraryAddresses,
+} from "../../contracts/factories/GenArt721CoreV3__factory";
+import { MinterFilterV2__factory } from "../../contracts/factories/MinterFilterV2__factory";
+import { MinterSetPriceV5__factory } from "../../contracts/factories/MinterSetPriceV5__factory";
+// hide nuisance logs about event overloading
+import { Logger } from "@ethersproject/logger";
+Logger.setLogLevel(Logger.levels.ERROR);
+
+// waiting for subgraph to sync can take longer than the default 5s timeout
+jest.setTimeout(30 * 1000);
+
+const config = getSubgraphConfig();
+
+const client = createSubgraphClient();
+const { deployer, artist } = getAccounts();
+
+// set up contract instances and/or addresses
+const coreRegistryAddress = config.metadata?.coreRegistryAddress;
+if (!coreRegistryAddress)
+  throw new Error("No core registry address found in config metadata");
+
+const sharedMinterFilter = config.sharedMinterFilterContracts?.[0];
+if (!sharedMinterFilter) {
+  throw new Error("No shared minter filter found in config metadata");
+}
+const sharedMinterFilterContract = new MinterFilterV2__factory(deployer).attach(
+  sharedMinterFilter.address
+);
+// get contract from the subgraph config
+if (!config.iGenArt721CoreContractV3_BaseContracts) {
+  throw new Error("No iGenArt721CoreContractV3_BaseContracts in config");
+}
+const genArt721CoreAddress =
+  config.iGenArt721CoreContractV3_BaseContracts[0].address;
+
+const bytecodeStorageReaderAddress =
+  config.metadata?.bytecodeStorageReaderAddress;
+if (!bytecodeStorageReaderAddress)
+  throw new Error(
+    "No bytecode storage reader address found in config metadata"
+  );
+const linkLibraryAddresses: GenArt721CoreV3LibraryAddresses = {
+  "contracts/libs/v0.8.x/BytecodeStorageV1.sol:BytecodeStorageReader":
+    bytecodeStorageReaderAddress,
+};
+const genArt721CoreContract = new GenArt721CoreV3__factory(
+  linkLibraryAddresses,
+  deployer
+).attach(genArt721CoreAddress);
+
+// get MinterSetPriceV5
+// @dev this is minter at index 0 in the subgraph config
+if (!config.genericMinterEventsLibContracts) {
+  throw new Error("No genericMinterEventsLibContracts in config");
+}
+const minterSetPriceV5Address =
+  config.genericMinterEventsLibContracts[0].address;
+const minterSetPriceV5Contract = new MinterSetPriceV5__factory(deployer).attach(
+  minterSetPriceV5Address
+);
+
+describe("MaxInvocationsLib event handling", () => {
+  beforeAll(async () => {
+    await waitUntilSubgraphIsSynced(client);
+  });
+
+  describe("Indexed after setup", () => {
+    test("created new Minter during deployment and allowlisting", async () => {
+      const targetId = minterSetPriceV5Address.toLowerCase();
+      const minterRes = await getMinterDetails(client, targetId);
+      expect(minterRes.id).toBe(targetId);
+    });
+  });
+
+  describe("ProjectMaxInvocationsUpdated", () => {
+    afterEach(async () => {
+      // reset minter max invocations to core max invocations
+      // @dev does not depend on test state, so can be run in afterEach
+      // without needing a try/catch block
+      await minterSetPriceV5Contract
+        .connect(artist)
+        .syncProjectMaxInvocationsToCore(0, genArt721CoreAddress);
+
+      // clear the minter for project zero
+      // @dev call success depends on test state, so use a try/catch block
+      try {
+        await sharedMinterFilterContract
+          .connect(artist)
+          .removeMinterForProject(0, genArt721CoreAddress);
+      } catch (error) {
+        // try block will only fail in case of previously failed test where
+        // project zero never had its minter assigned.
+        // Thus, swallow error here because the test failure has already been
+        // reported, and additional error messaging from afterEach is not
+        // helpful.
+      }
+    });
+
+    test("Max invocations is updated and configured", async () => {
+      // set minter for project zero to the target minter
+      await sharedMinterFilterContract
+        .connect(artist)
+        .setMinterForProject(0, genArt721CoreAddress, minterSetPriceV5Address);
+      // verify initial max invocation state in subgraph
+      const projectStateData = await genArt721CoreContract.projectStateData(0);
+      const targetId = `${minterSetPriceV5Address.toLowerCase()}-${genArt721CoreAddress.toLowerCase()}-0`;
+      const minterConfigRes = await getProjectMinterConfigurationDetails(
+        client,
+        targetId
+      );
+      // subgraph max invocations should match core max invocations
+      expect(minterConfigRes.maxInvocations).toBe(
+        projectStateData.maxInvocations.toString()
+      );
+      // set max invocations to 99
+      await minterSetPriceV5Contract
+        .connect(artist)
+        .manuallyLimitProjectMaxInvocations(0, genArt721CoreAddress, 99);
+      await waitUntilSubgraphIsSynced(client);
+      // validate max invocations in subgraph was updated
+      const minterConfigRes2 = await getProjectMinterConfigurationDetails(
+        client,
+        targetId
+      );
+      // subgraph max invocations should match core max invocations
+      expect(minterConfigRes2.maxInvocations).toBe("99");
+      // state is reset in afterEach
+    });
+  });
+});

--- a/tests/e2e/runner/__tests__/minter-suite-v2/merkle-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/merkle-lib.test.ts
@@ -33,12 +33,12 @@ if (!sharedMinterFilter) {
 }
 
 // get MinterSetPriceMerkleV5 contract from the subgraph config
-if (!config.iSharedMerkleContracts) {
-  throw new Error("No iSharedMerkleContracts in config");
+if (!config.merkleLibContracts) {
+  throw new Error("No merkleLibContracts in config");
 }
-const minterSetPriceMerkleV5Address = config.iSharedMerkleContracts[0].address;
+const minterSetPriceMerkleV5Address = config.merkleLibContracts[0].address;
 
-describe("ISharedMinterMerkleV0 event handling", () => {
+describe("MerkleLib event handling", () => {
   beforeAll(async () => {
     await waitUntilSubgraphIsSynced(client);
   });

--- a/tests/e2e/runner/__tests__/minter-suite-v2/sea-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/sea-lib.test.ts
@@ -52,15 +52,15 @@ const genArt721CoreAddress =
   config.iGenArt721CoreContractV3_BaseContracts[0].address;
 
 // get MinterSEAV1 contract from the subgraph config
-if (!config.iSharedSEAContracts) {
-  throw new Error("No iSharedSEAContracts in config");
+if (!config.SEALibContracts) {
+  throw new Error("No SEALibContracts in config");
 }
-const minterSEAV1Address = config.iSharedSEAContracts[0].address;
+const minterSEAV1Address = config.SEALibContracts[0].address;
 const minterSEAV1Contract = new MinterSEAV1__factory(deployer).attach(
   minterSEAV1Address
 );
 
-describe("iFilteredSharedMerkle event handling", () => {
+describe("SEALib event handling", () => {
   beforeAll(async () => {
     await waitUntilSubgraphIsSynced(client);
   });
@@ -99,7 +99,7 @@ describe("iFilteredSharedMerkle event handling", () => {
       const minterConfigInitial =
         await minterSEAV1Contract.minterConfigurationDetails();
       const newMinterTimeBufferSeconds =
-        minterConfigInitial.minterTimeBufferSeconds_ + 1;
+        minterConfigInitial.minterTimeBufferSeconds + 1;
       // update the minter time buffer
       await minterSEAV1Contract
         .connect(deployer)
@@ -122,7 +122,7 @@ describe("iFilteredSharedMerkle event handling", () => {
       const minterConfigInitial =
         await minterSEAV1Contract.minterConfigurationDetails();
       const newMinterRefundGasLimit =
-        minterConfigInitial.minterRefundGasLimit_ + 1;
+        minterConfigInitial.minterRefundGasLimit + 1;
       // update the minter time buffer
       await minterSEAV1Contract
         .connect(deployer)

--- a/tests/e2e/runner/__tests__/minter-suite-v2/set-price-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/set-price-lib.test.ts
@@ -1,0 +1,215 @@
+import { describe, test, expect } from "@jest/globals";
+import {
+  getSubgraphConfig,
+  getAccounts,
+  createSubgraphClient,
+  waitUntilSubgraphIsSynced,
+  getMinterDetails,
+  getProjectMinterConfigurationDetails,
+} from "../utils/helpers";
+import { MinterFilterV2__factory } from "../../contracts/factories/MinterFilterV2__factory";
+import { MinterSetPriceV5__factory } from "../../contracts/factories/MinterSetPriceV5__factory";
+import { MinterSetPriceERC20V5__factory } from "../../contracts/factories/MinterSetPriceERC20V5__factory";
+import { ERC20Mock__factory } from "../../contracts/factories/ERC20Mock__factory";
+import { ethers } from "ethers";
+// hide nuisance logs about event overloading
+import { Logger } from "@ethersproject/logger";
+Logger.setLogLevel(Logger.levels.ERROR);
+
+// waiting for subgraph to sync can take longer than the default 5s timeout
+jest.setTimeout(30 * 1000);
+
+const config = getSubgraphConfig();
+
+const client = createSubgraphClient();
+const { deployer, artist } = getAccounts();
+
+// set up contract instances and/or addresses
+const coreRegistryAddress = config.metadata?.coreRegistryAddress;
+if (!coreRegistryAddress)
+  throw new Error("No core registry address found in config metadata");
+
+const sharedMinterFilter = config.sharedMinterFilterContracts?.[0];
+if (!sharedMinterFilter) {
+  throw new Error("No shared minter filter found in config metadata");
+}
+const sharedMinterFilterContract = new MinterFilterV2__factory(deployer).attach(
+  sharedMinterFilter.address
+);
+// get contract from the subgraph config
+if (!config.iGenArt721CoreContractV3_BaseContracts) {
+  throw new Error("No iGenArt721CoreContractV3_BaseContracts in config");
+}
+const genArt721CoreAddress =
+  config.iGenArt721CoreContractV3_BaseContracts[0].address;
+
+const bytecodeStorageReaderAddress =
+  config.metadata?.bytecodeStorageReaderAddress;
+if (!bytecodeStorageReaderAddress)
+  throw new Error(
+    "No bytecode storage reader address found in config metadata"
+  );
+
+// get MinterSetPriceV5
+// @dev this is minter at index 0 in the subgraph config
+if (!config.genericMinterEventsLibContracts) {
+  throw new Error("No genericMinterEventsLibContracts in config");
+}
+const minterSetPriceV5Address =
+  config.genericMinterEventsLibContracts[0].address;
+const minterSetPriceV5Contract = new MinterSetPriceV5__factory(deployer).attach(
+  minterSetPriceV5Address
+);
+
+// get MinterSetPriceERC20V5
+// @dev this is minter at index 1 in the subgraph config
+const minterSetPriceERC20V5Address =
+  config.genericMinterEventsLibContracts[1].address;
+const minterSetPriceERC20V5Contract = new MinterSetPriceERC20V5__factory(
+  deployer
+).attach(minterSetPriceERC20V5Address);
+
+describe("SetPriceLib event handling", () => {
+  beforeAll(async () => {
+    await waitUntilSubgraphIsSynced(client);
+  });
+
+  describe("Indexed after setup", () => {
+    test("created new Minter during deployment and allowlisting", async () => {
+      const targetId = minterSetPriceV5Address.toLowerCase();
+      const minterRes = await getMinterDetails(client, targetId);
+      expect(minterRes.id).toBe(targetId);
+    });
+  });
+
+  describe("PricePerTokenUpdated", () => {
+    afterEach(async () => {
+      // clear the minter for project zero
+      // @dev call success depends on test state, so use a try/catch block
+      try {
+        await sharedMinterFilterContract
+          .connect(artist)
+          .removeMinterForProject(0, genArt721CoreAddress);
+      } catch (error) {
+        // try block will only fail in case of previously failed test where
+        // project zero never had its minter assigned.
+        // Thus, swallow error here because the test failure has already been
+        // reported, and additional error messaging from afterEach is not
+        // helpful.
+      }
+    });
+
+    test("Price is updated and configured", async () => {
+      // set minter for project zero to the target minter
+      await sharedMinterFilterContract
+        .connect(artist)
+        .setMinterForProject(0, genArt721CoreAddress, minterSetPriceV5Address);
+      // update price
+      const newPrice = ethers.utils.parseEther(Math.random().toString());
+      await minterSetPriceV5Contract
+        .connect(artist)
+        .updatePricePerTokenInWei(0, genArt721CoreAddress, newPrice);
+      await waitUntilSubgraphIsSynced(client);
+      // validate price in subgraph
+      const targetId = `${minterSetPriceV5Address.toLowerCase()}-${genArt721CoreAddress.toLowerCase()}-0`;
+      const minterConfigRes = await getProjectMinterConfigurationDetails(
+        client,
+        targetId
+      );
+      expect(minterConfigRes.basePrice).toBe(newPrice.toString());
+      // @dev this could have been true before the update, but we can't know for sure, and
+      // at least we validate that it's true after the update
+      expect(minterConfigRes.priceIsConfigured).toBe(true);
+    });
+  });
+
+  describe("PricePerTokenReset", () => {
+    afterEach(async () => {
+      // clear the minter for project zero
+      // @dev call success depends on test state, so use a try/catch block
+      try {
+        await sharedMinterFilterContract
+          .connect(artist)
+          .removeMinterForProject(0, genArt721CoreAddress);
+      } catch (error) {
+        // try block will only fail in case of previously failed test where
+        // project zero never had its minter assigned.
+        // Thus, swallow error here because the test failure has already been
+        // reported, and additional error messaging from afterEach is not
+        // helpful.
+      }
+      // @dev we don't clear the currency info for project zero on the ERC20
+      // minter, because it cannot be set to the zero address. Instead, we
+      // deploy new ERC20 currencies for each test, and set the minter to use
+      // that currency
+    });
+
+    test("Currency is updated and configured", async () => {
+      const currencySymbol = "ERC20";
+      // deploy new ERC20 currency, sending initial supply to artist
+      const newCurrency = await new ERC20Mock__factory(artist).deploy(
+        ethers.utils.parseEther("100")
+      );
+      // set minter for project zero to the fixed price ERC20 minter
+      await sharedMinterFilterContract
+        .connect(artist)
+        .setMinterForProject(
+          0,
+          genArt721CoreAddress,
+          minterSetPriceERC20V5Address
+        );
+      // update currency info
+      await minterSetPriceERC20V5Contract
+        .connect(artist)
+        .updateProjectCurrencyInfo(
+          0,
+          genArt721CoreAddress,
+          currencySymbol,
+          newCurrency.address
+        );
+      // configure price
+      const newPrice = ethers.utils.parseEther(Math.random().toString());
+      await minterSetPriceERC20V5Contract
+        .connect(artist)
+        .updatePricePerTokenInWei(0, genArt721CoreAddress, newPrice);
+      await waitUntilSubgraphIsSynced(client);
+      // validate currency info and price is configured in subgraph
+      const targetId = `${minterSetPriceERC20V5Address.toLowerCase()}-${genArt721CoreAddress.toLowerCase()}-0`;
+      const minterConfigRes = await getProjectMinterConfigurationDetails(
+        client,
+        targetId
+      );
+      expect(minterConfigRes.currencySymbol).toBe(currencySymbol);
+      expect(minterConfigRes.currencyAddress).toBe(
+        newCurrency.address.toLowerCase()
+      );
+      expect(minterConfigRes.basePrice).toBe(newPrice.toString());
+      expect(minterConfigRes.priceIsConfigured).toBe(true);
+      // invoke price reset by updating to a different currency
+      const newCurrency2 = await new ERC20Mock__factory(artist).deploy(
+        ethers.utils.parseEther("100")
+      );
+      const currencySymbol2 = "ERC20";
+      await minterSetPriceERC20V5Contract
+        .connect(artist)
+        .updateProjectCurrencyInfo(
+          0,
+          genArt721CoreAddress,
+          currencySymbol2,
+          newCurrency2.address
+        );
+      await waitUntilSubgraphIsSynced(client);
+      // validate currency info and price is NOT configured in subgraph
+      const minterConfigRes2 = await getProjectMinterConfigurationDetails(
+        client,
+        targetId
+      );
+      expect(minterConfigRes2.currencySymbol).toBe(currencySymbol2);
+      expect(minterConfigRes2.currencyAddress).toBe(
+        newCurrency2.address.toLowerCase()
+      );
+      expect(minterConfigRes2.priceIsConfigured).toBe(false);
+      expect(minterConfigRes2.basePrice).toBe("0");
+    });
+  });
+});

--- a/tests/e2e/runner/__tests__/minter-suite-v2/settlement-exp-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/settlement-exp-lib.test.ts
@@ -63,16 +63,16 @@ const genArt721CoreContract = new GenArt721CoreV3__factory(
 ).attach(genArt721CoreAddress);
 
 // get MinterDAExpSettlement contract from the subgraph config
-if (!config.iSharedDAExpSettlementContracts) {
-  throw new Error("No iSharedDAExpSettlementContracts in config");
+if (!config.settlementExpLibContracts) {
+  throw new Error("No settlementExpLibContracts in config");
 }
 const minterDAExpSettlementV3Address =
-  config.iSharedDAExpSettlementContracts[0].address;
+  config.settlementExpLibContracts[0].address;
 const minterDAExpSettlementV3Contract = new MinterDAExpSettlementV3__factory(
   deployer
 ).attach(minterDAExpSettlementV3Address);
 
-describe("iSharedMinterDAExpSettlement event handling", () => {
+describe("SettlementExpLib event handling", () => {
   beforeAll(async () => {
     await waitUntilSubgraphIsSynced(client);
   });

--- a/tests/e2e/runner/__tests__/subgraph-config.d.ts
+++ b/tests/e2e/runner/__tests__/subgraph-config.d.ts
@@ -24,14 +24,17 @@ export type SubgraphConfig = Partial<{
   iDependencyRegistryV0Contracts: { address: string }[];
   ownableUpgradeableDependencyRegistryContracts: { address: string }[];
   ICoreRegistryContracts: { address: string }[];
-  iSharedMinterV0Contracts: { address: string }[];
-  iSharedMerkleContracts: { address: string }[];
-  iSharedHolderContracts: { address: string }[];
-  iSharedSEAContracts: { address: string }[];
-  iSharedDAContracts: { address: string }[];
-  iSharedDAExpContracts: { address: string }[];
-  iSharedDALinContracts: { address: string }[];
-  iSharedDAExpSettlementContracts: { address: string }[];
+  genericMinterEventsLibContracts: { address: string }[];
+  splitFundsLibContracts: { address: string }[];
+  setPriceLibContracts: { address: string }[];
+  maxInvocationsLibContracts: { address: string }[];
+  merkleLibContracts: { address: string }[];
+  holderLibContracts: { address: string }[];
+  SEALibContracts: { address: string }[];
+  DALibContracts: { address: string }[];
+  DAExpLibContracts: { address: string }[];
+  DALinLibContracts: { address: string }[];
+  settlementExpLibContracts: { address: string }[];
   metadata: {
     minterFilterAdminACLAddress: string;
     coreRegistryAddress: string;

--- a/tests/e2e/runner/package.json
+++ b/tests/e2e/runner/package.json
@@ -6,7 +6,7 @@
     "generate-supplemental-abis": "path-exists ./supplemental_abis/*.json && typechain --target ethers-v5 --out-dir ./contracts './supplemental_abis/*.json' || echo 'No supplemental ABIs found.'"
   },
   "devDependencies": {
-    "@artblocks/contracts": "^1.0.4",
+    "@artblocks/contracts": "1.1.0",
     "@graphql-codegen/cli": "^3.0.0",
     "@graphql-codegen/typescript": "^3.0.0",
     "@graphql-codegen/typescript-document-nodes": "^3.0.0",

--- a/tests/e2e/runner/yarn.lock
+++ b/tests/e2e/runner/yarn.lock
@@ -45,17 +45,17 @@
   dependencies:
     node-fetch "^2.6.1"
 
-"@artblocks/contracts@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@artblocks/contracts/-/contracts-1.0.4.tgz#c0fa6a39e5897a71f6b15adef921852ee8c197de"
-  integrity sha512-yaKOtZd+P8NDs2xEc3q+DUrLzIxoInEuuZvVyw+xl+bZD363Qbna+Jos8TOc1LLGJnTDOvpr9KgFxIplTHeE1Q==
+"@artblocks/contracts@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@artblocks/contracts/-/contracts-1.1.0.tgz#3dc17759a672c99bc3d0006d4352bdea92325ea0"
+  integrity sha512-pes9VoiC0pzDoRQbwbVoYKwrQ6kFZUJTt5PUu1j90DNASWvKaNAQSQAUzsKFrDmhpRX0hllbXzlfBDy0tE0D1A==
   dependencies:
     "@openzeppelin-0.5/contracts" "npm:@openzeppelin/contracts@2.5.1"
     "@openzeppelin-4.5/contracts" "npm:@openzeppelin/contracts@4.5.0"
     "@openzeppelin-4.7/contracts" "npm:@openzeppelin/contracts@4.7.1"
     "@openzeppelin-4.8/contracts-upgradeable" "npm:@openzeppelin/contracts-upgradeable@4.8.0"
     "@urql/exchange-retry" "^1.2.0"
-    graphql "^16.8.0"
+    graphql "^16.8.1"
     urql "^4.0.5"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
@@ -3242,7 +3242,7 @@ graphql-ws@5.11.3:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.11.3.tgz#eaf8e6baf669d167975cff13ad86abca4ecfe82f"
   integrity sha512-fU8zwSgAX2noXAsuFiCZ8BtXeXZOzXyK5u1LloCdacsVth4skdBMPO74EG51lBoWSIZ8beUocdpV8+cQHBODnQ==
 
-graphql@^16.8.0, graphql@^16.8.1:
+graphql@^16.8.1:
   version "16.8.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.1.tgz#1930a965bef1170603702acdb68aedd3f3cf6f07"
   integrity sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==

--- a/tests/e2e/seed/package.json
+++ b/tests/e2e/seed/package.json
@@ -5,7 +5,7 @@
     "generate-supplemental-abis": "path-exists ./supplemental_abis/*.json && typechain --target ethers-v5 --out-dir ./contracts './supplemental_abis/*.json' || echo 'No supplemental ABIs found.'"
   },
   "devDependencies": {
-    "@artblocks/contracts": "^1.0.4",
+    "@artblocks/contracts": "1.1.0",
     "@typechain/ethers-v5": "^9.0.0",
     "@types/node": "^18.13.0",
     "ethers": "^5.0.0",

--- a/tests/e2e/seed/scripts/deploy.ts
+++ b/tests/e2e/seed/scripts/deploy.ts
@@ -219,7 +219,17 @@ async function main() {
   );
   await minterSetPriceV5.deployed();
   console.log(`MinterSetPriceV5 deployed at ${minterSetPriceV5.address}`);
-  subgraphConfig.iSharedMinterV0Contracts = [
+  subgraphConfig.genericMinterEventsLibContracts = [
+    {
+      address: minterSetPriceV5.address,
+    },
+  ];
+  subgraphConfig.setPriceLibContracts = [
+    {
+      address: minterSetPriceV5.address,
+    },
+  ];
+  subgraphConfig.maxInvocationsLibContracts = [
     {
       address: minterSetPriceV5.address,
     },
@@ -236,7 +246,18 @@ async function main() {
   console.log(
     `MinterSetPriceERC20V5 deployed at ${minterSetPriceERC20V5.address}`
   );
-  subgraphConfig.iSharedMinterV0Contracts.push({
+  subgraphConfig.genericMinterEventsLibContracts.push({
+    address: minterSetPriceERC20V5.address,
+  });
+  subgraphConfig.splitFundsLibContracts = [
+    {
+      address: minterSetPriceERC20V5.address,
+    },
+  ];
+  subgraphConfig.setPriceLibContracts.push({
+    address: minterSetPriceERC20V5.address,
+  });
+  subgraphConfig.maxInvocationsLibContracts.push({
     address: minterSetPriceERC20V5.address,
   });
 
@@ -250,10 +271,16 @@ async function main() {
   console.log(
     `MinterSetPriceMerkleV5 deployed at ${minterSetPriceMerkleV5.address}`
   );
-  subgraphConfig.iSharedMinterV0Contracts.push({
+  subgraphConfig.genericMinterEventsLibContracts.push({
     address: minterSetPriceMerkleV5.address,
   });
-  subgraphConfig.iSharedMerkleContracts = [
+  subgraphConfig.setPriceLibContracts.push({
+    address: minterSetPriceMerkleV5.address,
+  });
+  subgraphConfig.maxInvocationsLibContracts.push({
+    address: minterSetPriceMerkleV5.address,
+  });
+  subgraphConfig.merkleLibContracts = [
     {
       address: minterSetPriceMerkleV5.address,
     },
@@ -269,10 +296,16 @@ async function main() {
   console.log(
     `minterSetPriceHolderV5 deployed at ${minterSetPriceHolderV5.address}`
   );
-  subgraphConfig.iSharedMinterV0Contracts.push({
+  subgraphConfig.genericMinterEventsLibContracts.push({
     address: minterSetPriceHolderV5.address,
   });
-  subgraphConfig.iSharedHolderContracts = [
+  subgraphConfig.setPriceLibContracts.push({
+    address: minterSetPriceHolderV5.address,
+  });
+  subgraphConfig.maxInvocationsLibContracts.push({
+    address: minterSetPriceHolderV5.address,
+  });
+  subgraphConfig.holderLibContracts = [
     {
       address: minterSetPriceHolderV5.address,
     },
@@ -283,10 +316,13 @@ async function main() {
   const minterSEAV1 = await MinterSEAV1Factory.deploy(minterFilter.address);
   await minterSEAV1.deployed();
   console.log(`minterSEAV1 deployed at ${minterSEAV1.address}`);
-  subgraphConfig.iSharedMinterV0Contracts.push({
+  subgraphConfig.genericMinterEventsLibContracts.push({
     address: minterSEAV1.address,
   });
-  subgraphConfig.iSharedSEAContracts = [
+  subgraphConfig.maxInvocationsLibContracts.push({
+    address: minterSEAV1.address,
+  });
+  subgraphConfig.SEALibContracts = [
     {
       address: minterSEAV1.address,
     },
@@ -297,15 +333,18 @@ async function main() {
   const minterDAExpV5 = await MinterDAExpV5Factory.deploy(minterFilter.address);
   await minterDAExpV5.deployed();
   console.log(`minterDAExpV5 deployed at ${minterDAExpV5.address}`);
-  subgraphConfig.iSharedMinterV0Contracts.push({
+  subgraphConfig.genericMinterEventsLibContracts.push({
     address: minterDAExpV5.address,
   });
-  subgraphConfig.iSharedDAContracts = [
+  subgraphConfig.maxInvocationsLibContracts.push({
+    address: minterDAExpV5.address,
+  });
+  subgraphConfig.DALibContracts = [
     {
       address: minterDAExpV5.address,
     },
   ];
-  subgraphConfig.iSharedDAExpContracts = [
+  subgraphConfig.DAExpLibContracts = [
     {
       address: minterDAExpV5.address,
     },
@@ -316,13 +355,16 @@ async function main() {
   const minterDALinV5 = await MinterDALinV5Factory.deploy(minterFilter.address);
   await minterDALinV5.deployed();
   console.log(`minterDALinV5 deployed at ${minterDALinV5.address}`);
-  subgraphConfig.iSharedMinterV0Contracts.push({
+  subgraphConfig.genericMinterEventsLibContracts.push({
     address: minterDALinV5.address,
   });
-  subgraphConfig.iSharedDAContracts.push({
+  subgraphConfig.maxInvocationsLibContracts.push({
     address: minterDALinV5.address,
   });
-  subgraphConfig.iSharedDALinContracts = [
+  subgraphConfig.DALibContracts.push({
+    address: minterDALinV5.address,
+  });
+  subgraphConfig.DALinLibContracts = [
     {
       address: minterDALinV5.address,
     },
@@ -339,16 +381,19 @@ async function main() {
   console.log(
     `minterDAExpSettlementV3 deployed at ${minterDAExpSettlementV3.address}`
   );
-  subgraphConfig.iSharedMinterV0Contracts.push({
+  subgraphConfig.genericMinterEventsLibContracts.push({
     address: minterDAExpSettlementV3.address,
   });
-  subgraphConfig.iSharedDAContracts.push({
+  subgraphConfig.maxInvocationsLibContracts.push({
     address: minterDAExpSettlementV3.address,
   });
-  subgraphConfig.iSharedDAExpContracts.push({
+  subgraphConfig.DALibContracts.push({
     address: minterDAExpSettlementV3.address,
   });
-  subgraphConfig.iSharedDAExpSettlementContracts = [
+  subgraphConfig.DAExpLibContracts.push({
+    address: minterDAExpSettlementV3.address,
+  });
+  subgraphConfig.settlementExpLibContracts = [
     {
       address: minterDAExpSettlementV3.address,
     },

--- a/tests/e2e/seed/yarn.lock
+++ b/tests/e2e/seed/yarn.lock
@@ -7,17 +7,17 @@
   resolved "https://registry.yarnpkg.com/@0no-co/graphql.web/-/graphql.web-1.0.4.tgz#9606eb651955499525d068ce0ad8bea596286ce2"
   integrity sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==
 
-"@artblocks/contracts@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@artblocks/contracts/-/contracts-1.0.4.tgz#c0fa6a39e5897a71f6b15adef921852ee8c197de"
-  integrity sha512-yaKOtZd+P8NDs2xEc3q+DUrLzIxoInEuuZvVyw+xl+bZD363Qbna+Jos8TOc1LLGJnTDOvpr9KgFxIplTHeE1Q==
+"@artblocks/contracts@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@artblocks/contracts/-/contracts-1.1.0.tgz#3dc17759a672c99bc3d0006d4352bdea92325ea0"
+  integrity sha512-pes9VoiC0pzDoRQbwbVoYKwrQ6kFZUJTt5PUu1j90DNASWvKaNAQSQAUzsKFrDmhpRX0hllbXzlfBDy0tE0D1A==
   dependencies:
     "@openzeppelin-0.5/contracts" "npm:@openzeppelin/contracts@2.5.1"
     "@openzeppelin-4.5/contracts" "npm:@openzeppelin/contracts@4.5.0"
     "@openzeppelin-4.7/contracts" "npm:@openzeppelin/contracts@4.7.1"
     "@openzeppelin-4.8/contracts-upgradeable" "npm:@openzeppelin/contracts-upgradeable@4.8.0"
     "@urql/exchange-retry" "^1.2.0"
-    graphql "^16.8.0"
+    graphql "^16.8.1"
     urql "^4.0.5"
 
 "@babel/code-frame@^7.0.0":
@@ -824,7 +824,7 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graphql@^16.8.0:
+graphql@^16.8.1:
   version "16.8.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.1.tgz#1930a965bef1170603702acdb68aedd3f3cf6f07"
   integrity sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,21 +3,19 @@
 
 
 "@0no-co/graphql.web@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@0no-co/graphql.web/-/graphql.web-1.0.1.tgz#db3da0d2cd41548b50f0583c0d2f4743c767e56b"
-  integrity sha512-6Yaxyv6rOwRkLIvFaL0NrLDgfNqC/Ng9QOPmTmlqW4mORXMEKmh5NYGkIvvt5Yw8fZesnMAqkj8cIqTj8f40cQ==
-
-"@artblocks/contracts@1.0.4":
   version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@artblocks/contracts/-/contracts-1.0.4.tgz#c0fa6a39e5897a71f6b15adef921852ee8c197de"
-  integrity sha512-yaKOtZd+P8NDs2xEc3q+DUrLzIxoInEuuZvVyw+xl+bZD363Qbna+Jos8TOc1LLGJnTDOvpr9KgFxIplTHeE1Q==
+  resolved "https://registry.yarnpkg.com/@0no-co/graphql.web/-/graphql.web-1.0.4.tgz#9606eb651955499525d068ce0ad8bea596286ce2"
+  integrity sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==
+
+"@artblocks/contracts@../artblocks-contracts/packages/contracts/":
+  version "1.0.4"
   dependencies:
     "@openzeppelin-0.5/contracts" "npm:@openzeppelin/contracts@2.5.1"
     "@openzeppelin-4.5/contracts" "npm:@openzeppelin/contracts@4.5.0"
     "@openzeppelin-4.7/contracts" "npm:@openzeppelin/contracts@4.7.1"
     "@openzeppelin-4.8/contracts-upgradeable" "npm:@openzeppelin/contracts-upgradeable@4.8.0"
     "@urql/exchange-retry" "^1.2.0"
-    graphql "^16.8.0"
+    graphql "^16.8.1"
     urql "^4.0.5"
 
 "@assemblyscript/loader@^0.19.22":
@@ -603,9 +601,9 @@
     "@types/node" "*"
 
 "@urql/core@>=4.0.0", "@urql/core@^4.1.0":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@urql/core/-/core-4.1.1.tgz#b1312eb0ecbc91e315457a3ec14741321cbee1c7"
-  integrity sha512-iIoAy6BY+BUZZ7KIpnMT7C9q+ULf5ZCVxGe3/i7WZSJBrQa2h1QkIMhL+8fAKmOn9gt83jSIv5drWWnhZ9izEA==
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/@urql/core/-/core-4.1.4.tgz#d1fe9f278b2d1ff32df2314b00d2d94009271665"
+  integrity sha512-wFm67yljv4uFAWNtPwcS1NMhF/n+p/68i+kZU6R1dPxhfq2nBW0142p4szeZsBDrtO7pBdOhp7YeSZROFFlXZg==
   dependencies:
     "@0no-co/graphql.web" "^1.0.1"
     wonka "^6.3.2"
@@ -1848,10 +1846,10 @@ graphql@^16.6.0:
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
   integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
 
-graphql@^16.8.0:
-  version "16.8.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.0.tgz#374478b7f27b2dc6153c8f42c1b80157f79d79d4"
-  integrity sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==
+graphql@^16.8.1:
+  version "16.8.1"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.1.tgz#1930a965bef1170603702acdb68aedd3f3cf6f07"
+  integrity sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -3652,9 +3650,9 @@ widest-line@^3.1.0:
     string-width "^4.0.0"
 
 wonka@^6.3.2:
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/wonka/-/wonka-6.3.2.tgz#6f32992b332251d7b696b038990f4dc284b3b33d"
-  integrity sha512-2xXbQ1LnwNS7egVm1HPhW2FyKrekolzhpM3mCwXdQr55gO+tAiY76rhb32OL9kKsW8taj++iP7C6hxlVzbnvrw==
+  version "6.3.4"
+  resolved "https://registry.yarnpkg.com/wonka/-/wonka-6.3.4.tgz#76eb9316e3d67d7febf4945202b5bdb2db534594"
+  integrity sha512-CjpbqNtBGNAeyNS/9W6q3kSkKE52+FjIj7AkFlLr11s/VWGUu6a2CdYSdGxocIhIVjaW/zchesBQUKPVU69Cqg==
 
 wordwrap@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,8 +7,10 @@
   resolved "https://registry.yarnpkg.com/@0no-co/graphql.web/-/graphql.web-1.0.4.tgz#9606eb651955499525d068ce0ad8bea596286ce2"
   integrity sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==
 
-"@artblocks/contracts@../artblocks-contracts/packages/contracts/":
-  version "1.0.4"
+"@artblocks/contracts@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@artblocks/contracts/-/contracts-1.1.0.tgz#3dc17759a672c99bc3d0006d4352bdea92325ea0"
+  integrity sha512-pes9VoiC0pzDoRQbwbVoYKwrQ6kFZUJTt5PUu1j90DNASWvKaNAQSQAUzsKFrDmhpRX0hllbXzlfBDy0tE0D1A==
   dependencies:
     "@openzeppelin-0.5/contracts" "npm:@openzeppelin/contracts@2.5.1"
     "@openzeppelin-4.5/contracts" "npm:@openzeppelin/contracts@4.5.0"


### PR DESCRIPTION
## Description of the change

Update subgraph for the many changes coming out of the shared minter suite review.

The updates include:

- Events being emitted from libraries instead of being included in the minter ABIs
- Updated naming of some events and event parameters
- New `PricePerTokenReset` event

The new @artblocks/contracts npm package is used for up-to-date ABIs (in main package.json, and in e2e testing).

## Tests
- A e2e new test is included to test the new `PricePerTokenReset` event handler
- e2e tests are updated for the new subgraph config naming schema, as well as broken out to align with the switch to library-based events
- non-e2e tests are unaffected by the changes in this PR (all shared minter suite testing is done via e2e tests)

note: e2e tests were ran and passed locally on last commit of this PR (no CI)

## Subgraph comparison

Commit [70923db](https://github.com/ArtBlocks/artblocks-subgraph/pull/255/commits/70923db8c78d7e38291dd3eb03ca579589d6d901) was deployed to old dev subgraph, and subgraph-comparison.ts confirmed no discrepancies between this refactor and the currently deployed goerli subgraph. This provides good confirmation that this refactor is WAI.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205750197133849