### PR TITLE
Remove deprecated fields

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -248,23 +248,11 @@ type Contract @entity {
   "Percentage of primary sales allocated to the platform"
   renderProviderPercentage: BigInt!
 
-  "Deprecated field, will be removed and is not populated for v3.2+ - see Project.renderProviderSecondarySalesAddress"
-  renderProviderSecondarySalesAddress: Bytes
-
-  "Deprecated field, will be removed and is not populated for v3.2+ - see Project.renderProviderSecondarySalesBPS"
-  renderProviderSecondarySalesBPS: BigInt
-
   "Address that receives primary sales platform fees, only for V3_Engine contracts"
   enginePlatformProviderAddress: Bytes
 
   "Percentage of primary sales allocated to the platform, only for V3_Engine contracts"
   enginePlatformProviderPercentage: BigInt
-
-  "Deprecated field, will be removed and is not populated for v3.2+ - see Project.enginePlatformProviderSecondarySalesAddress"
-  enginePlatformProviderSecondarySalesAddress: Bytes
-
-  "Deprecated field, will be removed and is not populated for v3.2+ - see Project.enginePlatformProviderSecondarySalesBPS"
-  enginePlatformProviderSecondarySalesBPS: BigInt
 
   "Default address that receives secondary sales render provider royalties when adding new projects (null for pre-V3 contracts)"
   defaultRenderProviderSecondarySalesAddress: Bytes

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -1531,18 +1531,14 @@ function refreshContract<T>(contract: T, timestamp: BigInt): Contract | null {
     const renderProviderSecondarySalesBPS = contract.artblocksSecondarySalesBPS();
     // detect if secondary sales payment info have changed
     const platformSecondaryHaveChanged =
-      !contractEntity.renderProviderSecondarySalesAddress ||
+      !contractEntity.defaultRenderProviderSecondarySalesAddress ||
       Address.fromBytes(
-        contractEntity.renderProviderSecondarySalesAddress as Bytes // @dev casting shouldn't be necessary, but is required to compile
+        contractEntity.defaultRenderProviderSecondarySalesAddress as Bytes // @dev casting shouldn't be necessary, but is required to compile
       ).toHexString() != renderProviderSecondarySalesAddress.toHexString() ||
-      !contractEntity.renderProviderSecondarySalesBPS ||
-      (contractEntity.renderProviderSecondarySalesBPS as BigInt) != // @dev casting shouldn't be necessary, but is required to compile
+      !contractEntity.defaultRenderProviderSecondarySalesBPS ||
+      (contractEntity.defaultRenderProviderSecondarySalesBPS as BigInt) != // @dev casting shouldn't be necessary, but is required to compile
         renderProviderSecondarySalesBPS;
     if (platformSecondaryHaveChanged) {
-      // @dev DEPRECATED-START ---
-      contractEntity.renderProviderSecondarySalesAddress = renderProviderSecondarySalesAddress;
-      contractEntity.renderProviderSecondarySalesBPS = renderProviderSecondarySalesBPS;
-      // @dev DEPRECATED-END ---
       contractEntity.defaultRenderProviderSecondarySalesAddress = renderProviderSecondarySalesAddress;
       contractEntity.defaultRenderProviderSecondarySalesBPS = renderProviderSecondarySalesBPS;
       // secondary sales are defined on the projects after release of v3.2 core contracts
@@ -1588,28 +1584,22 @@ function refreshContract<T>(contract: T, timestamp: BigInt): Contract | null {
       const enginePlatformProviderSecondarySalesBPS = preV3_2Contract.platformProviderSecondarySalesBPS();
       // detect if secondary sales payment info have changed (to prevent unnecessary updates)
       let platformSecondaryHaveChanged =
-        !contractEntity.renderProviderSecondarySalesAddress ||
+        !contractEntity.defaultRenderProviderSecondarySalesAddress ||
         Address.fromBytes(
-          contractEntity.renderProviderSecondarySalesAddress as Bytes // @dev casting shouldn't be necessary, but is required to compile
+          contractEntity.defaultRenderProviderSecondarySalesAddress as Bytes // @dev casting shouldn't be necessary, but is required to compile
         ).toHexString() != renderProviderSecondarySalesAddress.toHexString() ||
-        !contractEntity.renderProviderSecondarySalesBPS ||
-        (contractEntity.renderProviderSecondarySalesBPS as BigInt) != // @dev casting shouldn't be necessary, but is required to compile
+        !contractEntity.defaultRenderProviderSecondarySalesBPS ||
+        (contractEntity.defaultRenderProviderSecondarySalesBPS as BigInt) != // @dev casting shouldn't be necessary, but is required to compile
           renderProviderSecondarySalesBPS ||
-        !contractEntity.enginePlatformProviderSecondarySalesAddress ||
+        !contractEntity.defaultEnginePlatformProviderSecondarySalesAddress ||
         Address.fromBytes(
-          contractEntity.enginePlatformProviderSecondarySalesAddress as Bytes // @dev casting shouldn't be necessary, but is required to compile
+          contractEntity.defaultEnginePlatformProviderSecondarySalesAddress as Bytes // @dev casting shouldn't be necessary, but is required to compile
         ).toHexString() !=
           enginePlatformProviderSecondarySalesAddress.toHexString() ||
-        !contractEntity.enginePlatformProviderSecondarySalesBPS ||
-        (contractEntity.enginePlatformProviderSecondarySalesBPS as BigInt) != // @dev casting shouldn't be necessary, but is required to compile
+        !contractEntity.defaultEnginePlatformProviderSecondarySalesBPS ||
+        (contractEntity.defaultEnginePlatformProviderSecondarySalesBPS as BigInt) != // @dev casting shouldn't be necessary, but is required to compile
           enginePlatformProviderSecondarySalesBPS;
       if (platformSecondaryHaveChanged) {
-        // @dev DEPRECATED-START ---
-        contractEntity.renderProviderSecondarySalesAddress = renderProviderSecondarySalesAddress;
-        contractEntity.renderProviderSecondarySalesBPS = renderProviderSecondarySalesBPS;
-        contractEntity.enginePlatformProviderSecondarySalesAddress = enginePlatformProviderSecondarySalesAddress;
-        contractEntity.enginePlatformProviderSecondarySalesBPS = enginePlatformProviderSecondarySalesBPS;
-        // @dev DEPRECATED-END ---
         // set defaults to the contract-level fields for pre-v3.2 contracts
         contractEntity.defaultRenderProviderSecondarySalesAddress = renderProviderSecondarySalesAddress;
         contractEntity.defaultRenderProviderSecondarySalesBPS = renderProviderSecondarySalesBPS;
@@ -1648,13 +1638,6 @@ function refreshContract<T>(contract: T, timestamp: BigInt): Contract | null {
       // @dev no need to optimally detect if secondary sales payment info have changed, as we are setting defaults
       // and not iterating over all projects on the contract
 
-      // backwards-compatible deprecated fields
-      // @dev DEPRECATED-START ---
-      contractEntity.renderProviderSecondarySalesAddress = defaultRenderProviderSecondarySalesAddress;
-      contractEntity.renderProviderSecondarySalesBPS = defaultRenderProviderSecondarySalesBPS;
-      contractEntity.enginePlatformProviderSecondarySalesAddress = defaultEnginePlatformProviderSecondarySalesAddress;
-      contractEntity.enginePlatformProviderSecondarySalesBPS = defaultEnginePlatformProviderSecondarySalesBPS;
-      // @dev DEPRECATED-END ---
       // set defaults to the default values for v3.2+ contracts
       contractEntity.defaultRenderProviderSecondarySalesAddress = defaultRenderProviderSecondarySalesAddress;
       contractEntity.defaultRenderProviderSecondarySalesBPS = defaultRenderProviderSecondarySalesBPS;

--- a/tests/subgraph/mapping-v3-core/helpers.ts
+++ b/tests/subgraph/mapping-v3-core/helpers.ts
@@ -204,7 +204,7 @@ export function mockRefreshContractCalls(
       "artblocksSecondarySalesAddress():(address)"
     ).returns([
       ethereum.Value.fromAddress(
-        TEST_CONTRACT.renderProviderSecondarySalesAddress
+        TEST_CONTRACT.defaultRenderProviderSecondarySalesAddress
       )
     ]);
 
@@ -214,7 +214,7 @@ export function mockRefreshContractCalls(
       "artblocksSecondarySalesBPS():(uint256)"
     ).returns([
       ethereum.Value.fromUnsignedBigInt(
-        TEST_CONTRACT.renderProviderSecondarySalesBPS
+        TEST_CONTRACT.defaultRenderProviderSecondarySalesBPS
       )
     ]);
 
@@ -250,7 +250,7 @@ export function mockRefreshContractCalls(
       "renderProviderSecondarySalesAddress():(address)"
     ).returns([
       ethereum.Value.fromAddress(
-        TEST_CONTRACT.renderProviderSecondarySalesAddress
+        TEST_CONTRACT.defaultRenderProviderSecondarySalesAddress
       )
     ]);
 
@@ -260,7 +260,7 @@ export function mockRefreshContractCalls(
       "renderProviderSecondarySalesBPS():(uint256)"
     ).returns([
       ethereum.Value.fromUnsignedBigInt(
-        TEST_CONTRACT.renderProviderSecondarySalesBPS
+        TEST_CONTRACT.defaultRenderProviderSecondarySalesBPS
       )
     ]);
 
@@ -289,7 +289,7 @@ export function mockRefreshContractCalls(
       "platformProviderSecondarySalesAddress():(address)"
     ).returns([
       ethereum.Value.fromAddress(
-        TEST_CONTRACT.enginePlatformProviderSecondarySalesAddress
+        TEST_CONTRACT.defaultEnginePlatformProviderSecondarySalesAddress
       )
     ]);
 
@@ -299,7 +299,7 @@ export function mockRefreshContractCalls(
       "platformProviderSecondarySalesBPS():(uint256)"
     ).returns([
       ethereum.Value.fromUnsignedBigInt(
-        TEST_CONTRACT.enginePlatformProviderSecondarySalesBPS
+        TEST_CONTRACT.defaultEnginePlatformProviderSecondarySalesBPS
       )
     ]);
 

--- a/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
@@ -772,14 +772,6 @@ test(`${coreType}: Handles PlatformUpdated::artblocksSecondarySalesAddress - def
   mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
 
   // default value should be false
-  // DEPRECATED START ---
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "renderProviderSecondarySalesAddress",
-    TEST_CONTRACT.renderProviderSecondarySalesAddress.toHexString()
-  );
-  // DEPRECATED END ---
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
@@ -818,14 +810,6 @@ test(`${coreType}: Handles PlatformUpdated::artblocksSecondarySalesAddress - cha
   handlePlatformUpdated(event);
 
   // value in store should be updated
-  // DEPRECATED START ---
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "renderProviderSecondarySalesAddress",
-    newAddress.toHexString()
-  );
-  // DEPRECATED END ---
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
@@ -887,14 +871,6 @@ test(`${coreType}: Handles PlatformUpdated::artblocksSecondarySalesAddress - cha
   handlePlatformUpdated(event);
 
   // value in store should be updated
-  // DEPRECATED START ---
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "renderProviderSecondarySalesAddress",
-    newAddress.toHexString()
-  );
-  // DEPRECATED END ---
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
@@ -1184,14 +1160,6 @@ test(`${coreType}: Handles PlatformUpdated::artblocksSecondaryBPS - default valu
   mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
 
   // default value should be false
-  // DEPRECATED START ---
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "renderProviderSecondarySalesBPS",
-    TEST_CONTRACT.renderProviderSecondarySalesBPS.toString()
-  );
-  // DEPRECATED END ---
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
@@ -1230,14 +1198,6 @@ test(`${coreType}: Handles PlatformUpdated::artblocksSecondaryBPS - changed valu
   handlePlatformUpdated(event);
 
   // value in store should be updated
-  // DEPRECATED START ---
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "renderProviderSecondarySalesBPS",
-    newValue.toString()
-  );
-  // DEPRECATED END ---
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),

--- a/tests/subgraph/mapping-v3-core/mapping-v3-engine-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-engine-core.test.ts
@@ -605,14 +605,6 @@ test(`${coreType}: Handles PlatformUpdated::providerSalesAddresses - changed val
     "renderProviderAddress",
     newRenderProviderPrimarySalesAddress.toHexString()
   );
-  // DEPRECATED START ---
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "renderProviderSecondarySalesAddress",
-    newRenderProviderSecondarySalesAddress.toHexString()
-  );
-  // DEPRECATED END ---
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
@@ -625,14 +617,6 @@ test(`${coreType}: Handles PlatformUpdated::providerSalesAddresses - changed val
     "enginePlatformProviderAddress",
     newPlatformProviderPrimarySalesAddress.toHexString()
   );
-  // DEPRECATED START ---
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "enginePlatformProviderSecondarySalesAddress",
-    newPlatformProviderSecondarySalesAddress.toHexString()
-  );
-  // DEPRECATED END ---
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
@@ -729,14 +713,6 @@ test(`${coreType}: Handles PlatformUpdated::providerSalesAddresses - changed val
     "renderProviderAddress",
     newRenderProviderPrimarySalesAddress.toHexString()
   );
-  // DEPRECATED START ---
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "renderProviderSecondarySalesAddress",
-    newRenderProviderSecondarySalesAddress.toHexString()
-  );
-  // DEPRECATED END ---
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
@@ -749,14 +725,6 @@ test(`${coreType}: Handles PlatformUpdated::providerSalesAddresses - changed val
     "enginePlatformProviderAddress",
     newPlatformProviderPrimarySalesAddress.toHexString()
   );
-  // DEPRECATED START ---
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "enginePlatformProviderSecondarySalesAddress",
-    newPlatformProviderSecondarySalesAddress.toHexString()
-  );
-  // DEPRECATED END ---
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
@@ -799,14 +767,6 @@ test(`${coreType}: Handles PlatformUpdated::providerPrimaryPercentages - default
   mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
 
   // default value should be test contract value
-  // DEPRECATED START ---
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "renderProviderSecondarySalesAddress",
-    TEST_CONTRACT.renderProviderSecondarySalesAddress.toHexString()
-  );
-  // DEPRECATED END ---
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
@@ -1190,7 +1150,7 @@ test(`${coreType}: Handles PlatformUpdated::providerSecondaryBPS - default value
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
     "renderProviderSecondarySalesBPS",
-    TEST_CONTRACT.renderProviderSecondarySalesBPS.toString()
+    TEST_CONTRACT.defaultRenderProviderSecondarySalesBPS.toString()
   );
   // DEFAULT END ---
   assert.fieldEquals(
@@ -1244,20 +1204,6 @@ test(`${coreType}: Handles PlatformUpdated::providerSecondaryBPS - changed value
   handlePlatformUpdated(event);
 
   // values in store should be updated
-  // DEPRECATED START ---
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "renderProviderSecondarySalesBPS",
-    newRenderProviderSecondarySalesBPS.toString()
-  );
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "enginePlatformProviderSecondarySalesBPS",
-    newPlatformProviderSecondarySalesBPS.toString()
-  );
-  // DEPRECATED END ---
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),

--- a/tests/subgraph/mapping-v3-core/mapping-v3-engine-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-engine-core.test.ts
@@ -1145,14 +1145,6 @@ test(`${coreType}: Handles PlatformUpdated::providerSecondaryBPS - default value
   mockRefreshContractCalls(BigInt.fromI32(0), coreType, null);
 
   // default value should be test contract default value
-  // DEFAULT START ---
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "renderProviderSecondarySalesBPS",
-    TEST_CONTRACT.defaultRenderProviderSecondarySalesBPS.toString()
-  );
-  // DEFAULT END ---
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),

--- a/tests/subgraph/mapping-v3-core/mapping-v3-engine-flex-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-engine-flex-core.test.ts
@@ -615,7 +615,7 @@ test(`${coreType}: Handles PlatformUpdated::providerSalesAddresses - changed val
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
-    "enginePlatformProviderSecondarySalesAddress",
+    "defaultEnginePlatformProviderSecondarySalesAddress",
     newPlatformProviderSecondarySalesAddress.toHexString()
   );
 });
