### PR TITLE
Index adminArtistOnlyMintPeriod boolean on RAM extraMinterDetails

### DIFF
--- a/src/ram-lib-mapping.ts
+++ b/src/ram-lib-mapping.ts
@@ -177,7 +177,7 @@ export function handleAuctionConfigUpdated(event: AuctionConfigUpdated): void {
       value: toJSONValue(event.params.numTokensInAuction)
     },
     {
-      key: "adminOnlyMintPeriodIfSellout",
+      key: "adminArtistOnlyMintPeriodIfSellout",
       value: toJSONValue(event.params.adminArtistOnlyMintPeriodIfSellout)
     }
   ]);

--- a/src/ram-lib-mapping.ts
+++ b/src/ram-lib-mapping.ts
@@ -175,6 +175,10 @@ export function handleAuctionConfigUpdated(event: AuctionConfigUpdated): void {
     {
       key: "numTokensInAuction",
       value: toJSONValue(event.params.numTokensInAuction)
+    },
+    {
+      key: "adminOnlyMintPeriodIfSellout",
+      value: toJSONValue(event.params.adminArtistOnlyMintPeriodIfSellout)
     }
   ]);
 

--- a/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
@@ -215,6 +215,7 @@ describe("RAMLib event handling", () => {
       const extraMinterDetails = JSON.parse(minterConfigRes.extraMinterDetails);
       expect(extraMinterDetails.startTime).toBe(targetAuctionStart);
       expect(extraMinterDetails.auctionEndTime).toBe(targetAuctionEnd);
+      expect(extraMinterDetails.adminArtistOnlyMintPeriodIfSellout).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Description of the change
In order to determine what function should be called in the creator dashboard to batch mint, index adminArtistOnlyMintPeriod

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
