### PR TITLE
Stop registering new contracts on compromised engine registries

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -64,3 +64,16 @@ export const KNOWN_MINTER_FILTER_TYPES = [
 ];
 
 export const JS_MAX_SAFE_INTEGER = BigInt.fromString("9007199254740991");
+
+// @dev these are used to stop indexing of new engine contracts registered
+// on a compromised core registry contract
+export const COMPROMISED_ENGINE_REGISTRY_ADDRESS_GOERLI =
+  "0xea698596b6009a622c3ed00dd5a8b5d1cae4fc36";
+export const COMPROMISED_ENGINE_REGISTRY_CUTOFF_BLOCK_GOERLI = BigInt.fromI32(
+  10050500
+);
+export const COMPROMISED_ENGINE_REGISTRY_ADDRESS_MAINNET =
+  "0x652490c8bb6e7ec3fd798537d2f348d7904bbbc2";
+export const COMPROMISED_ENGINE_REGISTRY_CUTOFF_BLOCK_MAINNET = BigInt.fromI32(
+  18580700
+);


### PR DESCRIPTION
## Description of the change

\<add description here\>

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
