### PR TITLE
Null Minter Filter Relation Fix

### DIFF
--- a/tests/subgraph/legacy-minter-suite/minter-filter-mapping.test.ts
+++ b/tests/subgraph/legacy-minter-suite/minter-filter-mapping.test.ts
@@ -865,6 +865,18 @@ test("handleMinterApproved should not add minter to minterGlobalAllowlist if the
     otherMinterFilterAddress.toHexString() != minterFilterAddress.toHexString()
   );
 
+  createMockedFunction(
+    Address.zero(),
+    "coreRegistry",
+    "coreRegistry():(address)"
+  ).reverts();
+
+  createMockedFunction(
+    Address.zero(),
+    "minterFilterType",
+    "minterFilterType():(string)"
+  ).reverts();
+
   const minterApprovedEvent: MinterApproved = changetype<MinterApproved>(
     newMockEvent()
   );


### PR DESCRIPTION
## Description of the change

This PR addresses an issue where a partner unintentionally approved a minter that was compliant with the shared minter interface but not linked to the specific shared minter filter in the current environment. This led to indexing the minter using an incorrect minter filter, not present in the subgraph store. As our schema defines the minter-minter filter relationship as mandatory, this mismatch triggered a failure in querying the minter, with the error `Error retrieving updates: [GraphQL] Null value resolved for non-null field minterFilter`. To resolve this, we've implemented a validation step to ensure the minter's associated minter filter is present in the subgraph store before proceeding with the save operation. In cases where the correct minter filter is absent, a placeholder minter filter is saved to circumvent the issue of null relationships.

This is currently deployed at https://thegraph.com/hosted-service/subgraph/artblocks/art-blocks-artist-staging-goerli

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
