### PR TITLE
Index project royalty splitters

### DIFF
--- a/abis-supplemental/IGenArt721CoreContractV3_Engine.json
+++ b/abis-supplemental/IGenArt721CoreContractV3_Engine.json
@@ -348,6 +348,86 @@
     {
       "inputs": [
         {
+          "components": [
+            {
+              "internalType": "string",
+              "name": "tokenName",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "tokenSymbol",
+              "type": "string"
+            },
+            {
+              "internalType": "address",
+              "name": "renderProviderAddress",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "platformProviderAddress",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "newSuperAdminAddress",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "randomizerContract",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "splitProviderAddress",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "minterFilterAddress",
+              "type": "address"
+            },
+            {
+              "internalType": "uint248",
+              "name": "startingProjectId",
+              "type": "uint248"
+            },
+            {
+              "internalType": "bool",
+              "name": "autoApproveArtistSplitProposals",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "nullPlatformProvider",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "allowArtistProjectActivation",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct EngineConfiguration",
+          "name": "engineConfiguration",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "adminACLContract_",
+          "type": "address"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
           "internalType": "address",
           "name": "minter",
           "type": "address"
@@ -680,6 +760,19 @@
       "name": "setTokenHash_8PT",
       "outputs": [],
       "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "splitProvider",
+      "outputs": [
+        {
+          "internalType": "contract ISplitProviderV0",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
       "type": "function"
     },
     {

--- a/abis-supplemental/IGenArt721CoreContractV3_Engine_Flex.json
+++ b/abis-supplemental/IGenArt721CoreContractV3_Engine_Flex.json
@@ -459,6 +459,86 @@
     {
       "inputs": [
         {
+          "components": [
+            {
+              "internalType": "string",
+              "name": "tokenName",
+              "type": "string"
+            },
+            {
+              "internalType": "string",
+              "name": "tokenSymbol",
+              "type": "string"
+            },
+            {
+              "internalType": "address",
+              "name": "renderProviderAddress",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "platformProviderAddress",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "newSuperAdminAddress",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "randomizerContract",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "splitProviderAddress",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "minterFilterAddress",
+              "type": "address"
+            },
+            {
+              "internalType": "uint248",
+              "name": "startingProjectId",
+              "type": "uint248"
+            },
+            {
+              "internalType": "bool",
+              "name": "autoApproveArtistSplitProposals",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "nullPlatformProvider",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "allowArtistProjectActivation",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct EngineConfiguration",
+          "name": "engineConfiguration",
+          "type": "tuple"
+        },
+        {
+          "internalType": "address",
+          "name": "adminACLContract_",
+          "type": "address"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
           "internalType": "address",
           "name": "minter",
           "type": "address"
@@ -913,6 +993,19 @@
       "name": "setTokenHash_8PT",
       "outputs": [],
       "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "splitProvider",
+      "outputs": [
+        {
+          "internalType": "contract ISplitProviderV0",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
       "type": "function"
     },
     {

--- a/schema.graphql
+++ b/schema.graphql
@@ -132,6 +132,9 @@ type Project @entity {
   "ERC-2981 royalty splitter address, used on v3.2 and-on"
   erc2981SplitterAddress: Bytes
 
+  "Royalty splitter contract, used on v3.2 and-on"
+  erc2981SplitterContract: RoyaltySplitterContract
+
   "Accounts that own tokens of the project"
   owners: [AccountProject!] @derivedFrom(field: "project")
 
@@ -283,6 +286,9 @@ type Contract @entity {
 
   "Dependency registry contract address"
   dependencyRegistry: DependencyRegistry
+
+  "Curent royalty split provider contract address, used on v3.2 and-on"
+  royaltySplitProvider: Bytes
 
   nextProjectId: BigInt!
 
@@ -635,6 +641,40 @@ type SplitAtomicSplit @entity {
 
   "Basis points of the split"
   basisPoints: BigInt!
+}
+
+type RoyaltySplitterContract @entity {
+  "unique identifier equal to royalty splitter's contract address"
+  id: ID!
+
+  "split provider contract address that was used to create this contract"
+  splitProviderCreator: Bytes!
+
+  "Core contract that this royalty splitter is associated with"
+  coreContract: Contract!
+
+  "Total allocation of all recipients on the contract"
+  totalAllocation: BigInt!
+
+  "List of split atomic contract splits"
+  royaltySplitRecipients: [RoyaltySplitRecipient!]!
+    @derivedFrom(field: "royaltySplitterContract")
+
+  createdAt: BigInt!
+}
+
+type RoyaltySplitRecipient @entity {
+  "unique identifier equal to {royalty splitter contract address}-{recipient address}"
+  id: ID!
+
+  "Royalty splitter contract that contains this split recipient"
+  royaltySplitterContract: RoyaltySplitterContract!
+
+  "Address of the recipient of this split"
+  recipientAddress: Bytes!
+
+  "Allocation of the recipient on the split. Recipient receives allocation / totalAllocation of all funds sent to the splitter"
+  allocation: BigInt!
 }
 
 enum SaleType {

--- a/schema.graphql
+++ b/schema.graphql
@@ -132,7 +132,7 @@ type Project @entity {
   "ERC-2981 royalty splitter address, used on v3.2 and-on"
   erc2981SplitterAddress: Bytes
 
-  "Royalty splitter contract, used on v3.2 and-on"
+  "The active royalty splitter contract, used on v3.2 and-on"
   erc2981SplitterContract: RoyaltySplitterContract
 
   "Accounts that own tokens of the project"

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -217,17 +217,6 @@ export function loadOrCreateRoyaltySplitterContract(
     throw new Error("Project entity does not have a contract field.");
   }
 
-  if (!contract.royaltySplitProvider) {
-    // should never happen, because project.contract is a required field
-    log.error(
-      "[WARN] Could not load royalty split provider address on contract with id {} when creating RoyaltySplitterContract entity with id {}",
-      [project.contract, royaltySplitterId]
-    );
-    throw new Error(
-      "v3.2+ Contract entity does not have a royalty split provider field, which is an invalid state."
-    );
-  }
-
   // get project's payment state via call to contract, because project entity may not be up-to-date
   // due to event ordering
   const boundContract = IGenArt721CoreContractV3_ProjectFinance.bind(

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -717,6 +717,9 @@ function createProject(
   project.scriptCount = scriptCount;
   project.useHashString = useHashString;
   project.useIpfs = false;
+  // @dev subsequent events will update royalty splitter address fields
+  project.erc2981SplitterAddress = null;
+  project.erc2981SplitterContract = null;
 
   // populate the project's financial information
   // available on all cores, populated to non-zero value for new projects on v3.2+ cores
@@ -1842,7 +1845,7 @@ function getIsLegacyMinterFilter(minterFilterAddress: Address): boolean {
  * @param version version string of V3 core contract
  * @returns boolean, true if the version is pre-v3.2, false otherwise.
  */
-function getIsPreV3_2(version: string): boolean {
+export function getIsPreV3_2(version: string): boolean {
   return version.startsWith("v3.0.") || version.startsWith("v3.1.");
 }
 

--- a/tests/subgraph/mapping-v3-core/mapping-v3-engine-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-engine-core.test.ts
@@ -939,6 +939,23 @@ test(`${coreType}: Handles PlatformUpdated::dependencyRegistryAddress - default 
   );
 });
 
+test(`${coreType}: does not populate royaltySplitProvider on contract refresh for v3.2`, () => {
+  // default value is false
+  clearStore();
+  // add new contract to store
+  const projectId = BigInt.fromI32(0);
+  addTestContractToStore(projectId);
+  mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
+
+  // value should be null on pre-v3.2
+  assert.fieldEquals(
+    CONTRACT_ENTITY_TYPE,
+    TEST_CONTRACT_ADDRESS.toHexString(),
+    "royaltySplitProvider",
+    "null"
+  );
+});
+
 test(`${coreType}: Handles PlatformUpdated::dependencyRegistryAddress - changed value`, () => {
   clearStore();
   // add new contract to store
@@ -1592,6 +1609,19 @@ describe(`${coreType}: handleProjectUpdated`, () => {
         generateContractSpecificId(TEST_CONTRACT_ADDRESS, projectId),
         "enginePlatformProviderSecondarySalesBPS",
         TEST_CONTRACT.defaultEnginePlatformProviderSecondarySalesBPS.toString()
+      );
+      // pre-v3.2 should have null splitters
+      assert.fieldEquals(
+        PROJECT_ENTITY_TYPE,
+        generateContractSpecificId(TEST_CONTRACT_ADDRESS, projectId),
+        "erc2981SplitterAddress",
+        "null"
+      );
+      assert.fieldEquals(
+        PROJECT_ENTITY_TYPE,
+        generateContractSpecificId(TEST_CONTRACT_ADDRESS, projectId),
+        "erc2981SplitterContract",
+        "null"
       );
     });
   });

--- a/tests/subgraph/mapping-v3-core/mapping-v3p2-engine-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3p2-engine-core.test.ts
@@ -20,6 +20,8 @@ import {
   CONTRACT_ENTITY_TYPE,
   PROJECT_SCRIPT_ENTITY_TYPE,
   TOKEN_ENTITY_TYPE,
+  ROYALTY_SPLITTER_ENTITY_TYPE,
+  ROYALTY_SPLIT_RECIPIENT_TYPE,
   CURRENT_BLOCK_TIMESTAMP,
   RandomAddressGenerator,
   mockProjectScriptByIndex,
@@ -39,7 +41,8 @@ import {
   booleanToString,
   TEST_CONTRACT,
   TEST_SUPER_ADMIN_ADDRESS,
-  WHITELISTING_ENTITY_TYPE
+  WHITELISTING_ENTITY_TYPE,
+  TEST_ARTIST_ADDRESS
 } from "../shared-helpers";
 import {
   mockProjectScriptDetailsCall,
@@ -47,9 +50,10 @@ import {
   testProjectDetailsUpdated,
   testProjectScriptDetailsUpdated,
   testProjectStateDataUpdated,
-  mockRefreshContractCalls
+  mockRefreshContractCalls,
+  mockProjectFinance
 } from "./helpers";
-import { Project } from "../../../generated/schema";
+import { Contract, Project } from "../../../generated/schema";
 import {
   Mint,
   ProjectUpdated,
@@ -96,9 +100,14 @@ const randomAddressGenerator = new RandomAddressGenerator();
 
 const coreType = "GenArt721CoreV3_Engine";
 const coreVersion = "v3.2.0"; // test v3.2 contract handling
+const SPLIT_PROVIDER_ADDRESS = randomAddressGenerator.generateRandomAddress();
 // override mock core version
 const mockCoreContractOverrides = new Map<string, string>();
 mockCoreContractOverrides.set("coreVersion", coreVersion);
+mockCoreContractOverrides.set(
+  "splitProvider",
+  SPLIT_PROVIDER_ADDRESS.toHexString()
+);
 
 test(`${coreType}-${coreVersion}: Can handle Mint`, () => {
   clearStore();
@@ -228,7 +237,7 @@ test(`${coreType}-${coreVersion}: Handles OwnershipTransferred to new address an
     // emitted by the V3 constructor, and we expect item may not be in store.
     // DO add mock contract calls, because we expect the contract to be called
     // during initial contract setup.
-    mockRefreshContractCalls(projectId, coreType, null);
+    mockRefreshContractCalls(projectId, coreType, mockCoreContractOverrides);
     // overwrite mock function to return the new admin
     createMockedFunction(
       TEST_CONTRACT_ADDRESS,
@@ -337,7 +346,7 @@ test(`${coreType}-${coreVersion}: Handles OwnershipTransferred to new address an
     // expect contract entity to be in store.
     addTestContractToStore(projectId);
     // also add mock contract calls, because that will always be available.
-    mockRefreshContractCalls(projectId, coreType, null);
+    mockRefreshContractCalls(projectId, coreType, mockCoreContractOverrides);
     // overwrite mock function to return the new admin
     createMockedFunction(
       TEST_CONTRACT_ADDRESS,
@@ -417,7 +426,11 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::nextProjectId`, () =>
     // add new contract to store
     const projectId = BigInt.fromI32(i);
     addTestContractToStore(projectId);
-    mockRefreshContractCalls(BigInt.fromI32(i), coreType, null);
+    mockRefreshContractCalls(
+      BigInt.fromI32(i),
+      coreType,
+      mockCoreContractOverrides
+    );
 
     const event: PlatformUpdated = changetype<PlatformUpdated>(newMockEvent());
     event.address = TEST_CONTRACT_ADDRESS;
@@ -447,7 +460,11 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::newProjectsForbidden 
   // add new contract to store
   const projectId = BigInt.fromI32(0);
   addTestContractToStore(projectId);
-  mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
+  mockRefreshContractCalls(
+    BigInt.fromI32(0),
+    coreType,
+    mockCoreContractOverrides
+  );
 
   // default value should be false
   assert.fieldEquals(
@@ -463,7 +480,11 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::newProjectsForbidden 
   // add new contract to store
   const projectId = BigInt.fromI32(0);
   addTestContractToStore(projectId);
-  mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
+  mockRefreshContractCalls(
+    BigInt.fromI32(0),
+    coreType,
+    mockCoreContractOverrides
+  );
 
   // update mock function return value to true
   createMockedFunction(
@@ -502,7 +523,11 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::nextProjectId`, () =>
     // add new contract to store
     const projectId = BigInt.fromI32(i);
     addTestContractToStore(projectId);
-    mockRefreshContractCalls(BigInt.fromI32(i), coreType, null);
+    mockRefreshContractCalls(
+      BigInt.fromI32(i),
+      coreType,
+      mockCoreContractOverrides
+    );
 
     const event: PlatformUpdated = changetype<PlatformUpdated>(newMockEvent());
     event.address = TEST_CONTRACT_ADDRESS;
@@ -532,7 +557,11 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::artblocksPrimarySales
   // add new contract to store
   const projectId = BigInt.fromI32(0);
   addTestContractToStore(projectId);
-  mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
+  mockRefreshContractCalls(
+    BigInt.fromI32(0),
+    coreType,
+    mockCoreContractOverrides
+  );
 
   // default value should be false
   assert.fieldEquals(
@@ -674,7 +703,11 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::providerPrimaryPercen
   // add new contract to store
   const projectId = BigInt.fromI32(0);
   addTestContractToStore(projectId);
-  mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
+  mockRefreshContractCalls(
+    BigInt.fromI32(0),
+    coreType,
+    mockCoreContractOverrides
+  );
 
   // default value should be test contract value
   // DEPRECATED START ---
@@ -699,7 +732,11 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::randomizerAddress - d
   // add new contract to store
   const projectId = BigInt.fromI32(0);
   addTestContractToStore(projectId);
-  mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
+  mockRefreshContractCalls(
+    BigInt.fromI32(0),
+    coreType,
+    mockCoreContractOverrides
+  );
 
   // default value should be false
   assert.fieldEquals(
@@ -715,7 +752,11 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::randomizerAddress - c
   // add new contract to store
   const projectId = BigInt.fromI32(0);
   addTestContractToStore(projectId);
-  mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
+  mockRefreshContractCalls(
+    BigInt.fromI32(0),
+    coreType,
+    mockCoreContractOverrides
+  );
 
   // update mock function return value
   const newAddress = randomAddressGenerator.generateRandomAddress();
@@ -754,7 +795,11 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::curationRegistryAddre
   // add new contract to store
   const projectId = BigInt.fromI32(0);
   addTestContractToStore(projectId);
-  mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
+  mockRefreshContractCalls(
+    BigInt.fromI32(0),
+    coreType,
+    mockCoreContractOverrides
+  );
 
   // default value should be nothing
   assert.fieldEquals(
@@ -770,7 +815,11 @@ test(`${coreType}-${coreVersion}: Null curationRegistryAddress on Engine contrac
   // add new contract to store
   const projectId = BigInt.fromI32(0);
   addTestContractToStore(projectId);
-  mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
+  mockRefreshContractCalls(
+    BigInt.fromI32(0),
+    coreType,
+    mockCoreContractOverrides
+  );
 
   // update mock function for curation registry to revert
   const newAddress = randomAddressGenerator.generateRandomAddress();
@@ -809,7 +858,11 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::dependencyRegistryAdd
   // add new contract to store
   const projectId = BigInt.fromI32(0);
   addTestContractToStore(projectId);
-  mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
+  mockRefreshContractCalls(
+    BigInt.fromI32(0),
+    coreType,
+    mockCoreContractOverrides
+  );
 
   // default value should be false
   assert.fieldEquals(
@@ -825,7 +878,11 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::dependencyRegistryAdd
   // add new contract to store
   const projectId = BigInt.fromI32(0);
   addTestContractToStore(projectId);
-  mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
+  mockRefreshContractCalls(
+    BigInt.fromI32(0),
+    coreType,
+    mockCoreContractOverrides
+  );
 
   // update mock function return value
   const newAddress = randomAddressGenerator.generateRandomAddress();
@@ -860,12 +917,52 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::dependencyRegistryAdd
   );
 });
 
+test(`${coreType}: populates royaltySplitProvider on contract refresh for v3.2`, () => {
+  clearStore();
+  // add new contract to store
+  const projectId = BigInt.fromI32(0);
+  addTestContractToStore(projectId);
+  mockRefreshContractCalls(
+    BigInt.fromI32(0),
+    coreType,
+    mockCoreContractOverrides
+  );
+
+  // create event
+  const event: PlatformUpdated = changetype<PlatformUpdated>(newMockEvent());
+  event.address = TEST_CONTRACT_ADDRESS;
+  event.transaction.hash = TEST_TX_HASH;
+  event.logIndex = BigInt.fromI32(0);
+  event.parameters = [
+    new ethereum.EventParam(
+      "_field",
+      ethereum.Value.fromBytes(
+        Bytes.fromUTF8("ENUM_FIELD_SPLIT_PROVIDER_BUT_ARBITRARY_FOR_HANDLER")
+      )
+    )
+  ];
+  // handle event
+  handlePlatformUpdated(event);
+
+  // value should be non-null v3.2+
+  assert.fieldEquals(
+    CONTRACT_ENTITY_TYPE,
+    TEST_CONTRACT_ADDRESS.toHexString(),
+    "royaltySplitProvider",
+    SPLIT_PROVIDER_ADDRESS.toHexString()
+  );
+});
+
 test(`${coreType}-${coreVersion}: Populated autoApproveAtistSplitProposals on Engine contract`, () => {
   clearStore();
   // add new contract to store
   const projectId = BigInt.fromI32(0);
   addTestContractToStore(projectId);
-  mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
+  mockRefreshContractCalls(
+    BigInt.fromI32(0),
+    coreType,
+    mockCoreContractOverrides
+  );
 
   // update mock function for autoApproveArtistSplitProposals to return tested value
   const valuesToTest = [true, false];
@@ -907,7 +1004,11 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::providerPrimaryPercen
   // add new contract to store
   const projectId = BigInt.fromI32(0);
   addTestContractToStore(projectId);
-  mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
+  mockRefreshContractCalls(
+    BigInt.fromI32(0),
+    coreType,
+    mockCoreContractOverrides
+  );
 
   // default value should be false
   assert.fieldEquals(
@@ -923,7 +1024,11 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::providerPrimaryPercen
   // add new contract to store
   const projectId = BigInt.fromI32(0);
   addTestContractToStore(projectId);
-  mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
+  mockRefreshContractCalls(
+    BigInt.fromI32(0),
+    coreType,
+    mockCoreContractOverrides
+  );
 
   // update mock function return values
   const newRenderProviderPrimarySalesPercentage = BigInt.fromI32(13);
@@ -979,7 +1084,11 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::providerSecondaryBPS 
   // add new contract to store
   const projectId = BigInt.fromI32(0);
   addTestContractToStore(projectId);
-  mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
+  mockRefreshContractCalls(
+    BigInt.fromI32(0),
+    coreType,
+    mockCoreContractOverrides
+  );
 
   // default value should be test contract default value
   // @dev v3.2 does not have function `renderProviderSecondarySalesBPS()`
@@ -1072,7 +1181,11 @@ describe(`${coreType}-${coreVersion}: handleIAdminACLV0SuperAdminTransferred`, (
     // add new contract to store
     const projectId = BigInt.fromI32(0);
     addTestContractToStore(projectId);
-    mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
+    mockRefreshContractCalls(
+      BigInt.fromI32(0),
+      coreType,
+      mockCoreContractOverrides
+    );
     // mock AdminACLV0 superAdmin
     const newOwnerSuperAdmin = randomAddressGenerator.generateRandomAddress();
     createMockedFunction(
@@ -1237,7 +1350,7 @@ describe(`${coreType}-${coreVersion}: handleProjectUpdated`, () => {
 
     test("should create a project entity", () => {
       const projectId = BigInt.fromI32(0);
-      const artistAddress = randomAddressGenerator.generateRandomAddress();
+      const artistAddress = TEST_ARTIST_ADDRESS;
       const projectName = "Test Project";
       const invocations = BigInt.fromI32(0);
       const maxInvocations = BigInt.fromI32(ONE_MILLION);
@@ -1319,44 +1432,12 @@ describe(`${coreType}-${coreVersion}: handleProjectUpdated`, () => {
         .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
         .returns([ethereum.Value.fromI32(5)]);
 
-      // mock projectIdToFinancials, used on v3.2 Engine core in handler
-      const localDefaultRenderProviderSecondarySalesAddress = randomAddressGenerator.generateRandomAddress();
-      const localDefaultRenderProviderSecondarySalesBPS = BigInt.fromI32(4);
-      const localDefaultEnginePlatformProviderSecondarySalesAddress = randomAddressGenerator.generateRandomAddress();
-      const localDefaultEnginePlatformProviderSecondarySalesBPS = BigInt.fromI32(
-        6
+      mockProjectFinance(
+        projectId,
+        BigInt.fromI32(0),
+        BigInt.fromI32(0),
+        BigInt.fromI32(0)
       );
-      // return is a struct, which solidity returns as a tuple
-      let tupleArray: Array<ethereum.Value> = [
-        ethereum.Value.fromAddress(Address.zero()), // additional payee primary sales (unused in this test)
-        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(0)), // secondary market royalty percentage (unused in this test)
-        ethereum.Value.fromAddress(Address.zero()), // additional payee secondary sales (unused in this test)
-        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(0)), // additional payee secondary sales percentage (unused in this test)
-        ethereum.Value.fromAddress(Address.zero()), // artist address (unused in this test)
-        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(0)), // additionalPayeePrimarySalesPercentage (unused in this test)
-        ethereum.Value.fromAddress(
-          localDefaultEnginePlatformProviderSecondarySalesAddress
-        ),
-        ethereum.Value.fromUnsignedBigInt(
-          localDefaultEnginePlatformProviderSecondarySalesBPS
-        ),
-        ethereum.Value.fromAddress(
-          localDefaultRenderProviderSecondarySalesAddress
-        ),
-        ethereum.Value.fromUnsignedBigInt(
-          localDefaultRenderProviderSecondarySalesBPS
-        ),
-        ethereum.Value.fromAddress(Address.zero()) // royalty splitter (unused in this test)
-      ];
-      let tuple: ethereum.Tuple = changetype<ethereum.Tuple>(tupleArray);
-
-      createMockedFunction(
-        TEST_CONTRACT_ADDRESS,
-        "projectIdToFinancials",
-        "projectIdToFinancials(uint256):((address,uint8,address,uint8,address,uint8,address,uint16,address,uint16,address))"
-      )
-        .withArgs([ethereum.Value.fromUnsignedBigInt(projectId)])
-        .returns([ethereum.Value.fromTuple(tuple)]);
 
       handleProjectUpdated(event);
 
@@ -1489,26 +1570,26 @@ describe(`${coreType}-${coreVersion}: handleProjectUpdated`, () => {
         PROJECT_ENTITY_TYPE,
         generateContractSpecificId(TEST_CONTRACT_ADDRESS, projectId),
         "renderProviderSecondarySalesAddress",
-        localDefaultRenderProviderSecondarySalesAddress.toHexString()
+        TEST_CONTRACT.renderProviderSecondarySalesAddress.toHexString()
       );
       assert.fieldEquals(
         PROJECT_ENTITY_TYPE,
         generateContractSpecificId(TEST_CONTRACT_ADDRESS, projectId),
         "renderProviderSecondarySalesBPS",
-        localDefaultRenderProviderSecondarySalesBPS.toString()
+        TEST_CONTRACT.defaultRenderProviderSecondarySalesBPS.toString()
       );
       // project platform provider royalties should equal contract-level values for pre-v3.2 Engine core
       assert.fieldEquals(
         PROJECT_ENTITY_TYPE,
         generateContractSpecificId(TEST_CONTRACT_ADDRESS, projectId),
         "enginePlatformProviderSecondarySalesAddress",
-        localDefaultEnginePlatformProviderSecondarySalesAddress.toHexString()
+        TEST_CONTRACT.enginePlatformProviderSecondarySalesAddress.toHexString()
       );
       assert.fieldEquals(
         PROJECT_ENTITY_TYPE,
         generateContractSpecificId(TEST_CONTRACT_ADDRESS, projectId),
         "enginePlatformProviderSecondarySalesBPS",
-        localDefaultEnginePlatformProviderSecondarySalesBPS.toString()
+        TEST_CONTRACT.defaultEnginePlatformProviderSecondarySalesBPS.toString()
       );
     });
   });
@@ -2293,6 +2374,21 @@ describe(`${coreType}-${coreVersion}: handleProjectUpdated`, () => {
         TEST_CONTRACT_ADDRESS,
         projectId
       );
+      addTestContractToStore(projectId.plus(BigInt.fromI32(1)));
+      // for v3.2, always have a populated royaltySplitProvider field
+      const contractInStore = Contract.load(
+        TEST_CONTRACT_ADDRESS.toHexString()
+      );
+      if (!contractInStore) {
+        throw new Error("Contract not found in store");
+      }
+      contractInStore.royaltySplitProvider = randomAddressGenerator.generateRandomAddress();
+      contractInStore.save();
+      mockRefreshContractCalls(
+        BigInt.fromI32(0),
+        coreType,
+        mockCoreContractOverrides
+      );
       addNewProjectToStore(
         TEST_CONTRACT_ADDRESS,
         projectId,
@@ -2319,6 +2415,14 @@ describe(`${coreType}-${coreVersion}: handleProjectUpdated`, () => {
           ethereum.Value.fromAddress(newRoyaltySplitter)
         )
       ];
+      // mock project finance call
+      mockProjectFinance(
+        projectId,
+        BigInt.fromI32(5),
+        BigInt.fromI32(0),
+        BigInt.fromI32(0)
+      );
+
       // call handleProjectRoyaltySplitterUpdated
       handleProjectRoyaltySplitterUpdated(event);
 
@@ -2334,6 +2438,109 @@ describe(`${coreType}-${coreVersion}: handleProjectUpdated`, () => {
         fullProjectId,
         "erc2981SplitterAddress",
         newRoyaltySplitter.toHexString()
+      );
+      // assert royalty splitter in store
+      assert.fieldEquals(
+        ROYALTY_SPLITTER_ENTITY_TYPE,
+        newRoyaltySplitter.toHexString(),
+        "id",
+        newRoyaltySplitter.toHexString()
+      );
+      assert.fieldEquals(
+        ROYALTY_SPLITTER_ENTITY_TYPE,
+        newRoyaltySplitter.toHexString(),
+        "splitProviderCreator",
+        (contractInStore.royaltySplitProvider as Bytes).toHexString()
+      );
+      assert.fieldEquals(
+        ROYALTY_SPLITTER_ENTITY_TYPE,
+        newRoyaltySplitter.toHexString(),
+        "coreContract",
+        TEST_CONTRACT_ADDRESS.toHexString()
+      );
+      assert.fieldEquals(
+        ROYALTY_SPLITTER_ENTITY_TYPE,
+        newRoyaltySplitter.toHexString(),
+        "totalAllocation",
+        "1050" // total 10.5% = 5% artist + 3.0% platform + 2.5% render provider
+      );
+      assert.fieldEquals(
+        ROYALTY_SPLITTER_ENTITY_TYPE,
+        newRoyaltySplitter.toHexString(),
+        "createdAt",
+        newTimestamp.toString()
+      );
+      // assert new split recipients in store
+      assert.fieldEquals(
+        ROYALTY_SPLIT_RECIPIENT_TYPE,
+        newRoyaltySplitter.toHexString() +
+          "-" +
+          TEST_ARTIST_ADDRESS.toHexString(),
+        "id",
+        newRoyaltySplitter.toHexString() +
+          "-" +
+          TEST_ARTIST_ADDRESS.toHexString()
+      );
+      assert.fieldEquals(
+        ROYALTY_SPLIT_RECIPIENT_TYPE,
+        newRoyaltySplitter.toHexString() +
+          "-" +
+          TEST_ARTIST_ADDRESS.toHexString(),
+        "royaltySplitterContract",
+        newRoyaltySplitter.toHexString()
+      );
+      assert.fieldEquals(
+        ROYALTY_SPLIT_RECIPIENT_TYPE,
+        newRoyaltySplitter.toHexString() +
+          "-" +
+          TEST_ARTIST_ADDRESS.toHexString(),
+        "recipientAddress",
+        TEST_ARTIST_ADDRESS.toHexString()
+      );
+      assert.fieldEquals(
+        ROYALTY_SPLIT_RECIPIENT_TYPE,
+        newRoyaltySplitter.toHexString() +
+          "-" +
+          TEST_ARTIST_ADDRESS.toHexString(),
+        "allocation",
+        "500"
+      );
+      // only check existence and allocation of platform and render provider recipients
+      assert.fieldEquals(
+        ROYALTY_SPLIT_RECIPIENT_TYPE,
+        newRoyaltySplitter.toHexString() +
+          "-" +
+          TEST_CONTRACT.defaultRenderProviderSecondarySalesAddress.toHexString(),
+        "id",
+        newRoyaltySplitter.toHexString() +
+          "-" +
+          TEST_CONTRACT.defaultRenderProviderSecondarySalesAddress.toHexString()
+      );
+      assert.fieldEquals(
+        ROYALTY_SPLIT_RECIPIENT_TYPE,
+        newRoyaltySplitter.toHexString() +
+          "-" +
+          TEST_CONTRACT.defaultRenderProviderSecondarySalesAddress.toHexString(),
+        "allocation",
+        "250"
+      );
+      assert.fieldEquals(
+        ROYALTY_SPLIT_RECIPIENT_TYPE,
+        newRoyaltySplitter.toHexString() +
+          "-" +
+          TEST_CONTRACT.defaultEnginePlatformProviderSecondarySalesAddress.toHexString(),
+        "id",
+        newRoyaltySplitter.toHexString() +
+          "-" +
+          TEST_CONTRACT.defaultEnginePlatformProviderSecondarySalesAddress.toHexString()
+      );
+      assert.fieldEquals(
+        ROYALTY_SPLIT_RECIPIENT_TYPE,
+        newRoyaltySplitter.toHexString() +
+          "-" +
+          TEST_CONTRACT.defaultEnginePlatformProviderSecondarySalesAddress.toHexString(),
+        "allocation",
+        "300"
       );
     });
   });

--- a/tests/subgraph/shared-helpers.ts
+++ b/tests/subgraph/shared-helpers.ts
@@ -91,6 +91,8 @@ export const PROJECT_EXTERNAL_ASSET_DEPENDENCY_ENTITY_TYPE =
   "ProjectExternalAssetDependency";
 export const PROJECT_SCRIPT_ENTITY_TYPE = "ProjectScript";
 export const TOKEN_ENTITY_TYPE = "Token";
+export const ROYALTY_SPLITTER_ENTITY_TYPE = "RoyaltySplitterContract";
+export const ROYALTY_SPLIT_RECIPIENT_TYPE = "RoyaltySplitRecipient";
 export const TRANSFER_ENTITY_TYPE = "Transfer";
 export const PROJECT_MINTER_CONFIGURATION_ENTITY_TYPE =
   "ProjectMinterConfiguration";
@@ -106,6 +108,8 @@ export const IPFS_CID2 = "QmQCqjqxVXZQ6vXNmZvF7FjyZkCXKXMykCyyPQQrZ6m7W2";
 export const CURRENT_BLOCK_TIMESTAMP = BigInt.fromI32(1647051214);
 export const TEST_CONTRACT_ADDRESS = randomAddressGenerator.generateRandomAddress();
 export const TEST_SUPER_ADMIN_ADDRESS = randomAddressGenerator.generateRandomAddress();
+export const TEST_ARTIST_ADDRESS = randomAddressGenerator.generateRandomAddress();
+export const TEST_ADDITIONAL_PAYEE_ADDRESS = randomAddressGenerator.generateRandomAddress();
 export const TEST_TOKEN_HASH = Bytes.fromByteArray(
   crypto.keccak256(Bytes.fromUTF8("token hash"))
 );
@@ -373,6 +377,7 @@ export function addTestContractToStore(nextProjectId: BigInt): Contract {
   contract.admin = TEST_CONTRACT.admin;
   contract.type = TEST_CONTRACT.type;
   contract.createdAt = CURRENT_BLOCK_TIMESTAMP.minus(BigInt.fromI32(10));
+  contract.royaltySplitProvider = null;
   contract.nextProjectId = nextProjectId;
   contract.randomizerContract = TEST_CONTRACT.randomizerContract;
   contract.renderProviderAddress = TEST_CONTRACT.renderProviderAddress;


### PR DESCRIPTION
## Description of the change

Index project royalty splitters to support downstream data indexing and automations.

This update adds new entities and populates them based on on-chain state.

Note that due to event ordering on v3.2 contracts, payment information is sourced from the contracts via a staticcall instead of referencing potentially not-yet-updated data in the store.

Also note that splits are sourced directly from the contracts instead of the splitters, avoiding adding a new dependency on the split implementation's contract interface.

## Tests

Existing matchstick tests are updated to pass + cover new functionality.

## Other 

Includes an ABI update for use of `splitProvider()` function from https://github.com/ArtBlocks/artblocks-contracts/pull/1546.