@@ -984,7 +984,7 @@ test(`${coreType}: Handles PlatformUpdated::providerSecondaryBPS - changed value
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
-    "enginePlatformProviderSecondarySalesBPS",
+    "defaultEnginePlatformProviderSecondarySalesBPS",
     newPlatformProviderSecondarySalesBPS.toString()
   );
 });

--- a/tests/subgraph/mapping-v3-core/mapping-v3-engine-flex-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-engine-flex-core.test.ts
@@ -603,7 +603,7 @@ test(`${coreType}: Handles PlatformUpdated::providerSalesAddresses - changed val
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
-    "renderProviderSecondarySalesAddress",
+    "defaultRenderProviderSecondarySalesAddress",
     newRenderProviderSecondarySalesAddress.toHexString()
   );
   assert.fieldEquals(
@@ -632,7 +632,7 @@ test(`${coreType}: Handles PlatformUpdated::providerPrimaryPercentages - default
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
-    "renderProviderSecondarySalesAddress",
+    "defaultRenderProviderSecondarySalesAddress",
     TEST_CONTRACT.defaultRenderProviderSecondarySalesAddress.toHexString()
   );
 });
@@ -929,7 +929,7 @@ test(`${coreType}: Handles PlatformUpdated::providerSecondaryBPS - default value
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
-    "renderProviderSecondarySalesBPS",
+    "defaultRenderProviderSecondarySalesBPS",
     TEST_CONTRACT.defaultRenderProviderSecondarySalesBPS.toString()
   );
 });
