### PR TITLE
Handle project royalty splitter updates

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -129,6 +129,9 @@ type Project @entity {
   "Proposed Artist addresses and payment split percentages"
   proposedArtistAddressesAndSplits: ProposedArtistAddressesAndSplit
 
+  "ERC-2981 royalty splitter address, used on v3.2 and-on"
+  erc2981SplitterAddress: Bytes
+
   "Accounts that own tokens of the project"
   owners: [AccountProject!] @derivedFrom(field: "project")
 

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -158,6 +158,8 @@ dataSources:
           handler: handleProposedArtistAddressesAndSplits
         - event: AcceptedArtistAddressesAndSplits(indexed uint256)
           handler: handleAcceptedArtistAddressesAndSplits
+        - event: ProjectRoyaltySplitterUpdated(indexed uint256,indexed address)
+          handler: handleProjectRoyaltySplitterUpdated
       file: ./src/mapping-v3-core.ts
   {{/iGenArt721CoreContractV3_BaseContracts}}
   {{#ownableGenArt721CoreV3Contracts}}


### PR DESCRIPTION
## Description of the change

Handle and index project royalty splitter updates.

Naming is aligned with previously merged downstream indexing updates.

Test added, non-e2e to be consistent with our existing V3 core test suite.
