### PR TITLE
Override contract coreVersion() for known testnet issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test:e2e": "cd tests/e2e && GRAPH_NODE_BASE_IMAGE=graphprotocol/graph-node:latest docker compose -f docker-compose.yml -f docker-compose.test.yml up --exit-code-from runner",
     "test:e2e:m1": "cd tests/e2e && GRAPH_NODE_BASE_IMAGE=graph-node:latest docker compose -f docker-compose.yml -f docker-compose.test.yml up --exit-code-from runner",
     "test:e2e:ci": "cd tests/e2e && GRAPH_NODE_BASE_IMAGE=graphprotocol/graph-node:latest docker compose -f docker-compose.yml -f docker-compose.ci.yml up --exit-code-from runner",
-    "run:local": "cd tests/e2e && docker compose -f docker-compose.yml -f docker-compose.local.yml up",
+    "run:local": "cd tests/e2e && GRAPH_NODE_BASE_IMAGE=graph-node:latest docker compose -f docker-compose.yml -f docker-compose.local.yml up",
     "coverage": "graph test -- -c",
     "deploy:mainnet-hosted": "yarn prepare:mainnet && graph deploy --product hosted-service --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ artblocks/art-blocks",
     "deploy:mainnet-with-secondary-hosted": "yarn prepare:mainnet-with-secondary && graph deploy --product hosted-service --ac --node https://api.thegraph.com/deploy/ --ipfs https://api.thegraph.com/ipfs/ artblocks/art-blocks-with-secondary",


### PR DESCRIPTION
## Description of the change

Override contract coreVersion() for known testnet issues where v3.2.2 was returned.

This is required because our V3 core handler logic is now branched based on contract minor version.
