### PR TITLE
Index allowExtraTime in RAM minter configuration extraMinterDetails

### DIFF
--- a/src/ram-lib-mapping.ts
+++ b/src/ram-lib-mapping.ts
@@ -177,6 +177,10 @@ export function handleAuctionConfigUpdated(event: AuctionConfigUpdated): void {
       value: toJSONValue(event.params.numTokensInAuction)
     },
     {
+      key: "allowExtraTime",
+      value: toJSONValue(event.params.allowExtraTime)
+    },
+    {
       key: "adminArtistOnlyMintPeriodIfSellout",
       value: toJSONValue(event.params.adminArtistOnlyMintPeriodIfSellout)
     }

--- a/src/ram-lib-mapping.ts
+++ b/src/ram-lib-mapping.ts
@@ -129,7 +129,18 @@ export function handleAuctionTimestampEndUpdated(
   }
 
   const projectMinterConfig = minterProjectAndConfig.projectMinterConfiguration;
-  // update project minter configuration extraMinterDetails json field
+
+  // Note: we do not update the configuredAuctionEndTime field in this handler.
+  // The configuredAuctionEndTime field is only updated when receiving an
+  // AuctionConfigUpdated event, not when receiving AuctionTimestampEndUpdated.
+  // While AuctionTimestampEndUpdated is emitted in three cases:
+  // 1. When a bid in the last 5 minutes extends the auction (most common)
+  // 2. When reduceAuctionLength is called
+  // 3. When adminAddEmergencyAuctionHours is called
+  // Ideally, we would update configuredAuctionEndTime for cases 2 and 3.
+  // However, since these are edge cases and we cannot reliably differentiate
+  // them from the more common case 1, we take the conservative approach of
+  // not updating configuredAuctionEndTime in this handler.
   setProjectMinterConfigExtraMinterDetailsValue(
     "auctionEndTime",
     event.params.timestampEnd,

--- a/src/ram-lib-mapping.ts
+++ b/src/ram-lib-mapping.ts
@@ -136,6 +136,16 @@ export function handleAuctionTimestampEndUpdated(
     projectMinterConfig
   );
 
+  // If the transaction value is 0, this is not an extension, so we should
+  // update the configured auction end time to the new auction end time.
+  if (event.transaction.value.equals(BigInt.fromI32(0))) {
+    setProjectMinterConfigExtraMinterDetailsValue(
+      "configuredAuctionEndTime",
+      event.params.timestampEnd,
+      projectMinterConfig
+    );
+  }
+
   projectMinterConfig.save();
 
   // induce sync if the project minter configuration is the active one
@@ -172,6 +182,14 @@ export function handleAuctionConfigUpdated(event: AuctionConfigUpdated): void {
       value: toJSONValue(event.params.timestampStart)
     },
     { key: "auctionEndTime", value: toJSONValue(event.params.timestampEnd) },
+    // If extensions are enabled, the auction end time may be updated when
+    // a bid is created. We want to track the configured end time separately
+    // so that we can calculate the latest possible auction end time (1 hour
+    // past the configured end time).
+    {
+      key: "configuredAuctionEndTime",
+      value: toJSONValue(event.params.timestampEnd)
+    },
     {
       key: "numTokensInAuction",
       value: toJSONValue(event.params.numTokensInAuction)

--- a/src/ram-lib-mapping.ts
+++ b/src/ram-lib-mapping.ts
@@ -136,16 +136,6 @@ export function handleAuctionTimestampEndUpdated(
     projectMinterConfig
   );
 
-  // If the transaction value is 0, this is not an extension, so we should
-  // update the configured auction end time to the new auction end time.
-  if (event.transaction.value.equals(BigInt.fromI32(0))) {
-    setProjectMinterConfigExtraMinterDetailsValue(
-      "configuredAuctionEndTime",
-      event.params.timestampEnd,
-      projectMinterConfig
-    );
-  }
-
   projectMinterConfig.save();
 
   // induce sync if the project minter configuration is the active one

--- a/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
@@ -603,7 +603,7 @@ describe("RAMLib event handling", () => {
         reducedTargetAuctionEnd
       );
       expect(extraMinterDetails.configuredAuctionEndTime).toBe(
-        reducedTargetAuctionEnd
+        targetAuctionEnd
       );
 
       // Wait until auction ends (assume it's been extended by 5 minutes)

--- a/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
@@ -530,7 +530,7 @@ describe("RAMLib event handling", () => {
       const extraMinterDetails = JSON.parse(minterConfigRes.extraMinterDetails);
       expect(extraMinterDetails.auctionEndTime).toBe(reducedTargetAuctionEnd);
       expect(extraMinterDetails.configuredAuctionEndTime).toBe(
-        targetAuctionEnd
+        reducedTargetAuctionEnd
       );
 
       // Jump to last minute of auction

--- a/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
@@ -459,12 +459,11 @@ describe("RAMLib event handling", () => {
         client,
         targetId
       );
+      let extraMinterDetails = JSON.parse(minterConfigRes.extraMinterDetails);
 
       // Validate
-      expect(minterConfigRes.extraMinterDetails.auctionEndTime).toBe(
-        targetAuctionEnd
-      );
-      expect(minterConfigRes.extraMinterDetails.configuredAuctionEndTime).toBe(
+      expect(extraMinterDetails.auctionEndTime).toBe(targetAuctionEnd);
+      expect(extraMinterDetails.configuredAuctionEndTime).toBe(
         targetAuctionEnd
       );
 
@@ -561,7 +560,7 @@ describe("RAMLib event handling", () => {
         targetId
       );
 
-      const extraMinterDetails = JSON.parse(minterConfigRes.extraMinterDetails);
+      extraMinterDetails = JSON.parse(minterConfigRes.extraMinterDetails);
       expect(extraMinterDetails.auctionEndTime).toBe(reducedTargetAuctionEnd);
       // The configuredAuctionEndTime is only updated when receiving an AuctionConfigUpdated event,
       // not when receiving AuctionTimestampEndUpdated. While AuctionTimestampEndUpdated is emitted
@@ -599,13 +598,11 @@ describe("RAMLib event handling", () => {
         client,
         targetId
       );
-      const updatedExtraMinterDetails = JSON.parse(
-        minterConfigRes.extraMinterDetails
-      );
-      expect(updatedExtraMinterDetails.auctionEndTime).toBeGreaterThan(
+      extraMinterDetails = JSON.parse(minterConfigRes.extraMinterDetails);
+      expect(extraMinterDetails.auctionEndTime).toBeGreaterThan(
         reducedTargetAuctionEnd
       );
-      expect(updatedExtraMinterDetails.configuredAuctionEndTime).toBe(
+      expect(extraMinterDetails.configuredAuctionEndTime).toBe(
         reducedTargetAuctionEnd
       );
 

--- a/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
@@ -216,6 +216,7 @@ describe("RAMLib event handling", () => {
       expect(extraMinterDetails.startTime).toBe(targetAuctionStart);
       expect(extraMinterDetails.auctionEndTime).toBe(targetAuctionEnd);
       expect(extraMinterDetails.adminArtistOnlyMintPeriodIfSellout).toBe(true);
+      expect(extraMinterDetails.allowExtraTime).toBe(true);
     });
   });
 

--- a/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
@@ -473,7 +473,9 @@ describe("RAMLib event handling", () => {
           }
         );
       await createBidTx1.wait();
+
       await waitUntilSubgraphIsSynced(client);
+
       // Place another bid
       const createBidTx2 = await minterRAMV0Contract
         .connect(deployer)
@@ -487,6 +489,7 @@ describe("RAMLib event handling", () => {
         );
       await createBidTx2.wait();
       await waitUntilSubgraphIsSynced(client);
+
       // Place a third, higher bid
       // Get slot index for bid value
       const slot10price = await minterRAMV0Contract.slotIndexToBidValue(
@@ -508,7 +511,9 @@ describe("RAMLib event handling", () => {
       const auctionBid3Timestamp = (
         await artist.provider.getBlock(receipt3.blockNumber)
       )?.timestamp;
+
       await waitUntilSubgraphIsSynced(client);
+
       // Validate the second Bid was removed
       const bidId = `${minterRAMV0Address.toLowerCase()}-${genArt721CoreAddress.toLowerCase()}-${currentProjectNumber}-2`;
       const bidRes = await getBidDetails(client, bidId);
@@ -528,12 +533,15 @@ describe("RAMLib event handling", () => {
           reducedTargetAuctionEnd // _auctionTimestampEnd
         );
       await reduceAuctionLengthTx.wait();
+
       await waitUntilSubgraphIsSynced(client);
+
       const targetId = `${minterRAMV0Address.toLowerCase()}-${genArt721CoreAddress.toLowerCase()}-${currentProjectNumber}`;
       const minterConfigRes = await getProjectMinterConfigurationDetails(
         client,
         targetId
       );
+
       // validate extraMinterDetails
       const extraMinterDetails = JSON.parse(minterConfigRes.extraMinterDetails);
       expect(extraMinterDetails.auctionEndTime).toBe(reducedTargetAuctionEnd);
@@ -575,6 +583,7 @@ describe("RAMLib event handling", () => {
 
       // Wait until auction ends (assume it's been extended by 5 minutes)
       await increaseTimeNextBlock(620);
+
       // Auto mint tokens to winners
       const adminArtistAutoMintTx = await minterRAMV0Contract
         .connect(artist)
@@ -587,10 +596,12 @@ describe("RAMLib event handling", () => {
       const auctionBid6Timestamp = (
         await artist.provider.getBlock(receipt6.blockNumber)
       )?.timestamp;
+
       await waitUntilSubgraphIsSynced(client);
+
       // validate Bids settled and minted
       const winningBidTokenId = Number(currentProjectNumber) * 1000000;
-      const winningBid1 = `${minterRAMV0Address.toLowerCase()}-${genArt721CoreAddress.toLowerCase()}-${currentProjectNumber}-1`;
+      const winningBid1 = `${minterRAMV0Address.toLowerCase()}-${genArt721CoreAddress.toLowerCase()}-${currentProjectNumber}-3`;
       const winningBid2 = `${minterRAMV0Address.toLowerCase()}-${genArt721CoreAddress.toLowerCase()}-${currentProjectNumber}-4`;
       const winningBid1Res = await getBidDetails(client, winningBid1);
       const winningBid2Res = await getBidDetails(client, winningBid2);

--- a/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
+++ b/tests/e2e/runner/__tests__/minter-suite-v2/ram-lib.test.ts
@@ -462,26 +462,30 @@ describe("RAMLib event handling", () => {
       await increaseTimeNextBlock(66);
       // Create bid for auction
       // @dev bids can only be created when auction is live
-      const tx = await minterRAMV0Contract.connect(deployer).createBid(
-        currentProjectNumber, // _projectId
-        genArt721CoreAddress, // _coreContract
-        5, // _slotIndex
-        {
-          value: slot5price,
-        }
-      );
-      await tx.wait();
+      const createBidTx1 = await minterRAMV0Contract
+        .connect(deployer)
+        .createBid(
+          currentProjectNumber, // _projectId
+          genArt721CoreAddress, // _coreContract
+          5, // _slotIndex
+          {
+            value: slot5price,
+          }
+        );
+      await createBidTx1.wait();
       await waitUntilSubgraphIsSynced(client);
       // Place another bid
-      const tx2 = await minterRAMV0Contract.connect(deployer).createBid(
-        currentProjectNumber, // _projectId
-        genArt721CoreAddress, // _coreContract
-        5, // _slotIndex
-        {
-          value: slot5price,
-        }
-      );
-      await tx2.wait();
+      const createBidTx2 = await minterRAMV0Contract
+        .connect(deployer)
+        .createBid(
+          currentProjectNumber, // _projectId
+          genArt721CoreAddress, // _coreContract
+          5, // _slotIndex
+          {
+            value: slot5price,
+          }
+        );
+      await createBidTx2.wait();
       await waitUntilSubgraphIsSynced(client);
       // Place a third, higher bid
       // Get slot index for bid value
@@ -490,15 +494,17 @@ describe("RAMLib event handling", () => {
         genArt721CoreAddress, // _coreContract
         10 // _slotIndex
       );
-      const tx3 = await minterRAMV0Contract.connect(deployer).createBid(
-        currentProjectNumber, // _projectId
-        genArt721CoreAddress, // _coreContract
-        10, // _slotIndex
-        {
-          value: slot10price,
-        }
-      );
-      const receipt3 = await tx3.wait();
+      const createBidTx3 = await minterRAMV0Contract
+        .connect(deployer)
+        .createBid(
+          currentProjectNumber, // _projectId
+          genArt721CoreAddress, // _coreContract
+          10, // _slotIndex
+          {
+            value: slot10price,
+          }
+        );
+      const receipt3 = await createBidTx3.wait();
       const auctionBid3Timestamp = (
         await artist.provider.getBlock(receipt3.blockNumber)
       )?.timestamp;
@@ -514,12 +520,14 @@ describe("RAMLib event handling", () => {
       expect(bidRes.updatedAt).toBe(auctionBid3Timestamp.toString());
 
       // Artist reduces auction length time
-      const tx4 = await minterRAMV0Contract.connect(artist).reduceAuctionLength(
-        currentProjectNumber, // _projectId
-        genArt721CoreAddress, // _coreContract
-        reducedTargetAuctionEnd // _auctionTimestampEnd
-      );
-      await tx4.wait();
+      const reduceAuctionLengthTx = await minterRAMV0Contract
+        .connect(artist)
+        .reduceAuctionLength(
+          currentProjectNumber, // _projectId
+          genArt721CoreAddress, // _coreContract
+          reducedTargetAuctionEnd // _auctionTimestampEnd
+        );
+      await reduceAuctionLengthTx.wait();
       await waitUntilSubgraphIsSynced(client);
       const targetId = `${minterRAMV0Address.toLowerCase()}-${genArt721CoreAddress.toLowerCase()}-${currentProjectNumber}`;
       const minterConfigRes = await getProjectMinterConfigurationDetails(
@@ -542,12 +550,12 @@ describe("RAMLib event handling", () => {
         genArt721CoreAddress,
         15
       );
-      const tx5 = await minterRAMV0Contract
+      const createBidTx4 = await minterRAMV0Contract
         .connect(deployer)
         .createBid(currentProjectNumber, genArt721CoreAddress, 15, {
           value: slot15price,
         });
-      await tx5.wait();
+      await createBidTx4.wait();
       await waitUntilSubgraphIsSynced(client);
 
       // Validate auction end time was extended but configured end time stayed same
@@ -565,17 +573,17 @@ describe("RAMLib event handling", () => {
         reducedTargetAuctionEnd
       );
 
-      // Wait until auction ends
-      await increaseTimeNextBlock(60);
+      // Wait until auction ends (assume it's been extended by 5 minutes)
+      await increaseTimeNextBlock(620);
       // Auto mint tokens to winners
-      const tx6 = await minterRAMV0Contract
+      const adminArtistAutoMintTx = await minterRAMV0Contract
         .connect(artist)
         .adminArtistAutoMintTokensToWinners(
           currentProjectNumber, // _projectId
           genArt721CoreAddress, // _coreContract
           2 // _numTokensToMint
         );
-      const receipt6 = await tx6.wait();
+      const receipt6 = await adminArtistAutoMintTx.wait();
       const auctionBid6Timestamp = (
         await artist.provider.getBlock(receipt6.blockNumber)
       )?.timestamp;

--- a/tests/e2e/runner/package.json
+++ b/tests/e2e/runner/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "codegen": "yarn graphql-codegen --require dotenv/config --config ./graphql.config.js dotenv_config_path=./.env",
-    "test": "yarn generate:typechain && yarn codegen && yarn jest --runInBand",
+    "test": "yarn generate:typechain && yarn codegen && yarn jest --runInBand __tests__/minter-suite-v2/ram-lib.test.ts",
     "generate:typechain": "typechain --target ethers-v5 --out-dir ./contracts './node_modules/@artblocks/contracts//artifacts/contracts/**/!(*.dbg)*.json' && yarn generate-supplemental-abis",
     "generate-supplemental-abis": "path-exists ./supplemental_abis/*.json && typechain --target ethers-v5 --out-dir ./contracts './supplemental_abis/*.json' || echo 'No supplemental ABIs found.'"
   },

--- a/tests/e2e/runner/package.json
+++ b/tests/e2e/runner/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "codegen": "yarn graphql-codegen --require dotenv/config --config ./graphql.config.js dotenv_config_path=./.env",
-    "test": "yarn generate:typechain && yarn codegen && yarn jest --runInBand __tests__/minter-suite-v2/ram-lib.test.ts",
+    "test": "yarn generate:typechain && yarn codegen && yarn jest --runInBand",
     "generate:typechain": "typechain --target ethers-v5 --out-dir ./contracts './node_modules/@artblocks/contracts//artifacts/contracts/**/!(*.dbg)*.json' && yarn generate-supplemental-abis",
     "generate-supplemental-abis": "path-exists ./supplemental_abis/*.json && typechain --target ethers-v5 --out-dir ./contracts './supplemental_abis/*.json' || echo 'No supplemental ABIs found.'"
   },


### PR DESCRIPTION
## Description of the change

Index allowExtraTime in RAM minter configuration extraMinterDetails. Index `configuredAuctionEndTime` on RAM minter configuration extraMinterDetails to differentiate between the end time that may have been extended due to a last minute bid.

https://linear.app/art-blocks/issue/PLT-861/index-allowextratime-in-subgraph

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
