### PR TITLE
Add new flex dependency type

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -848,6 +848,8 @@ enum ProjectExternalAssetDependencyType {
   ARWEAVE
   "Asset hosted on chain"
   ONCHAIN
+  "Asset defined on the Art Blocks Dependency Registry"
+  ART_BLOCKS_DEPENDENCY_REGISTRY
 }
 
 type ProjectExternalAssetDependency @entity {
@@ -860,7 +862,7 @@ type ProjectExternalAssetDependency @entity {
   "The dependency type"
   dependencyType: ProjectExternalAssetDependencyType!
 
-  "The dependency cid. This will be an empty string assets of type ONCHAIN."
+  "The dependency cid. This will be the CID of the dependency if IPFS or ARWEAVE, empty string of ONCHAIN, or a string representation of the Art Blocks Dependency Registry's `dependencyNameAndVersion` if ART_BLOCKS_DEPENDENCY_REGISTRY."
   cid: String!
 
   "The dependency index"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -52,7 +52,8 @@ export const ERC1155 = "ERC1155";
 export const FLEX_CONTRACT_EXTERNAL_ASSET_DEP_TYPES = [
   "IPFS",
   "ARWEAVE",
-  "ONCHAIN"
+  "ONCHAIN",
+  "ART_BLOCKS_DEPENDENCY_REGISTRY"
 ];
 
 // This is directly tied to the MinterFilterType enum defined in the subgraph schema


### PR DESCRIPTION
## Description of the change

Add new flex dependency type of `ART_BLOCKS_DEPENDENCY_REGISTRY`.

This is a required update to not crash when encountering the capabilities added in https://github.com/ArtBlocks/artblocks-contracts/pull/1518

## Follow on

A similar update is required for our db to also prevent issues while syncing the new enum value.

linear: https://linear.app/art-blocks/issue/PRO-220/update-subgraph-for-new-dependency-registry-flex-asset-type
