### PR TITLE
add Bid.logIndex to schema, handlers, and tests

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -553,6 +553,9 @@ type Bid @entity {
   "The timestamp of the bid"
   timestamp: BigInt!
 
+  "The log index of the event triggering bid update"
+  logIndex: BigInt!
+
   updatedAt: BigInt!
 }
 

--- a/src/ram-lib-mapping.ts
+++ b/src/ram-lib-mapping.ts
@@ -299,6 +299,7 @@ export function handleBidCreated(event: BidCreated): void {
   bid.isRemoved = false;
   bid.slotIndex = event.params.slotIndex;
   bid.timestamp = event.block.timestamp;
+  bid.logIndex = event.logIndex;
   bid.updatedAt = event.block.timestamp;
   bid.save();
 }
@@ -395,6 +396,7 @@ export function handleBidToppedUp(event: BidToppedUp): void {
   bid.slotIndex = event.params.newSlotIndex;
   bid.value = bidValue;
   bid.timestamp = event.block.timestamp;
+  bid.logIndex = event.logIndex;
   bid.updatedAt = event.block.timestamp;
   bid.save();
 }

--- a/src/sea-lib-mapping.ts
+++ b/src/sea-lib-mapping.ts
@@ -490,6 +490,7 @@ function createBidFromValidEvent<T>(event: T): void {
   bid.winningBid = true;
   bid.isRemoved = false;
   bid.timestamp = event.block.timestamp;
+  bid.logIndex = event.logIndex;
   bid.updatedAt = event.block.timestamp;
   bid.save();
 }

--- a/tests/e2e/runner/__tests__/graphql/get-bids.graphql
+++ b/tests/e2e/runner/__tests__/graphql/get-bids.graphql
@@ -19,6 +19,7 @@ fragment BidDetails on Bid {
   value
   winningBid
   timestamp
+  logIndex
   updatedAt
 }
 

--- a/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
@@ -347,6 +347,7 @@ describe("RAMLib event handling", () => {
       expect(bidRes.winningBid).toBe(false);
       expect(bidRes.isRemoved).toBe(false);
       expect(bidRes.timestamp).toBe(auctionBidTimestamp.toString());
+      expect(bidRes.logIndex).toBeDefined();
       expect(bidRes.updatedAt).toBe(auctionBidTimestamp.toString());
       expect(bidRes.project.id).toBe(`${genArt721CoreAddress.toLowerCase()}-0`);
       expect(bidRes.minter.id).toBe(minterRAMV0Address.toLowerCase());
@@ -380,6 +381,7 @@ describe("RAMLib event handling", () => {
       expect(toppedUpBidRes.value).toBe(slot12price.toString());
       expect(toppedUpBidRes.updatedAt).toBe(auctionBid2Timestamp.toString());
       expect(toppedUpBidRes.timestamp).toBe(auctionBid2Timestamp.toString());
+      expect(toppedUpBidRes.logIndex).toBeDefined();
     });
   });
 

--- a/tests/e2e/runner/__tests__/minter-suite-v2/sea-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/sea-lib.test.ts
@@ -409,6 +409,7 @@ describe("SEALib event handling", () => {
       expect(bidRes.winningBid).toBe(true);
       expect(bidRes.isRemoved).toBe(false);
       expect(bidRes.timestamp).toBe(auctionBidTimestamp.toString());
+      expect(bidRes.logIndex).toBeDefined();
       expect(bidRes.updatedAt).toBe(auctionBidTimestamp.toString());
       expect(bidRes.project.id).toBe(`${genArt721CoreAddress.toLowerCase()}-1`);
       expect(bidRes.minter.id).toBe(minterSEAV1Address.toLowerCase());
@@ -564,6 +565,7 @@ describe("SEALib event handling", () => {
       expect(bidRes.timestamp).toBe(
         auctionSettledBidCreatedTimestamp.toString()
       );
+      expect(bidRes.logIndex).toBeDefined();
       expect(bidRes.updatedAt).toBe(
         auctionSettledBidCreatedTimestamp.toString()
       );


### PR DESCRIPTION
## Description of the change

Add Bid.logIndex to schema, handlers, and tests to facilitate more accurate sorting off-chain.

This enables indexed data to be deterministically sorted in the case that two or more bids are changed in the same block, when one or more is a top-up on RAM.

https://linear.app/art-blocks/issue/PLT-788/index-logindex-on-ram-bids