### PR TITLE
Track purchase details on token mint

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -349,6 +349,26 @@ type Token @entity {
 
   "Next available sale id"
   nextSaleId: BigInt!
+
+  primaryPurchaseDetails: PrimaryPurchaseDetails
+}
+
+type PrimaryPurchaseDetails @entity {
+  id: ID!
+
+  token: Token!
+
+  "Transaction hash of token purchase"
+  transactionHash: Bytes!
+
+  "Address of the minter used to mint token"
+  minterAddress: Bytes
+
+  "Address of currency used to purchase token"
+  currencyAddress: Bytes
+
+  "Symbol of currency used to purchase token"
+  currencySymbol: String
 }
 
 type MinterFilter @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -354,6 +354,7 @@ type Token @entity {
 }
 
 type PrimaryPurchaseDetails @entity {
+  "Unique identifier made up of contract address and token id"
   id: ID!
 
   token: Token!

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -2,13 +2,11 @@ import {
   Address,
   BigInt,
   Bytes,
-  json,
   JSONValue,
-  JSONValueKind,
   TypedMap,
   store,
   log,
-  ethereum
+  ByteArray
 } from "@graphprotocol/graph-ts";
 import { IFilteredMinterV2 } from "../generated/MinterSetPrice/IFilteredMinterV2";
 import {
@@ -20,7 +18,9 @@ import {
   Receipt,
   MinterFilter,
   CoreRegistry,
-  Contract
+  Contract,
+  Token,
+  PrimaryPurchaseDetails
 } from "../generated/schema";
 
 import { IMinterFilterV1 } from "../generated/SharedMinterFilter/IMinterFilterV1";
@@ -34,6 +34,8 @@ import {
 import { createTypedMapFromJSONString } from "./json";
 
 import { KNOWN_MINTER_FILTER_TYPES } from "./constants";
+import { Mint as GenArt721Core2PBABMint } from "../generated/GenArt721Core2PBAB/GenArt721Core2PBAB";
+import { Mint as GenArt721CoreV1Mint } from "../generated/GenArt721Core/GenArt721Core";
 
 export class MinterProjectAndConfig {
   minter: Minter;
@@ -655,5 +657,87 @@ export function snapshotStateAtSettlementRevenueWithdrawal(
       "[WARN] Legacy (non-shared) minter event handler encountered null contract at address {}. Withdrawal details for project {} were not saved to extra minter details",
       [project.contract, project.id]
     );
+  }
+}
+
+/**
+ * Creates a PurchaseDetails entity for a given token based on the provided event and returns its ID.
+ * The function processes events that are instances of GenArt721CoreV1Mint or GenArt721Core2PBABMint.
+ * If the event does not match these types, a warning is logged, and the function returns null.
+ *
+ * The function populates the PurchaseDetails with the minter's address, purchase currency address,
+ * and purchase currency symbol. It first checks for a minter configuration associated with the
+ * token's project. If found, this configuration is used. Otherwise, it falls back to the minter
+ * address from the event's transaction data, provided it's whitelisted in the project's contract.
+ *
+ * In cases where required data is missing or relevant configurations or contracts are not found,
+ * the function logs a warning and returns null.
+ *
+ * @param token - The token for which to create purchase details.
+ * @param project - The project associated with the token.
+ * @param event - The event triggering the creation of purchase details.
+ * @returns The ID of the newly created PurchaseDetails entity if successful, or null if not.
+ */
+export function createPrimaryPurchaseDetailsFromTokenMint<T>(
+  token: Token,
+  project: Project,
+  event: T
+): string | null {
+  if (
+    !(
+      event instanceof GenArt721CoreV1Mint ||
+      event instanceof GenArt721Core2PBABMint
+    )
+  ) {
+    log.warning(
+      "[WARN] createAndAssociatePurchaseDetails was called with an event that is not a GenArt721CoreV1Mint or GenArt721Core2PBABMint. The event was not processed.",
+      []
+    );
+    return null;
+  }
+
+  const purchaseDetails = new PrimaryPurchaseDetails(token.id);
+  purchaseDetails.token = token.id;
+  purchaseDetails.transactionHash = event.transaction.hash;
+
+  // If the token's project has an associated minter configuration, use it to populate the tokens purchase info
+  const minterConfigId = project.minterConfiguration;
+  if (minterConfigId) {
+    const minterConfig = ProjectMinterConfiguration.load(minterConfigId);
+    if (minterConfig) {
+      purchaseDetails.minterAddress = changetype<Bytes>(
+        ByteArray.fromHexString(minterConfig.minter)
+      );
+      purchaseDetails.currencyAddress = minterConfig.currencyAddress;
+      purchaseDetails.currencySymbol = minterConfig.currencySymbol;
+
+      purchaseDetails.save();
+      return purchaseDetails.id;
+    } else {
+      log.warning("Minter configuration with id {} does not exists", [
+        minterConfigId
+      ]);
+      return null;
+    }
+  } else {
+    // If no minter configuration is associated with the project, use the minter currently assigned to the contract
+    const contract = Contract.load(project.contract);
+    const to = changetype<Address>(event.transaction.to || Address.zero());
+
+    // If the transaction to address is a whitelisted minter, use it as the minter address
+    if (contract && contract.mintWhitelisted.includes(to)) {
+      purchaseDetails.minterAddress = to;
+
+      // Assume the minter uses the core contract's currency info
+      purchaseDetails.currencyAddress =
+        project.currencyAddress || Address.zero();
+      purchaseDetails.currencySymbol = project.currencySymbol || "ETH";
+
+      purchaseDetails.save();
+      return purchaseDetails.id;
+    } else {
+      log.warning("Contract with id {} does not exist", [project.contract]);
+      return null;
+    }
   }
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -725,8 +725,15 @@ export function createPrimaryPurchaseDetailsFromTokenMint<T>(
     const to = changetype<Address>(event.transaction.to || Address.zero());
 
     // If the transaction to address is a whitelisted minter, use it as the minter address
-    if (contract && contract.mintWhitelisted.includes(to)) {
-      purchaseDetails.minterAddress = to;
+    // or if there is only one whitelisted minter, use it as the minter address
+    if (
+      contract &&
+      (contract.mintWhitelisted.includes(to) ||
+        contract.mintWhitelisted.length === 1)
+    ) {
+      purchaseDetails.minterAddress = contract.mintWhitelisted.includes(to)
+        ? to
+        : contract.mintWhitelisted[0];
 
       // Assume the minter uses the core contract's currency info
       purchaseDetails.currencyAddress =

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -714,7 +714,7 @@ export function createPrimaryPurchaseDetailsFromTokenMint<T>(
       purchaseDetails.save();
       return purchaseDetails.id;
     } else {
-      log.warning("Minter configuration with id {} does not exists", [
+      log.warning("Minter configuration with id {} does not exist", [
         minterConfigId
       ]);
       return null;

--- a/src/mapping-v0-core.ts
+++ b/src/mapping-v0-core.ts
@@ -60,7 +60,8 @@ import {
   Account,
   AccountProject,
   Whitelisting,
-  ProjectScript
+  ProjectScript,
+  PrimaryPurchaseDetails
 } from "../generated/schema";
 import {
   generateAccountProjectId,
@@ -98,6 +99,17 @@ export function handleMint(event: Mint): void {
     token.updatedAt = event.block.timestamp;
     token.transactionHash = event.transaction.hash;
     token.nextSaleId = BigInt.fromI32(0);
+
+    // V0 Contracts are purchased using the core contract directly
+    const primaryPurchaseDetails = new PrimaryPurchaseDetails(token.id);
+    primaryPurchaseDetails.token = token.id;
+    primaryPurchaseDetails.transactionHash = event.transaction.hash;
+    primaryPurchaseDetails.minterAddress = event.address;
+    primaryPurchaseDetails.currencyAddress = Address.zero();
+    primaryPurchaseDetails.currencySymbol = "ETH";
+    primaryPurchaseDetails.save();
+    token.primaryPurchaseDetails = primaryPurchaseDetails.id;
+
     token.save();
 
     project.invocations = invocation.plus(BigInt.fromI32(1));

--- a/src/mapping-v1-core.ts
+++ b/src/mapping-v1-core.ts
@@ -62,21 +62,18 @@ import {
   Account,
   AccountProject,
   Contract,
-  Whitelisting,
   ProjectScript,
-  MinterFilter,
-  ProjectMinterConfiguration
+  MinterFilter
 } from "../generated/schema";
 
 import {
   generateAccountProjectId,
-  generateWhitelistingId,
   generateContractSpecificId,
   generateProjectScriptId,
   addWhitelisting,
   removeWhitelisting,
   generateTransferId,
-  getProjectMinterConfigId
+  createPrimaryPurchaseDetailsFromTokenMint
 } from "./helpers";
 import { GEN_ART_721_CORE_V1 } from "./constants";
 
@@ -106,6 +103,12 @@ export function handleMint(event: Mint): void {
     token.updatedAt = event.block.timestamp;
     token.transactionHash = event.transaction.hash;
     token.nextSaleId = BigInt.fromI32(0);
+    token.primaryPurchaseDetails = createPrimaryPurchaseDetailsFromTokenMint(
+      token,
+      project,
+      event
+    );
+
     token.save();
 
     project.invocations = invocation.plus(BigInt.fromI32(1));

--- a/src/mapping-v2-core.ts
+++ b/src/mapping-v2-core.ts
@@ -59,20 +59,19 @@ import {
   Account,
   AccountProject,
   Contract,
-  Whitelisting,
   ProjectScript,
   ProjectExternalAssetDependency
 } from "../generated/schema";
 
 import {
   generateAccountProjectId,
-  generateWhitelistingId,
   generateContractSpecificId,
   generateProjectScriptId,
   generateProjectExternalAssetDependencyId,
   addWhitelisting,
   removeWhitelisting,
-  generateTransferId
+  generateTransferId,
+  createPrimaryPurchaseDetailsFromTokenMint
 } from "./helpers";
 import {
   FLEX_CONTRACT_EXTERNAL_ASSET_DEP_TYPES,
@@ -105,6 +104,12 @@ export function handleMint(event: Mint): void {
     token.updatedAt = event.block.timestamp;
     token.transactionHash = event.transaction.hash;
     token.nextSaleId = BigInt.fromI32(0);
+    token.primaryPurchaseDetails = createPrimaryPurchaseDetailsFromTokenMint(
+      token,
+      project,
+      event
+    );
+
     token.save();
 
     project.invocations = invocation.plus(BigInt.fromI32(1));

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -1,4 +1,11 @@
-import { BigInt, store, log, Address, Bytes } from "@graphprotocol/graph-ts";
+import {
+  BigInt,
+  store,
+  log,
+  Address,
+  Bytes,
+  ByteArray
+} from "@graphprotocol/graph-ts";
 
 import {
   Mint,
@@ -50,7 +57,9 @@ import {
   Contract,
   MinterFilter,
   ProposedArtistAddressesAndSplit,
-  ProjectExternalAssetDependency
+  ProjectExternalAssetDependency,
+  ProjectMinterConfiguration,
+  PrimaryPurchaseDetails
 } from "../generated/schema";
 
 import {
@@ -124,6 +133,30 @@ export function handleMint(event: Mint): void {
     token.updatedAt = event.block.timestamp;
     token.transactionHash = event.transaction.hash;
     token.nextSaleId = BigInt.fromI32(0);
+
+    if (project.minterConfiguration) {
+      const minterConfiguration = ProjectMinterConfiguration.load(
+        changetype<string>(project.minterConfiguration)
+      );
+
+      if (minterConfiguration) {
+        const purchaseDetails = new PrimaryPurchaseDetails(token.id);
+        purchaseDetails.token = token.id;
+        purchaseDetails.transactionHash = event.transaction.hash;
+        purchaseDetails.minterAddress = changetype<Bytes>(
+          ByteArray.fromHexString(minterConfiguration.minter)
+        );
+        purchaseDetails.currencyAddress = minterConfiguration.currencyAddress;
+        purchaseDetails.currencySymbol = minterConfiguration.currencySymbol;
+        purchaseDetails.save();
+        token.primaryPurchaseDetails = purchaseDetails.id;
+      } else {
+        log.warning("Minter configuration not found with id: {}", [
+          changetype<string>(project.minterConfiguration)
+        ]);
+      }
+    }
+
     token.save();
 
     project.invocations = invocation.plus(BigInt.fromI32(1));

--- a/tests/subgraph/mapping-v0-core/helpers.ts
+++ b/tests/subgraph/mapping-v0-core/helpers.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
 import {
   assert,
   createMockedFunction,
@@ -251,3 +251,20 @@ export function mockProjectScriptInfoCall(
     .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
     .returns(projectScriptInfoReturnArray);
 }
+
+export const mockShowTokenHashes = function(
+  contractAddress: Address,
+  tokenId: BigInt,
+  hash: Bytes
+): void {
+  let showTokenHashesInput: Array<ethereum.Value> = [
+    ethereum.Value.fromUnsignedBigInt(tokenId)
+  ];
+  createMockedFunction(
+    contractAddress,
+    "showTokenHashes",
+    "showTokenHashes(uint256):(bytes32[])"
+  )
+    .withArgs(showTokenHashesInput)
+    .returns([ethereum.Value.fromBytesArray([hash])]);
+};

--- a/tests/subgraph/mapping-v0-core/original-mapping.test.ts
+++ b/tests/subgraph/mapping-v0-core/original-mapping.test.ts
@@ -24,7 +24,9 @@ import {
   addTestContractToStore,
   TEST_CONTRACT,
   TRANSFER_ENTITY_TYPE,
-  addNewTokenToStore
+  addNewTokenToStore,
+  TEST_TOKEN_HASH,
+  PRIMARY_PURCHASE_DETAILS_ENTITY_TYPE
 } from "../shared-helpers";
 
 import {
@@ -33,12 +35,14 @@ import {
   mockProjectTokenInfoCallWithDefaults,
   mockProjectDetailsCallWithDefaults,
   addNewProjectToStore,
-  mockTokenURICall
+  mockTokenURICall,
+  mockShowTokenHashes
 } from "./helpers";
 
 import {
   Account,
   Contract,
+  PrimaryPurchaseDetails,
   Project,
   ProjectScript,
   Token,
@@ -74,7 +78,8 @@ import {
   UpdateProjectSecondaryMarketRoyaltyPercentageCall,
   UpdateProjectScriptCall,
   UpdateProjectScriptJSONCall,
-  Transfer
+  Transfer,
+  Mint
 } from "../../../generated/GenArt721/GenArt721";
 import {
   handleAddProject,
@@ -106,7 +111,8 @@ import {
   handleUpdateProjectSecondaryMarketRoyaltyPercentage,
   handleUpdateProjectScript,
   handleUpdateProjectScriptJSON,
-  handleTransfer
+  handleTransfer,
+  handleMint
 } from "../../../src/mapping-v0-core";
 
 import {
@@ -1717,7 +1723,7 @@ test("GenArt721: Can handleUpdateProjectScriptJSON", () => {
   const updateCallBlockTimestamp = CURRENT_BLOCK_TIMESTAMP.plus(
     BigInt.fromI32(10)
   );
-  const scriptJSON = '{}';
+  const scriptJSON = "{}";
 
   const call = changetype<UpdateProjectScriptJSONCall>(newMockCall());
 
@@ -1913,25 +1919,25 @@ test("GenArt721: Can handle transfer", () => {
     "token",
     fullTokenId
   );
- 
+
   assert.fieldEquals(
     TRANSFER_ENTITY_TYPE,
     generateTransferId(hash, logIndex),
     "blockHash",
     event.block.hash.toHexString()
-  )
+  );
   assert.fieldEquals(
     TRANSFER_ENTITY_TYPE,
     generateTransferId(hash, logIndex),
     "blockNumber",
     event.block.number.toString()
-  )
+  );
   assert.fieldEquals(
     TRANSFER_ENTITY_TYPE,
     generateTransferId(hash, logIndex),
     "blockTimestamp",
     event.block.timestamp.toString()
-  )
+  );
 });
 
 test("GenArt721: Can handle mint transfer", () => {
@@ -1982,25 +1988,124 @@ test("GenArt721: Can handle mint transfer", () => {
     "token",
     fullTokenId
   );
- 
+
   assert.fieldEquals(
     TRANSFER_ENTITY_TYPE,
     generateTransferId(hash, logIndex),
     "blockHash",
     event.block.hash.toHexString()
-  )
+  );
   assert.fieldEquals(
     TRANSFER_ENTITY_TYPE,
     generateTransferId(hash, logIndex),
     "blockNumber",
     event.block.number.toString()
-  )
+  );
   assert.fieldEquals(
     TRANSFER_ENTITY_TYPE,
     generateTransferId(hash, logIndex),
     "blockTimestamp",
     event.block.timestamp.toString()
-  )
+  );
+});
+
+test("GenArt721: Can handle mint", () => {
+  clearStore();
+  // add contract to store
+  const projectId = BigInt.fromI32(1);
+  const tokenId = BigInt.fromI32(1000001);
+  addTestContractToStore(projectId);
+  mockShowTokenHashes(TEST_CONTRACT_ADDRESS, tokenId, TEST_TOKEN_HASH);
+  // add project to store
+  const fullProjectId = generateContractSpecificId(
+    TEST_CONTRACT_ADDRESS,
+    projectId
+  );
+  const artistAddress = randomAddressGenerator.generateRandomAddress();
+  const projectName = "Test Project";
+  const pricePerTokenInWei = BigInt.fromI64(i64(1e18));
+
+  addNewProjectToStore(
+    projectId,
+    projectName,
+    artistAddress,
+    pricePerTokenInWei,
+    true,
+    CURRENT_BLOCK_TIMESTAMP
+  );
+
+  // handle mint
+  const fullTokenId = generateContractSpecificId(
+    TEST_CONTRACT_ADDRESS,
+    tokenId
+  );
+
+  const toAddress = randomAddressGenerator.generateRandomAddress();
+
+  const hash = Bytes.fromUTF8("QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG");
+
+  const logIndex = BigInt.fromI32(0);
+
+  const event: Mint = changetype<Mint>(newMockEvent());
+  event.address = TEST_CONTRACT_ADDRESS;
+  event.transaction.hash = hash;
+  event.logIndex = logIndex;
+  event.parameters = [
+    new ethereum.EventParam("_to", ethereum.Value.fromAddress(toAddress)),
+    new ethereum.EventParam(
+      "_tokenId",
+      ethereum.Value.fromUnsignedBigInt(tokenId)
+    ),
+    new ethereum.EventParam(
+      "_projectId",
+      ethereum.Value.fromUnsignedBigInt(projectId)
+    ),
+    new ethereum.EventParam(
+      "_invocations",
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(1))
+    ),
+    new ethereum.EventParam(
+      "_value",
+      ethereum.Value.fromUnsignedBigInt(pricePerTokenInWei)
+    )
+  ];
+
+  handleMint(event);
+
+  assert.fieldEquals(
+    TOKEN_ENTITY_TYPE,
+    fullTokenId,
+    "owner",
+    toAddress.toHexString()
+  );
+
+  assert.fieldEquals(
+    PRIMARY_PURCHASE_DETAILS_ENTITY_TYPE,
+    fullTokenId,
+    "token",
+    fullTokenId
+  );
+
+  assert.fieldEquals(
+    PRIMARY_PURCHASE_DETAILS_ENTITY_TYPE,
+    fullTokenId,
+    "minterAddress",
+    TEST_CONTRACT_ADDRESS.toHexString()
+  );
+
+  assert.fieldEquals(
+    PRIMARY_PURCHASE_DETAILS_ENTITY_TYPE,
+    fullTokenId,
+    "currencySymbol",
+    "ETH"
+  );
+
+  assert.fieldEquals(
+    PRIMARY_PURCHASE_DETAILS_ENTITY_TYPE,
+    fullTokenId,
+    "currencyAddress",
+    Address.zero().toHexString()
+  );
 });
 export {
   handleAddProject,
@@ -2031,5 +2136,6 @@ export {
   handleUpdateProjectWebsite,
   handleUpdateProjectSecondaryMarketRoyaltyPercentage,
   handleUpdateProjectScript,
-  handleUpdateProjectScriptJSON
+  handleUpdateProjectScriptJSON,
+  handleMint
 };

--- a/tests/subgraph/mapping-v1-core/mapping.test.ts
+++ b/tests/subgraph/mapping-v1-core/mapping.test.ts
@@ -30,7 +30,8 @@ import {
   addTestContractToStore,
   addNewTokenToStore,
   TRANSFER_ENTITY_TYPE,
-  addNewLegacyProjectMinterConfigToStore
+  addNewLegacyProjectMinterConfigToStore,
+  PRIMARY_PURCHASE_DETAILS_ENTITY_TYPE
 } from "../shared-helpers";
 
 import {
@@ -46,6 +47,7 @@ import {
   Account,
   Contract,
   MinterFilter,
+  PrimaryPurchaseDetails,
   Project,
   ProjectScript,
   Token,
@@ -2307,6 +2309,288 @@ test("GenArt721CoreV1: Can handle Mint", () => {
     "owner",
     toAddress.toHexString()
   );
+});
+
+test("GenArt721CoreV1: Can handle Mint and create purchase details with project minter configuration", () => {
+  clearStore();
+  // add contract to store
+  const projectId = BigInt.fromI32(1);
+  const tokenId = BigInt.fromI32(1000001);
+  addTestContractToStore(projectId);
+  mockTokenIdToHash(TEST_CONTRACT_ADDRESS, tokenId, TEST_TOKEN_HASH);
+  // add project to store
+  const fullProjectId = generateContractSpecificId(
+    TEST_CONTRACT_ADDRESS,
+    projectId
+  );
+  const artistAddress = randomAddressGenerator.generateRandomAddress();
+  const projectName = "Test Project";
+  const pricePerTokenInWei = BigInt.fromI64(i64(1e18));
+
+  const project = addNewProjectToStore(
+    projectId,
+    projectName,
+    artistAddress,
+    pricePerTokenInWei,
+    true,
+    CURRENT_BLOCK_TIMESTAMP
+  );
+
+  const minterAddress = randomAddressGenerator.generateRandomAddress();
+  const currencyAddress = randomAddressGenerator.generateRandomAddress();
+  const currencySymbol = "TEST";
+  const projectMinterConfig = addNewLegacyProjectMinterConfigToStore(
+    fullProjectId,
+    minterAddress
+  );
+  projectMinterConfig.currencyAddress = currencyAddress;
+  projectMinterConfig.currencySymbol = currencySymbol;
+  projectMinterConfig.save();
+
+  project.minterConfiguration = projectMinterConfig.id;
+  project.save();
+
+  // handle mint
+  const fullTokenId = generateContractSpecificId(
+    TEST_CONTRACT_ADDRESS,
+    tokenId
+  );
+
+  const toAddress = randomAddressGenerator.generateRandomAddress();
+
+  const hash = Bytes.fromUTF8("QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG");
+
+  const logIndex = BigInt.fromI32(0);
+
+  const event: Mint = changetype<Mint>(newMockEvent());
+  event.address = TEST_CONTRACT_ADDRESS;
+  event.transaction.hash = hash;
+  event.logIndex = logIndex;
+  event.parameters = [
+    new ethereum.EventParam("_to", ethereum.Value.fromAddress(toAddress)),
+    new ethereum.EventParam(
+      "_tokenId",
+      ethereum.Value.fromUnsignedBigInt(tokenId)
+    ),
+    new ethereum.EventParam(
+      "_projectId",
+      ethereum.Value.fromUnsignedBigInt(projectId)
+    )
+  ];
+
+  handleMint(event);
+
+  assert.fieldEquals(
+    TOKEN_ENTITY_TYPE,
+    fullTokenId,
+    "owner",
+    toAddress.toHexString()
+  );
+
+  assert.fieldEquals(
+    PRIMARY_PURCHASE_DETAILS_ENTITY_TYPE,
+    fullTokenId,
+    "token",
+    fullTokenId
+  );
+
+  assert.fieldEquals(
+    PRIMARY_PURCHASE_DETAILS_ENTITY_TYPE,
+    fullTokenId,
+    "minterAddress",
+    minterAddress.toHexString()
+  );
+
+  assert.fieldEquals(
+    PRIMARY_PURCHASE_DETAILS_ENTITY_TYPE,
+    fullTokenId,
+    "currencyAddress",
+    currencyAddress.toHexString()
+  );
+
+  assert.fieldEquals(
+    PRIMARY_PURCHASE_DETAILS_ENTITY_TYPE,
+    fullTokenId,
+    "currencySymbol",
+    currencySymbol
+  );
+});
+
+test("GenArt721CoreV1: Can handle Mint and create purchase details with allowed minter", () => {
+  clearStore();
+  // add contract to store
+  const projectId = BigInt.fromI32(1);
+  const tokenId = BigInt.fromI32(1000001);
+  const contract = addTestContractToStore(projectId);
+  mockTokenIdToHash(TEST_CONTRACT_ADDRESS, tokenId, TEST_TOKEN_HASH);
+  // add project to store
+  const fullProjectId = generateContractSpecificId(
+    TEST_CONTRACT_ADDRESS,
+    projectId
+  );
+  const artistAddress = randomAddressGenerator.generateRandomAddress();
+  const projectName = "Test Project";
+  const pricePerTokenInWei = BigInt.fromI64(i64(1e18));
+
+  const project = addNewProjectToStore(
+    projectId,
+    projectName,
+    artistAddress,
+    pricePerTokenInWei,
+    true,
+    CURRENT_BLOCK_TIMESTAMP
+  );
+
+  const minterAddress = randomAddressGenerator.generateRandomAddress();
+  const currencyAddress = randomAddressGenerator.generateRandomAddress();
+  const currencySymbol = "TEST";
+  contract.mintWhitelisted = [minterAddress];
+  contract.save();
+
+  project.currencyAddress = currencyAddress;
+  project.currencySymbol = currencySymbol;
+  project.save();
+
+  // handle mint
+  const fullTokenId = generateContractSpecificId(
+    TEST_CONTRACT_ADDRESS,
+    tokenId
+  );
+
+  const toAddress = randomAddressGenerator.generateRandomAddress();
+
+  const hash = Bytes.fromUTF8("QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG");
+
+  const logIndex = BigInt.fromI32(0);
+
+  const event: Mint = changetype<Mint>(newMockEvent());
+  event.address = TEST_CONTRACT_ADDRESS;
+  event.transaction.hash = hash;
+  event.transaction.to = minterAddress;
+  event.logIndex = logIndex;
+  event.parameters = [
+    new ethereum.EventParam("_to", ethereum.Value.fromAddress(toAddress)),
+    new ethereum.EventParam(
+      "_tokenId",
+      ethereum.Value.fromUnsignedBigInt(tokenId)
+    ),
+    new ethereum.EventParam(
+      "_projectId",
+      ethereum.Value.fromUnsignedBigInt(projectId)
+    )
+  ];
+
+  handleMint(event);
+
+  assert.fieldEquals(
+    TOKEN_ENTITY_TYPE,
+    fullTokenId,
+    "owner",
+    toAddress.toHexString()
+  );
+
+  assert.fieldEquals(
+    PRIMARY_PURCHASE_DETAILS_ENTITY_TYPE,
+    fullTokenId,
+    "token",
+    fullTokenId
+  );
+
+  assert.fieldEquals(
+    PRIMARY_PURCHASE_DETAILS_ENTITY_TYPE,
+    fullTokenId,
+    "minterAddress",
+    minterAddress.toHexString()
+  );
+
+  assert.fieldEquals(
+    PRIMARY_PURCHASE_DETAILS_ENTITY_TYPE,
+    fullTokenId,
+    "currencyAddress",
+    currencyAddress.toHexString()
+  );
+
+  assert.fieldEquals(
+    PRIMARY_PURCHASE_DETAILS_ENTITY_TYPE,
+    fullTokenId,
+    "currencySymbol",
+    currencySymbol
+  );
+});
+
+test("GenArt721CoreV1: Can handle Mint without purchase details for unknown minter", () => {
+  clearStore();
+  // add contract to store
+  const projectId = BigInt.fromI32(1);
+  const tokenId = BigInt.fromI32(1000001);
+  const contract = addTestContractToStore(projectId);
+  mockTokenIdToHash(TEST_CONTRACT_ADDRESS, tokenId, TEST_TOKEN_HASH);
+  // add project to store
+  const fullProjectId = generateContractSpecificId(
+    TEST_CONTRACT_ADDRESS,
+    projectId
+  );
+  const artistAddress = randomAddressGenerator.generateRandomAddress();
+  const projectName = "Test Project";
+  const pricePerTokenInWei = BigInt.fromI64(i64(1e18));
+
+  const project = addNewProjectToStore(
+    projectId,
+    projectName,
+    artistAddress,
+    pricePerTokenInWei,
+    true,
+    CURRENT_BLOCK_TIMESTAMP
+  );
+
+  const proxyContractAddress = randomAddressGenerator.generateRandomAddress();
+  const currencyAddress = randomAddressGenerator.generateRandomAddress();
+  const currencySymbol = "TEST";
+  contract.save();
+
+  project.currencyAddress = currencyAddress;
+  project.currencySymbol = currencySymbol;
+  project.save();
+
+  // handle mint
+  const fullTokenId = generateContractSpecificId(
+    TEST_CONTRACT_ADDRESS,
+    tokenId
+  );
+
+  const toAddress = randomAddressGenerator.generateRandomAddress();
+
+  const hash = Bytes.fromUTF8("QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG");
+
+  const logIndex = BigInt.fromI32(0);
+
+  const event: Mint = changetype<Mint>(newMockEvent());
+  event.address = TEST_CONTRACT_ADDRESS;
+  event.transaction.hash = hash;
+  event.transaction.to = proxyContractAddress;
+  event.logIndex = logIndex;
+  event.parameters = [
+    new ethereum.EventParam("_to", ethereum.Value.fromAddress(toAddress)),
+    new ethereum.EventParam(
+      "_tokenId",
+      ethereum.Value.fromUnsignedBigInt(tokenId)
+    ),
+    new ethereum.EventParam(
+      "_projectId",
+      ethereum.Value.fromUnsignedBigInt(projectId)
+    )
+  ];
+
+  handleMint(event);
+
+  assert.fieldEquals(
+    TOKEN_ENTITY_TYPE,
+    fullTokenId,
+    "owner",
+    toAddress.toHexString()
+  );
+
+  assert.notInStore(PRIMARY_PURCHASE_DETAILS_ENTITY_TYPE, fullTokenId);
 });
 
 test("GenArt721Core: Can handle transfer", () => {

--- a/tests/subgraph/mapping-v2-core/helpers.ts
+++ b/tests/subgraph/mapping-v2-core/helpers.ts
@@ -11,6 +11,8 @@ import {
   TEST_CONTRACT,
   DEFAULT_PROJECT_VALUES
 } from "../shared-helpers";
+import { Project } from "../../../generated/schema";
+import { generateContractSpecificId } from "../../../src/helpers";
 
 // helper mock function to initialize a Project entity in local in-memory store
 export function addNewProjectToStore(
@@ -20,7 +22,7 @@ export function addNewProjectToStore(
   pricePerTokenInWei: BigInt,
   mockCallsWithDefaults: boolean,
   timestamp: BigInt | null
-): void {
+): Project {
   if (mockCallsWithDefaults) {
     mockProjectDetailsCallWithDefaults(projectId, projectName);
     mockProjectTokenInfoCallWithDefaults(
@@ -51,6 +53,10 @@ export function addNewProjectToStore(
   ];
 
   handleAddProject(newProjectCall);
+
+  return changetype<Project>(
+    Project.load(generateContractSpecificId(TEST_CONTRACT_ADDRESS, projectId))
+  );
 }
 
 // mocks return values for Soldity contract calls in refreshContract() helper function

--- a/tests/subgraph/shared-helpers.ts
+++ b/tests/subgraph/shared-helpers.ts
@@ -98,6 +98,7 @@ export const RECEIPT_ENTITY_TYPE = "Receipt";
 export const MINTER_FILTER_ENTITY_TYPE = "MinterFilter";
 export const CORE_REGISTRY_TYPE = "CoreRegistry";
 export const MINTER_ENTITY_TYPE = "Minter";
+export const PRIMARY_PURCHASE_DETAILS_ENTITY_TYPE = "PrimaryPurchaseDetails";
 export const ONE_MILLION = 1000000;
 export const RANDOMIZER_ADDRESS = randomAddressGenerator.generateRandomAddress();
 export const IPFS_CID = "QmQCqjqxVXZQ6vXNmZvF7FjyZkCXKXMykCyyPQQrZ6m7W";


### PR DESCRIPTION
## Description of the change
This PR adds a new PrimaryPurchaseDetails entity type that includes data about the minter address used to mint a token, as well as currency info. All core handlers have been updated to add this data. Pre-v3 contracts will not always have this populated as the necessary data is not always available from within the handler.

https://app.asana.com/0/1201568815538912/1205847400671374/f

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
