### PR TITLE
Add base uri to create project to capture default value

### DIFF
--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -460,7 +460,8 @@ function createProject(
     projectDetails.reverted ||
     projectScriptDetails.reverted ||
     projectStateData.reverted ||
-    projectArtistAddress.reverted
+    projectArtistAddress.reverted ||
+    projectBaseURI.reverted
   ) {
     log.warning("Failed to get project details for new project: {}-{}", [
       contractAddress,
@@ -488,6 +489,7 @@ function createProject(
   let project = new Project(
     generateContractSpecificId(contract._address, projectId)
   );
+
 
   project.active = false;
   project.artist = artist.id;

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -454,6 +454,7 @@ function createProject(
   const projectScriptDetails = contract.try_projectScriptDetails(projectId);
   const projectStateData = contract.try_projectStateData(projectId);
   const projectArtistAddress = contract.try_projectIdToArtistAddress(projectId);
+  const projectBaseURI = contract.try_projectURIInfo(projectId);
 
   if (
     projectDetails.reverted ||
@@ -492,6 +493,7 @@ function createProject(
   project.active = false;
   project.artist = artist.id;
   project.artistAddress = artistAddress;
+  project.baseUri = projectBaseURI.value;
   project.complete = false;
   project.contract = contractAddress;
   project.createdAt = timestamp;

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -470,7 +470,6 @@ function createProject(
   }
 
   let name = projectDetails.value.getProjectName();
-  let artistName = projectDetails.value.getArtist();
 
   let artistAddress = projectArtistAddress.value;
   let artist = new Account(artistAddress.toHexString());

--- a/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
@@ -1301,6 +1301,7 @@ describe(`${coreType}: handleProjectUpdated`, () => {
       const maxInvocations = BigInt.fromI32(ONE_MILLION);
       const paused = true;
       const scriptCount = BigInt.fromI32(0);
+      const newBaseUri = "New Base URI";
 
       const event: ProjectUpdated = changetype<ProjectUpdated>(newMockEvent());
       event.address = TEST_CONTRACT_ADDRESS;
@@ -1366,6 +1367,15 @@ describe(`${coreType}: handleProjectUpdated`, () => {
         .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
         .returns([ethereum.Value.fromAddress(artistAddress)]);
 
+      // // mock projectURIInfo
+      createMockedFunction(
+        TEST_CONTRACT_ADDRESS,
+        "projectURIInfo",
+        "projectURIInfo(uint256):(string)"
+      )
+        .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
+        .returns([ethereum.Value.fromString(newBaseUri)]);
+
       handleProjectUpdated(event);
 
       // Artist entity
@@ -1388,6 +1398,12 @@ describe(`${coreType}: handleProjectUpdated`, () => {
         generateContractSpecificId(TEST_CONTRACT_ADDRESS, projectId),
         "artistAddress",
         artistAddress.toHexString()
+      );
+      assert.fieldEquals(
+        PROJECT_ENTITY_TYPE,
+        generateContractSpecificId(TEST_CONTRACT_ADDRESS, projectId),
+        "baseUri",
+        newBaseUri
       );
       assert.fieldEquals(
         PROJECT_ENTITY_TYPE,

--- a/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
@@ -1221,7 +1221,7 @@ describe(`${coreType}: handleProjectUpdated`, () => {
 
     test("should do nothing if request for project info reverts", () => {
       const projectId = BigInt.fromI32(0);
-
+      const newBaseUri = "New Base URI";
       const event: ProjectUpdated = changetype<ProjectUpdated>(newMockEvent());
       event.address = TEST_CONTRACT_ADDRESS;
       event.parameters = [
@@ -1284,6 +1284,15 @@ describe(`${coreType}: handleProjectUpdated`, () => {
       )
         .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
         .reverts();
+
+      // // mock projectURIInfo
+      createMockedFunction(
+        TEST_CONTRACT_ADDRESS,
+        "projectURIInfo",
+        "projectURIInfo(uint256):(string)"
+      )
+        .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
+        .returns([ethereum.Value.fromString(newBaseUri)]);
 
       handleProjectUpdated(event);
 

--- a/tests/subgraph/mapping-v3-core/mapping-v3-engine-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-engine-core.test.ts
@@ -86,6 +86,7 @@ import {
   generateProjectScriptId,
   generateWhitelistingId
 } from "../../../src/helpers";
+import { logStore, log } from "matchstick-as";
 
 const randomAddressGenerator = new RandomAddressGenerator();
 
@@ -1078,7 +1079,7 @@ describe(`${coreType}: handleProjectUpdated`, () => {
 
     test("should do nothing if request for project info reverts", () => {
       const projectId = BigInt.fromI32(0);
-
+      const newBaseUri = "New Base URI";
       const event: ProjectUpdated = changetype<ProjectUpdated>(newMockEvent());
       event.address = TEST_CONTRACT_ADDRESS;
       event.parameters = [
@@ -1142,6 +1143,15 @@ describe(`${coreType}: handleProjectUpdated`, () => {
         .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
         .reverts();
 
+      // // mock projectURIInfo
+      createMockedFunction(
+        TEST_CONTRACT_ADDRESS,
+        "projectURIInfo",
+        "projectURIInfo(uint256):(string)"
+      )
+        .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
+        .returns([ethereum.Value.fromString(newBaseUri)]);
+
       handleProjectUpdated(event);
 
       assert.notInStore(
@@ -1158,6 +1168,7 @@ describe(`${coreType}: handleProjectUpdated`, () => {
       const maxInvocations = BigInt.fromI32(ONE_MILLION);
       const paused = true;
       const scriptCount = BigInt.fromI32(0);
+      const newBaseUri = "New Base URI";
 
       const event: ProjectUpdated = changetype<ProjectUpdated>(newMockEvent());
       event.address = TEST_CONTRACT_ADDRESS;
@@ -1222,6 +1233,15 @@ describe(`${coreType}: handleProjectUpdated`, () => {
       )
         .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
         .returns([ethereum.Value.fromAddress(artistAddress)]);
+
+      // // mock projectURIInfo
+      createMockedFunction(
+        TEST_CONTRACT_ADDRESS,
+        "projectURIInfo",
+        "projectURIInfo(uint256):(string)"
+      )
+        .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
+        .returns([ethereum.Value.fromString(newBaseUri)]);
 
       handleProjectUpdated(event);
 

--- a/tests/subgraph/mapping-v3-core/mapping-v3-engine-flex-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-engine-flex-core.test.ts
@@ -55,7 +55,6 @@ import {
   PlatformUpdated
 } from "../../../generated/IGenArt721CoreV3_Base/IGenArt721CoreContractV3_Base";
 
-
 import { Transfer } from "../../../generated/IERC721GenArt721CoreV3Contract/IERC721";
 import { OwnershipTransferred } from "../../../generated/OwnableGenArt721CoreV3Contract/Ownable";
 import { SuperAdminTransferred } from "../../../generated/AdminACLV0/IAdminACLV0";
@@ -1080,7 +1079,7 @@ describe(`${coreType}: handleProjectUpdated`, () => {
 
     test("should do nothing if request for project info reverts", () => {
       const projectId = BigInt.fromI32(0);
-
+      const newBaseUri = "New Base URI";
       const event: ProjectUpdated = changetype<ProjectUpdated>(newMockEvent());
       event.address = TEST_CONTRACT_ADDRESS;
       event.parameters = [
@@ -1143,6 +1142,14 @@ describe(`${coreType}: handleProjectUpdated`, () => {
       )
         .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
         .reverts();
+      // // mock projectURIInfo
+      createMockedFunction(
+        TEST_CONTRACT_ADDRESS,
+        "projectURIInfo",
+        "projectURIInfo(uint256):(string)"
+      )
+        .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
+        .returns([ethereum.Value.fromString(newBaseUri)]);
 
       handleProjectUpdated(event);
 
@@ -1160,6 +1167,7 @@ describe(`${coreType}: handleProjectUpdated`, () => {
       const maxInvocations = BigInt.fromI32(ONE_MILLION);
       const paused = true;
       const scriptCount = BigInt.fromI32(0);
+      const newBaseUri = "New Base URI";
 
       const event: ProjectUpdated = changetype<ProjectUpdated>(newMockEvent());
       event.address = TEST_CONTRACT_ADDRESS;
@@ -1224,6 +1232,15 @@ describe(`${coreType}: handleProjectUpdated`, () => {
       )
         .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
         .returns([ethereum.Value.fromAddress(artistAddress)]);
+
+      // // mock projectURIInfo
+      createMockedFunction(
+        TEST_CONTRACT_ADDRESS,
+        "projectURIInfo",
+        "projectURIInfo(uint256):(string)"
+      )
+        .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
+        .returns([ethereum.Value.fromString(newBaseUri)]);
 
       handleProjectUpdated(event);
 

--- a/tests/subgraph/mapping-v3-core/mapping-v3p2-engine-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3p2-engine-core.test.ts
@@ -1170,6 +1170,7 @@ describe(`${coreType}-${coreVersion}: handleProjectUpdated`, () => {
 
     test("should do nothing if request for project info reverts", () => {
       const projectId = BigInt.fromI32(0);
+      const newBaseUri = "New Base URI";
 
       const event: ProjectUpdated = changetype<ProjectUpdated>(newMockEvent());
       event.address = TEST_CONTRACT_ADDRESS;
@@ -1234,6 +1235,15 @@ describe(`${coreType}-${coreVersion}: handleProjectUpdated`, () => {
         .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
         .reverts();
 
+      // // mock projectURIInfo
+      createMockedFunction(
+        TEST_CONTRACT_ADDRESS,
+        "projectURIInfo",
+        "projectURIInfo(uint256):(string)"
+      )
+        .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
+        .returns([ethereum.Value.fromString(newBaseUri)]);
+
       handleProjectUpdated(event);
 
       assert.notInStore(
@@ -1250,6 +1260,7 @@ describe(`${coreType}-${coreVersion}: handleProjectUpdated`, () => {
       const maxInvocations = BigInt.fromI32(ONE_MILLION);
       const paused = true;
       const scriptCount = BigInt.fromI32(0);
+      const newBaseUri = "New Base URI";
 
       const event: ProjectUpdated = changetype<ProjectUpdated>(newMockEvent());
       event.address = TEST_CONTRACT_ADDRESS;
@@ -1364,6 +1375,15 @@ describe(`${coreType}-${coreVersion}: handleProjectUpdated`, () => {
       )
         .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
         .returns([ethereum.Value.fromTuple(tuple)]);
+
+      // // mock projectURIInfo
+      createMockedFunction(
+        TEST_CONTRACT_ADDRESS,
+        "projectURIInfo",
+        "projectURIInfo(uint256):(string)"
+      )
+        .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
+        .returns([ethereum.Value.fromString(newBaseUri)]);
 
       handleProjectUpdated(event);
 


### PR DESCRIPTION
## Description of the change

baseURI if never updated is never synced -- so it causes confusion if it is set correctly if viewing purely from the CD.
This updates the create project to instantiate the default base uri returned from the contract

