### PR TITLE
Fix tests on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
       - checkout
       - node/install:
           install-yarn: true
+          node-version: "18.15"
       - node/install-packages:
           pkg-manager: yarn
       - run: node --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ jobs:
       - checkout
       - node/install:
           install-yarn: true
-          lts: true
       - node/install-packages:
           pkg-manager: yarn
       - run: node --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@4.7
+  node: circleci/node@5.1.0
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   test:
     docker:
-      - image: "cimg/base:stable"
+      - image: "cimg/base:current"
     steps:
       - checkout
       - node/install:

--- a/tests/subgraph/legacy-minter-suite/minter-filter-mapping.test.ts
+++ b/tests/subgraph/legacy-minter-suite/minter-filter-mapping.test.ts
@@ -1290,12 +1290,13 @@ test("handleMinterRevoke should remove minter from MinterFilter's minterGlobalAl
   );
   // Minter should remain in store (to persist any populated fields)
   assert.assertNotNull(Minter.load(minter.id));
-  // MinterFilter should still recognize the revoked Minter as an associated minter
+  // cannot query derived field `knownMinters`, so check that minter is in
+  // store with appropriate minterFilter field value
   assert.fieldEquals(
-    MINTER_FILTER_ENTITY_TYPE,
-    minterFilterAddress.toHexString(),
-    "knownMinters",
-    `[${minterToBeRevokedAddress.toHexString()}]`
+    MINTER_ENTITY_TYPE,
+    minterToBeApprovedAddress.toHexString(),
+    "minterFilter",
+    `${minterFilterAddress.toHexString()}`
   );
   // MinterFilter should have been updated
   assert.fieldEquals(
@@ -1365,13 +1366,6 @@ test("handleMinterRevoke should handle revoking a minter more than once", () => 
   );
   // Minter should remain in store (to persist any populated fields)
   assert.assertNotNull(Minter.load(minter.id));
-  // MinterFilter should still recognize the revoked Minter as an associated minter
-  assert.fieldEquals(
-    MINTER_FILTER_ENTITY_TYPE,
-    minterFilterAddress.toHexString(),
-    "knownMinters",
-    `[${minterToBeRevokedAddress.toHexString()}]`
-  );
   // MinterFilter should have been updated
   assert.fieldEquals(
     MINTER_FILTER_ENTITY_TYPE,

--- a/yarn.lock
+++ b/yarn.lock
@@ -813,7 +813,7 @@ assemblyscript@0.19.10:
     binaryen "101.0.0-nightly.20210723"
     long "^4.0.0"
 
-assemblyscript@0.19.23, assemblyscript@^0.19.20, assemblyscript@^0.19.22:
+assemblyscript@0.19.23, assemblyscript@^0.19.22:
   version "0.19.23"
   resolved "https://registry.yarnpkg.com/assemblyscript/-/assemblyscript-0.19.23.tgz#16ece69f7f302161e2e736a0f6a474e6db72134c"
   integrity sha512-fwOQNZVTMga5KRsfY80g7cpOl4PsFQczMwHzdtgoqLXaYhkhavufKb0sB0l3T1DUxpAufA0KNhlbpuuhZUwxMA==
@@ -2469,9 +2469,9 @@ long@^4.0.0:
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
 long@^5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/long/-/long-5.2.1.tgz#e27595d0083d103d2fa2c20c7699f8e0c92b897f"
-  integrity sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
+  integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -2491,12 +2491,10 @@ make-error@^1.1.1:
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 matchstick-as@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/matchstick-as/-/matchstick-as-0.5.0.tgz#cdafc1ef49d670b9cbe98e933bc2a5cb7c450aeb"
-  integrity sha512-4K619YDH+so129qt4RB4JCNxaFwJJYLXPc7drpG+/mIj86Cfzg6FKs/bA91cnajmS1CLHdhHl9vt6Kd6Oqvfkg==
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/matchstick-as/-/matchstick-as-0.5.2.tgz#6a6dde02d1d939c32458bd67bac688891a07a34c"
+  integrity sha512-fb1OVphDKEvJY06Ue02Eh1CNncuW95vp6b8tNAP7UIqplICSLoU/zgN6U7ge7R0upsoO78C7CRi4EyK/7Jxz7g==
   dependencies:
-    "@graphprotocol/graph-ts" "^0.27.0"
-    assemblyscript "^0.19.20"
     wabt "1.0.24"
 
 md5.js@^1.3.4:


### PR DESCRIPTION
## Description of the change

Fix tests that are failing on main.

I'm perplexed as to how these tests ever passed 😕 When CI was re-ran on the same commit, they failed. Either way, this update makes more sense to me.

Also had to update CI cimg to use the new `current` flag instead of the deprecated `stable` flag, due to matchstick removing support for the old version `stable` was tied to. (see https://circleci.com/developer/images/image/cimg/base)
