### PR TITLE
Update DependencyRegistry subgraph modeling

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -275,8 +275,8 @@ type Contract @entity {
   "Curation registry contract address"
   curationRegistry: Bytes
 
-  "Dependency registry contract address"
-  dependencyRegistry: DependencyRegistry
+  "Latest Override Allowlisted on Dependency Registry; only populated if allowlisted on a DependencyRegistry instead of the CoreRegistry"
+  latestDepenencyRegistryOverrideAllowlistedOn: DependencyRegistry
 
   "Curent royalty split provider contract address, used on v3.2 and-on"
   royaltySplitProvider: Bytes
@@ -839,8 +839,11 @@ type Dependency @entity {
 type DependencyRegistry @entity {
   "Unique identifier made up of dependency registry contract address"
   id: Bytes!
-  "Core contracts that this registry can provide dependeny overrides for"
-  supportedCoreContracts: [Contract!]! @derivedFrom(field: "dependencyRegistry")
+  "Core registry that defines the base set of contracts supported by this registry"
+  coreRegistry: CoreRegistry!
+  "List of core contracts that are explicitly allowlisted on this registry, extending those on the CoreRegistry"
+  supportedCoreContractsOverride: [Contract!]!
+    @derivedFrom(field: "latestDepenencyRegistryOverrideAllowlistedOn")
   "List of dependencies that are registered on this registry contract"
   dependencies: [Dependency!] @derivedFrom(field: "dependencyRegistry")
   "Current owner of this contract"


### PR DESCRIPTION
## Description of the change

Update subgraph to reflect recent updates 

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
