### PR TITLE
Add split atomic factory deployments to configs

### DIFF
--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -741,5 +741,12 @@
       "name": "Mainnet dependency registry contract",
       "startBlock": 18772893
     }
+  ],
+  "iSplitAtomicFactoryV0Contracts": [
+    {
+      "address": "0xb26aaD97B0e1d250dB131CD4133c11629EBB4ef7",
+      "name": "Mainnet split atomic factory contract",
+      "startBlock": 18924905
+    }
   ]
 }

--- a/config/sepolia-dev.json
+++ b/config/sepolia-dev.json
@@ -311,5 +311,12 @@
       "name": "Sepolia dev dependency registry contract",
       "startBlock": 4869157
     }
+  ],
+  "iSplitAtomicFactoryV0Contracts": [
+    {
+      "address": "0x39D9580445A3Fcf486c6AD0d06F66fe0d42230eC",
+      "name": "Sepolia dev split atomic factory contract",
+      "startBlock": 5011408
+    }
   ]
 }

--- a/config/sepolia-staging.json
+++ b/config/sepolia-staging.json
@@ -329,5 +329,12 @@
       "name": "Sepolia staging dependency registry contract",
       "startBlock": 4874684
     }
+  ],
+  "iSplitAtomicFactoryV0Contracts": [
+    {
+      "address": "0x39D9580445A3Fcf486c6AD0d06F66fe0d42230eC",
+      "name": "Sepolia staging split atomic factory contract",
+      "startBlock": 5011536
+    }
   ]
 }


### PR DESCRIPTION
## Description of the change

Add split atomic factory deployments to config files.

The factory deployment addresses are sourced from here: https://github.com/ArtBlocks/artblocks-contracts/blob/main/packages/contracts/README.md#splitter-factories
