### PR TITLE
Bugfix - Create bid SEA Minter

### DIFF
--- a/src/sea-lib-mapping.ts
+++ b/src/sea-lib-mapping.ts
@@ -196,6 +196,33 @@ export function handleAuctionInitialized(event: AuctionInitialized): void {
     projectMinterConfig,
     event.block.timestamp
   );
+
+  // Update Bids entity
+  const bidId = generateSEAMinterBidId(
+    event.address.toHexString(),
+    event.params.bidder.toHexString(),
+    event.params.bidAmount.toString(),
+    event.params.tokenId.toString()
+  );
+
+  // @dev: a bid with this ID should not already exist for the SEA Minter
+  const bid = new Bid(bidId);
+  // Create new account entity if one for the bidder doesn't exist
+  const bidderAccount = new Account(event.params.bidder.toHexString());
+  bidderAccount.save();
+
+  bid.project = minterProjectAndConfig.project.id;
+  bid.minter = event.address.toHexString();
+  bid.token = generateContractSpecificId(
+    event.params.coreContract,
+    event.params.tokenId
+  );
+  bid.bidder = bidderAccount.id;
+  bid.value = event.params.bidAmount;
+  bid.winningBid = true;
+  bid.timestamp = event.block.timestamp;
+  bid.updatedAt = event.block.timestamp;
+  bid.save();
 }
 
 export function handleAuctionBid(event: AuctionBid): void {

--- a/src/sea-lib-mapping.ts
+++ b/src/sea-lib-mapping.ts
@@ -198,31 +198,7 @@ export function handleAuctionInitialized(event: AuctionInitialized): void {
   );
 
   // Update Bids entity
-  const bidId = generateSEAMinterBidId(
-    event.address.toHexString(),
-    event.params.bidder.toHexString(),
-    event.params.bidAmount.toString(),
-    event.params.tokenId.toString()
-  );
-
-  // @dev: a bid with this ID should not already exist for the SEA Minter
-  const bid = new Bid(bidId);
-  // Create new account entity if one for the bidder doesn't exist
-  const bidderAccount = new Account(event.params.bidder.toHexString());
-  bidderAccount.save();
-
-  bid.project = minterProjectAndConfig.project.id;
-  bid.minter = event.address.toHexString();
-  bid.token = generateContractSpecificId(
-    event.params.coreContract,
-    event.params.tokenId
-  );
-  bid.bidder = bidderAccount.id;
-  bid.value = event.params.bidAmount;
-  bid.winningBid = true;
-  bid.timestamp = event.block.timestamp;
-  bid.updatedAt = event.block.timestamp;
-  bid.save();
+  createBidFromValidEvent(event);
 }
 
 export function handleAuctionBid(event: AuctionBid): void {
@@ -324,31 +300,7 @@ export function handleAuctionBid(event: AuctionBid): void {
   );
 
   // Update Bids entity
-  const bidId = generateSEAMinterBidId(
-    event.address.toHexString(),
-    event.params.bidder.toHexString(),
-    event.params.bidAmount.toString(),
-    event.params.tokenId.toString()
-  );
-
-  // @dev: a bid with this ID should not already exist for the SEA Minter
-  const bid = new Bid(bidId);
-  // Create new account entity if one for the bidder doesn't exist
-  const bidderAccount = new Account(event.params.bidder.toHexString());
-  bidderAccount.save();
-
-  bid.project = minterProjectAndConfig.project.id;
-  bid.minter = event.address.toHexString();
-  bid.token = generateContractSpecificId(
-    event.params.coreContract,
-    event.params.tokenId
-  );
-  bid.bidder = bidderAccount.id;
-  bid.value = event.params.bidAmount;
-  bid.winningBid = true;
-  bid.timestamp = event.block.timestamp;
-  bid.updatedAt = event.block.timestamp;
-  bid.save();
+  createBidFromValidEvent(event);
 }
 
 export function handleAuctionSettled(event: AuctionSettled): void {
@@ -482,3 +434,59 @@ export function handleProjectNextTokenEjected(
 ///////////////////////////////////////////////////////////////////////////////
 // EVENT HANDLERS end here
 ///////////////////////////////////////////////////////////////////////////////
+
+/**
+ *
+ * @param event AuctionInitialized or AuctionBid event
+ * @description This helper function handles the Bid creation for AuctionInitialized and AuctionBid events
+ */
+function createBidFromValidEvent<T>(event: T): void {
+  // Invalid call, not a valid event
+  if (
+    !(event instanceof AuctionInitialized) &&
+    !(event instanceof AuctionBid)
+  ) {
+    return;
+  }
+  const projectIdNumber = generateProjectIdNumberFromTokenIdNumber(
+    event.params.tokenId
+  );
+  const minterProjectAndConfig = loadOrCreateMinterProjectAndConfigIfProject(
+    event.address, // minter
+    event.params.coreContract,
+    projectIdNumber,
+    event.block.timestamp
+  );
+
+  if (!minterProjectAndConfig) {
+    // project wasn't found, warning already logged in helper function
+    return;
+  }
+
+  // Update Bids entity
+  const bidId = generateSEAMinterBidId(
+    event.address.toHexString(),
+    event.params.bidder.toHexString(),
+    event.params.bidAmount.toString(),
+    event.params.tokenId.toString()
+  );
+
+  // @dev: a bid with this ID should not already exist for the SEA Minter
+  const bid = new Bid(bidId);
+  // Create new account entity if one for the bidder doesn't exist
+  const bidderAccount = new Account(event.params.bidder.toHexString());
+  bidderAccount.save();
+
+  bid.project = minterProjectAndConfig.project.id;
+  bid.minter = event.address.toHexString();
+  bid.token = generateContractSpecificId(
+    event.params.coreContract,
+    event.params.tokenId
+  );
+  bid.bidder = bidderAccount.id;
+  bid.value = event.params.bidAmount;
+  bid.winningBid = true;
+  bid.timestamp = event.block.timestamp;
+  bid.updatedAt = event.block.timestamp;
+  bid.save();
+}

--- a/tests/e2e/runner/__tests__/minter-suite-v2/sea-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/sea-lib.test.ts
@@ -545,7 +545,7 @@ describe("SEALib event handling", () => {
       );
       expect(extraMinterDetails.auctionInitialized).toBe(true);
       expect(extraMinterDetails.auctionSettled).toBe(false);
-      expect(extraMinterDetails.auctionTokenId).toBe(targetTokenId);
+      expect(extraMinterDetails.auctionTokenId).toBe(nextTargetTokenId);
       expect(extraMinterDetails.auctionMinBidIncrementPercentage).toBe(5);
 
       // Validate bid entity was created and auction initialized on target token

--- a/tests/e2e/runner/__tests__/minter-suite-v2/sea-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/sea-lib.test.ts
@@ -528,7 +528,7 @@ describe("SEALib event handling", () => {
       );
       // @dev auction end time should be start time + duration
       expect(extraMinterDetails.auctionEndTime).toBe(
-        auctionInitializedTimestamp + 60
+        auctionSettledBidCreatedTimestamp + 60
       );
       expect(extraMinterDetails.auctionInitialized).toBe(true);
       expect(extraMinterDetails.auctionSettled).toBe(true);

--- a/tests/e2e/runner/__tests__/minter-suite-v2/sea-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/sea-lib.test.ts
@@ -563,7 +563,7 @@ describe("SEALib event handling", () => {
       expect(bidRes.updatedAt).toBe(
         auctionSettledBidCreatedTimestamp.toString()
       );
-      expect(bidRes.project.id).toBe(`${genArt721CoreAddress.toLowerCase()}-1`);
+      expect(bidRes.project.id).toBe(`${genArt721CoreAddress.toLowerCase()}-2`);
       expect(bidRes.minter.id).toBe(minterSEAV1Address.toLowerCase());
       expect(bidRes.token?.id).toBe(
         `${genArt721CoreAddress.toLowerCase()}-${nextTargetTokenId.toString()}`


### PR DESCRIPTION
## Description of the change

When `createBid` is called and an auction has not yet been initialized, an auction is initialized with a starting bid equal to the amount of msg.value. This PR creates a Bid for this initial bid in the AuctionInitialized event handler.