@@ -978,7 +978,7 @@ test(`${coreType}: Handles PlatformUpdated::providerSecondaryBPS - changed value
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
-    "renderProviderSecondarySalesBPS",
+    "defaultRenderProviderSecondarySalesBPS",
     newRenderProviderSecondarySalesBPS.toString()
   );
   assert.fieldEquals(

--- a/tests/subgraph/mapping-v3-core/mapping-v3-engine-flex-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-engine-flex-core.test.ts
@@ -633,7 +633,7 @@ test(`${coreType}: Handles PlatformUpdated::providerPrimaryPercentages - default
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
     "renderProviderSecondarySalesAddress",
-    TEST_CONTRACT.renderProviderSecondarySalesAddress.toHexString()
+    TEST_CONTRACT.defaultRenderProviderSecondarySalesAddress.toHexString()
   );
 });
 
@@ -930,7 +930,7 @@ test(`${coreType}: Handles PlatformUpdated::providerSecondaryBPS - default value
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
     "renderProviderSecondarySalesBPS",
-    TEST_CONTRACT.renderProviderSecondarySalesBPS.toString()
+    TEST_CONTRACT.defaultRenderProviderSecondarySalesBPS.toString()
   );
 });
 

--- a/tests/subgraph/mapping-v3-core/mapping-v3p2-engine-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3p2-engine-core.test.ts
@@ -661,14 +661,6 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::providerSalesAddresse
     "renderProviderAddress",
     newRenderProviderPrimarySalesAddress.toHexString()
   );
-  // DEPRECATED START ---
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "renderProviderSecondarySalesAddress",
-    newRenderProviderSecondarySalesAddress.toHexString()
-  );
-  // DEPRECATED END ---
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
@@ -681,14 +673,6 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::providerSalesAddresse
     "enginePlatformProviderAddress",
     newPlatformProviderPrimarySalesAddress.toHexString()
   );
-  // DEPRECATED START ---
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "enginePlatformProviderSecondarySalesAddress",
-    newPlatformProviderSecondarySalesAddress.toHexString()
-  );
-  // DEPRECATED END ---
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
@@ -710,14 +694,6 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::providerPrimaryPercen
   );
 
   // default value should be test contract value
-  // DEPRECATED START ---
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "renderProviderSecondarySalesAddress",
-    TEST_CONTRACT.renderProviderSecondarySalesAddress.toHexString()
-  );
-  // DEPRECATED END ---
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
@@ -1147,20 +1123,6 @@ test(`${coreType}-${coreVersion}: Handles PlatformUpdated::providerSecondaryBPS 
   handlePlatformUpdated(event);
 
   // values in store should be updated
-  // DEPRECATED START ---
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "renderProviderSecondarySalesBPS",
-    newRenderProviderSecondarySalesBPS.toString()
-  );
-  assert.fieldEquals(
-    CONTRACT_ENTITY_TYPE,
-    TEST_CONTRACT_ADDRESS.toHexString(),
-    "enginePlatformProviderSecondarySalesBPS",
-    newPlatformProviderSecondarySalesBPS.toString()
-  );
-  // DEPRECATED END ---
   assert.fieldEquals(
     CONTRACT_ENTITY_TYPE,
     TEST_CONTRACT_ADDRESS.toHexString(),
@@ -1603,7 +1565,7 @@ describe(`${coreType}-${coreVersion}: handleProjectUpdated`, () => {
         PROJECT_ENTITY_TYPE,
         generateContractSpecificId(TEST_CONTRACT_ADDRESS, projectId),
         "renderProviderSecondarySalesAddress",
-        TEST_CONTRACT.renderProviderSecondarySalesAddress.toHexString()
+        TEST_CONTRACT.defaultRenderProviderSecondarySalesAddress.toHexString()
       );
       assert.fieldEquals(
         PROJECT_ENTITY_TYPE,
@@ -1616,7 +1578,7 @@ describe(`${coreType}-${coreVersion}: handleProjectUpdated`, () => {
         PROJECT_ENTITY_TYPE,
         generateContractSpecificId(TEST_CONTRACT_ADDRESS, projectId),
         "enginePlatformProviderSecondarySalesAddress",
-        TEST_CONTRACT.enginePlatformProviderSecondarySalesAddress.toHexString()
+        TEST_CONTRACT.defaultEnginePlatformProviderSecondarySalesAddress.toHexString()
       );
       assert.fieldEquals(
         PROJECT_ENTITY_TYPE,

--- a/tests/subgraph/shared-helpers.ts
+++ b/tests/subgraph/shared-helpers.ts
@@ -161,10 +161,6 @@ export class ContractValues {
   minterContract: Address;
   renderProviderAddress: Address;
   renderProviderPercentage: BigInt;
-  // DEPRECATED START ---
-  renderProviderSecondarySalesAddress: Address;
-  renderProviderSecondarySalesBPS: BigInt;
-  // DEPRECATED END ---
   defaultRenderProviderSecondarySalesAddress: Address;
   defaultRenderProviderSecondarySalesBPS: BigInt;
   dependencyRegistry: Address;
@@ -173,10 +169,6 @@ export class ContractValues {
   // engine-specific fields
   enginePlatformProviderAddress: Address;
   enginePlatformProviderPercentage: BigInt;
-  // DEPRECATED START ---
-  enginePlatformProviderSecondarySalesAddress: Address;
-  enginePlatformProviderSecondarySalesBPS: BigInt;
-  // DEPRECATED END ---
   defaultEnginePlatformProviderSecondarySalesAddress: Address;
   defaultEnginePlatformProviderSecondarySalesBPS: BigInt;
   autoApproveArtistSplitProposals: boolean;
@@ -189,12 +181,6 @@ export const TEST_CONTRACT: ContractValues = {
   renderProviderAddress: Address.fromString(
     "0xf7a55108a6e830a809e88e74cbf5f5de9d930153"
   ),
-  // DEPRECATED START ---
-  renderProviderSecondarySalesAddress: Address.fromString(
-    "0xf4c61bd7b43e89f072fe1ef4e063fcf07f94565c"
-  ),
-  renderProviderSecondarySalesBPS: BigInt.fromI32(250),
-  // DEPRECATED END ---
   defaultRenderProviderSecondarySalesAddress: Address.fromString(
     "0xf4c61bd7b43e89f072fe1ef4e063fcf07f94565c"
   ),
@@ -208,10 +194,6 @@ export const TEST_CONTRACT: ContractValues = {
   // engine-specific fields
   enginePlatformProviderAddress: ENGINE_PLATFORM_PROVIDER_ADDRESS,
   enginePlatformProviderPercentage: ENGINE_PLATFORM_PROVIDER_PERCENTAGE,
-  // DEPRECATED START ---
-  enginePlatformProviderSecondarySalesAddress: ENGINE_PLATFORM_PROVIDER_SECONDARY_SALES_ADDRESS,
-  enginePlatformProviderSecondarySalesBPS: ENGINE_PLATFORM_PROVIDER_SECONDARY_SALES_BPS,
-  // DEPRECATED END ---
   defaultEnginePlatformProviderSecondarySalesAddress: ENGINE_PLATFORM_PROVIDER_SECONDARY_SALES_ADDRESS,
   defaultEnginePlatformProviderSecondarySalesBPS: ENGINE_PLATFORM_PROVIDER_SECONDARY_SALES_BPS,
   autoApproveArtistSplitProposals: DEFAULT_AUTO_APPROVE_ARTIST_SPLIT_PROPOSALS
@@ -384,12 +366,6 @@ export function addTestContractToStore(nextProjectId: BigInt): Contract {
   contract.randomizerContract = TEST_CONTRACT.randomizerContract;
   contract.renderProviderAddress = TEST_CONTRACT.renderProviderAddress;
   contract.renderProviderPercentage = TEST_CONTRACT.renderProviderPercentage;
-  // DEPRECATED START ---
-  contract.renderProviderSecondarySalesAddress =
-    TEST_CONTRACT.renderProviderSecondarySalesAddress;
-  contract.renderProviderSecondarySalesBPS =
-    TEST_CONTRACT.renderProviderSecondarySalesBPS;
-  // DEPRECATED END ---
   contract.defaultRenderProviderSecondarySalesAddress =
     TEST_CONTRACT.defaultRenderProviderSecondarySalesAddress;
   contract.defaultRenderProviderSecondarySalesBPS =
@@ -420,12 +396,6 @@ export function addTestContractToStoreOfTypeAndVersion(
   contract.randomizerContract = TEST_CONTRACT.randomizerContract;
   contract.renderProviderAddress = TEST_CONTRACT.renderProviderAddress;
   contract.renderProviderPercentage = TEST_CONTRACT.renderProviderPercentage;
-  // DEPRECATED START ---
-  contract.renderProviderSecondarySalesAddress =
-    TEST_CONTRACT.renderProviderSecondarySalesAddress;
-  contract.renderProviderSecondarySalesBPS =
-    TEST_CONTRACT.renderProviderSecondarySalesBPS;
-  // DEPRECATED END ---
   contract.defaultRenderProviderSecondarySalesAddress =
     TEST_CONTRACT.defaultRenderProviderSecondarySalesAddress;
   contract.defaultRenderProviderSecondarySalesBPS =
@@ -453,12 +423,6 @@ export function addArbitraryContractToStore(
   contract.randomizerContract = TEST_CONTRACT.randomizerContract;
   contract.renderProviderAddress = TEST_CONTRACT.renderProviderAddress;
   contract.renderProviderPercentage = TEST_CONTRACT.renderProviderPercentage;
-  // DEPRECATED START ---
-  contract.renderProviderSecondarySalesAddress =
-    TEST_CONTRACT.renderProviderSecondarySalesAddress;
-  contract.renderProviderSecondarySalesBPS =
-    TEST_CONTRACT.renderProviderSecondarySalesBPS;
-  // DEPRECATED END ---
   contract.defaultRenderProviderSecondarySalesAddress =
     TEST_CONTRACT.defaultRenderProviderSecondarySalesAddress;
   contract.defaultRenderProviderSecondarySalesBPS =


### PR DESCRIPTION
## Description of the change

Remove deprecated fields of contract-level provider secondary payment addresses.

⚠️ do not remove prior to other portions of infrastructure have been updated to handle this change.

Note: this is a re-creation of the PR #307, which I ruined by accidentally merging a separate PR into.
