### PR TITLE
Index dependency registry script type and version overrides in a separate field

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -96,6 +96,9 @@ type Project @entity {
   "Script type and version (see `scriptJSON` if null)"
   scriptTypeAndVersion: String
 
+  "Script type and version override (override set on dependency registry)"
+  scriptTypeAndVersionOverride: String
+
   "Aspect ratio of the project (see `scriptJSON` if null)"
   aspectRatio: String
 


### PR DESCRIPTION
## Description of the change

Updates dependency registry handleProjectDependencyNameAndVersionAdded/Removed functions to modify a new scriptTypeAndVersionOverride field instead of the existing scriptTypeAndVersionField.

Additionally adds a comment addressing the single dependency registry expectation.

https://app.asana.com/0/1201568815538912/1206099136189473/f
https://app.asana.com/0/1201568815538912/1206099136189468/f

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
