### PR TITLE
Dependency registry config

### DIFF
--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -727,5 +727,19 @@
       "name": "Shared mainnet core registry contract",
       "startBlock": 18486235
     }
+  ],
+  "iDependencyRegistryV0Contracts": [
+    {
+      "address": "0x37861f95882ACDba2cCD84F5bFc4598e2ECDDdAF",
+      "name": "Mainnet dependency registry contract",
+      "startBlock": 18772893
+    }
+  ],
+  "ownableUpgradeableDependencyRegistryContracts": [
+    {
+      "address": "0x37861f95882ACDba2cCD84F5bFc4598e2ECDDdAF",
+      "name": "Mainnet dependency registry contract",
+      "startBlock": 18772893
+    }
   ]
 }

--- a/config/sepolia-dev.json
+++ b/config/sepolia-dev.json
@@ -297,5 +297,19 @@
       "name": "Sepolia staging engine registry contract",
       "startBlock": 4405396
     }
+  ],
+  "iDependencyRegistryV0Contracts": [
+    {
+      "address": "0x5Fcc415BCFb164C5F826B5305274749BeB684e9b",
+      "name": "Sepolia dev dependency registry contract",
+      "startBlock": 4869157
+    }
+  ],
+  "ownableUpgradeableDependencyRegistryContracts": [
+    {
+      "address": "0x5Fcc415BCFb164C5F826B5305274749BeB684e9b",
+      "name": "Sepolia dev dependency registry contract",
+      "startBlock": 4869157
+    }
   ]
 }

--- a/config/sepolia-staging.json
+++ b/config/sepolia-staging.json
@@ -310,5 +310,19 @@
       "name": "Bright Moments - Flex",
       "startBlock": 4849041
     }
+  ],
+  "iDependencyRegistryV0Contracts": [
+    {
+      "address": "0xEFA7Ef074A6E90a99fba8bAd4dCf337ef298387f",
+      "name": "Sepolia staging dependency registry contract",
+      "startBlock": 4874684
+    }
+  ],
+  "ownableUpgradeableDependencyRegistryContracts": [
+    {
+      "address": "0xEFA7Ef074A6E90a99fba8bAd4dCf337ef298387f",
+      "name": "Sepolia staging dependency registry contract",
+      "startBlock": 4874684
+    }
   ]
 }


### PR DESCRIPTION
## Description of the change

Updates config files to index newly deployed dependency registries

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
