### PR TITLE
Index activated at for v3 contracts

### DIFF
--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -446,7 +446,12 @@ export function handleProjectUpdated(event: ProjectUpdated): void {
     update == FIELD_PROJECT_MAX_INVOCATIONS ||
     update == FIELD_PROJECT_PAUSED
   ) {
-    handleProjectStateDataUpdated(contract, project, timestamp);
+    handleProjectStateDataUpdated(
+      contract,
+      project,
+      timestamp,
+      update as string
+    );
   } else if (update == FIELD_PROJECT_ARTIST_ADDRESS) {
     handleProjectArtistAddressUpdated(contract, project, timestamp);
   } else if (
@@ -500,11 +505,17 @@ export function handleProjectUpdated(event: ProjectUpdated): void {
 function handleProjectStateDataUpdated(
   contract: IGenArt721CoreContractV3_Base,
   project: Project,
-  timestamp: BigInt
+  timestamp: BigInt,
+  updateField: string
 ): void {
   const projectStateData = contract.try_projectStateData(project.projectId);
   if (!projectStateData.reverted) {
-    project.active = projectStateData.value.getActive();
+    const active = projectStateData.value.getActive();
+    project.active = active;
+    if (updateField === FIELD_PROJECT_ACTIVE) {
+      project.activatedAt = active ? timestamp : null;
+    }
+
     project.maxInvocations = projectStateData.value.getMaxInvocations();
     project.paused = projectStateData.value.getPaused();
     project.updatedAt = timestamp;

--- a/tests/subgraph/mapping-v3-core/helpers.ts
+++ b/tests/subgraph/mapping-v3-core/helpers.ts
@@ -705,6 +705,15 @@ export function testProjectStateDataUpdated(
     newValueAsString
   );
 
+  if (updateField === FIELD_PROJECT_ACTIVE) {
+    assert.fieldEquals(
+      PROJECT_ENTITY_TYPE,
+      fullProjectId,
+      "activatedAt",
+      CURRENT_BLOCK_TIMESTAMP.toString()
+    );
+  }
+
   assert.fieldEquals(
     PROJECT_ENTITY_TYPE,
     fullProjectId,


### PR DESCRIPTION
## Description of the change

https://linear.app/art-blocks/issue/PLT-657/add-activated-at-from-pojects-metadata-to-the-subgraph-for-v3

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
