### PR TITLE
Add commands to deploy testnet subgraphs to alchemy

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "deploy:studio-sepolia-dev": "yarn prepare:sepolia-dev && graph deploy --studio art-blocks-dev-sepolia",
     "deploy:studio-sepolia-staging": "yarn prepare:sepolia-staging && graph deploy --studio art-blocks-staging-sepolia",
     "deploy:studio-arbitrum-one": "yarn prepare:arbitrum-one && graph deploy --studio art-blocks-arbitrum",
+    "deploy:alchemy-sepolia-dev": "yarn prepare:sepolia-dev && export $(cat .env | xargs) && graph deploy art-blocks-sepolia-dev --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key $ALCHEMY_DEPLOY_KEY",
+    "deploy:alchemy-sepolia-staging": "yarn prepare:sepolia-staging && export $(cat .env | xargs) && graph deploy art-blocks-sepolia-staging --node https://subgraphs.alchemy.com/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key $ALCHEMY_DEPLOY_KEY",
     "create:local": "graph create --node http://localhost:8020/ artblocks/art-blocks",
     "remove:local": "graph remove --node http://localhost:8020/ artblocks/art-blocks",
     "deploy:local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 artblocks/art-blocks",


### PR DESCRIPTION
## Description of the change

\<add description here\>

>reminder: Any subgraph deployments should be documented as [Releases](https://github.com/ArtBlocks/artblocks-subgraph/releases) in this repository.

>reminder: Any changes to subgraph schema should be accompanied by corresponding changes to the Art Blocks documentation site, available at https://docs.artblocks.io/ (specifically, see the [Subgraph Entities](https://docs.artblocks.io/creator-docs/art-blocks-api/entities/) and [Subgraph Querying and API Overview](https://docs.artblocks.io/creator-docs/art-blocks-api/queries/) sections).
