### PR TITLE
add missing event + handler to v3 base template

### DIFF
--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -2377,6 +2377,8 @@ templates:
           handler: handleProposedArtistAddressesAndSplits
         - event: AcceptedArtistAddressesAndSplits(indexed uint256)
           handler: handleAcceptedArtistAddressesAndSplits
+        - event: ProjectRoyaltySplitterUpdated(indexed uint256,indexed address)
+          handler: handleProjectRoyaltySplitterUpdated
       file: ./src/mapping-v3-core.ts
 
   - name: OwnableGenArt721CoreV3Contract_Template


### PR DESCRIPTION
## Description of the change

Align data source template with config events+handlers by adding missing event to template.

This fixes a bug where royalty splitter updated events were not being detected on the new v3.2 core contracts deployed via EngineRegistry.

## Test

Confirmed to be working on dev subgraph!