### PR TITLE
Update bid timestamp on top up

### DIFF
--- a/src/ram-lib-mapping.ts
+++ b/src/ram-lib-mapping.ts
@@ -394,6 +394,7 @@ export function handleBidToppedUp(event: BidToppedUp): void {
   // Update slot index and value
   bid.slotIndex = event.params.newSlotIndex;
   bid.value = bidValue;
+  bid.timestamp = event.block.timestamp;
   bid.updatedAt = event.block.timestamp;
   bid.save();
 }

--- a/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
@@ -379,6 +379,7 @@ describe("RAMLib event handling", () => {
       expect(toppedUpBidRes.isRemoved).toBe(false);
       expect(toppedUpBidRes.value).toBe(slot12price.toString());
       expect(toppedUpBidRes.updatedAt).toBe(auctionBid2Timestamp.toString());
+      expect(toppedUpBidRes.timestamp).toBe(auctionBid2Timestamp.toString());
     });
   });
 


### PR DESCRIPTION
## Description of the change

When a bid is topped up its timestamp should be updated in order to track its ranking properly.

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
