### PR TITLE
New mint event

### DIFF
--- a/abis-supplemental/IGenArt721CoreContractV3_Base.json
+++ b/abis-supplemental/IGenArt721CoreContractV3_Base.json
@@ -1,0 +1,640 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "IGenArt721CoreContractV3_Base",
+  "sourceName": "contracts/interfaces/v0.8.x/IGenArt721CoreContractV3_Base.sol",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "enum IGenArt721CoreContractV3_Base.ErrorCodes",
+          "name": "_errorCode",
+          "type": "uint8"
+        }
+      ],
+      "name": "GenArt721Error",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "AcceptedArtistAddressesAndSplits",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "artblocksCurationRegistryAddress",
+          "type": "address"
+        }
+      ],
+      "name": "ArtBlocksCurationRegistryContractUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "Mint",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_tokenId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "_tokenHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "Mint",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "_currentMinter",
+          "type": "address"
+        }
+      ],
+      "name": "MinterUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_field",
+          "type": "bytes32"
+        }
+      ],
+      "name": "PlatformUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "royaltySplitter",
+          "type": "address"
+        }
+      ],
+      "name": "ProjectRoyaltySplitterUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "_update",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ProjectUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "_artistAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "_additionalPayeePrimarySales",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_additionalPayeePrimarySalesPercentage",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "_additionalPayeeSecondarySales",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_additionalPayeeSecondarySalesPercentage",
+          "type": "uint256"
+        }
+      ],
+      "name": "ProposedArtistAddressesAndSplits",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "admin",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_sender",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_contract",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes4",
+          "name": "_selector",
+          "type": "bytes4"
+        }
+      ],
+      "name": "adminACLAllowed",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "adminACLContract",
+      "outputs": [
+        {
+          "internalType": "contract IAdminACLV0",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "coreType",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "coreVersion",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "minter",
+          "type": "address"
+        }
+      ],
+      "name": "isMintWhitelisted",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_by",
+          "type": "address"
+        }
+      ],
+      "name": "mint_Ecf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "nextProjectId",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "projectDetails",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "projectName",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "artist",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "description",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "website",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "license",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "projectIdToArtistAddress",
+      "outputs": [
+        {
+          "internalType": "address payable",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "projectIdToSecondaryMarketRoyaltyPercentage",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_index",
+          "type": "uint256"
+        }
+      ],
+      "name": "projectScriptByIndex",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_index",
+          "type": "uint256"
+        }
+      ],
+      "name": "projectScriptBytecodeAddressByIndex",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "projectScriptDetails",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "scriptTypeAndVersion",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "aspectRatio",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "scriptCount",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "projectStateData",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "invocations",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxInvocations",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "active",
+          "type": "bool"
+        },
+        {
+          "internalType": "bool",
+          "name": "paused",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint256",
+          "name": "completedTimestamp",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "locked",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_projectId",
+          "type": "uint256"
+        }
+      ],
+      "name": "projectURIInfo",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "projectBaseURI",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_tokenId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "_hash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "setTokenHash_8PT",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "startingProjectId",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "tokenIdToHash",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "tokenIdToProjectId",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "projectId",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x",
+  "deployedBytecode": "0x",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -138,6 +138,11 @@ export function handleMint(event: Mint): void {
  * performance and reliability.
  * Both handlers must remain active: legacy contracts emit the 2-param
  * Mint event, while v3.2.9+ contracts emit this 3-param version.
+ * @dev If `_tokenHash` is bytes32(0), it means the token's hash was not
+ * atomically assigned during the mint transaction. If that flow is to be
+ * supported in the future, this handler's logic will need to be updated
+ * to handle that case (e.g. by deferring hash assignment or listening
+ * for a subsequent hash-assignment event).
  */
 export function handleMintWithTokenHash(event: MintWithTokenHash): void {
   _handleMintEvent(

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -114,83 +114,18 @@ export function handleIAdminACLV0SuperAdminTransferred(
 }
 
 export function handleMint(event: Mint): void {
+  // Legacy Mint event (pre-v3.2.9) does not include token hash, so we
+  // must fetch it via an RPC call to `tokenIdToHash`.
   const contract = getIGenArt721CoreContractV3_BaseContract(event.address);
-  let token = new Token(
-    generateContractSpecificId(event.address, event.params._tokenId)
+  const tokenHash = contract.tokenIdToHash(event.params._tokenId);
+  _handleMintEvent(
+    event.address,
+    event.params._tokenId,
+    event.params._to,
+    tokenHash,
+    event.block.timestamp,
+    event.transaction.hash
   );
-  let projectIdNumber = generateProjectIdNumberFromTokenIdNumber(
-    event.params._tokenId
-  );
-  let projectId = generateContractSpecificId(event.address, projectIdNumber);
-
-  let project = Project.load(projectId);
-  if (project) {
-    // @dev use invocations from entity in store. This will reflect the state
-    // at the time of the event, not the end of the block, which is required
-    // because many invocations often occur in a single block.
-    let invocation = project.invocations;
-
-    token.tokenId = event.params._tokenId;
-    token.contract = event.address.toHexString();
-    token.project = projectId;
-    token.owner = event.params._to.toHexString();
-    // Okay to assume the hash is assigned in same tx as mint for now,
-    // but this will need to be updated if we ever support async token hash
-    // assignment.
-    token.hash = contract.tokenIdToHash(event.params._tokenId);
-    token.invocation = invocation;
-    token.createdAt = event.block.timestamp;
-    token.updatedAt = event.block.timestamp;
-    token.transactionHash = event.transaction.hash;
-    token.nextSaleId = BigInt.fromI32(0);
-
-    if (project.minterConfiguration) {
-      const minterConfiguration = ProjectMinterConfiguration.load(
-        changetype<string>(project.minterConfiguration)
-      );
-
-      if (minterConfiguration) {
-        const purchaseDetails = new PrimaryPurchase(token.id);
-        purchaseDetails.token = token.id;
-        purchaseDetails.transactionHash = event.transaction.hash;
-        purchaseDetails.minterAddress = changetype<Bytes>(
-          ByteArray.fromHexString(minterConfiguration.minter)
-        );
-        purchaseDetails.currencyAddress = minterConfiguration.currencyAddress;
-        purchaseDetails.currencySymbol = minterConfiguration.currencySymbol;
-        purchaseDetails.save();
-        token.primaryPurchaseDetails = purchaseDetails.id;
-      } else {
-        log.warning("Minter configuration not found with id: {}", [
-          changetype<string>(project.minterConfiguration)
-        ]);
-      }
-    }
-
-    token.save();
-
-    project.invocations = invocation.plus(BigInt.fromI32(1));
-    if (project.invocations == project.maxInvocations) {
-      project.complete = true;
-      project.completedAt = event.block.timestamp;
-      project.updatedAt = event.block.timestamp;
-    }
-    project.save();
-
-    let account = new Account(token.owner);
-    account.save();
-
-    let accountProjectId = generateAccountProjectId(account.id, project.id);
-    let accountProject = AccountProject.load(accountProjectId);
-    if (!accountProject) {
-      accountProject = new AccountProject(accountProjectId);
-      accountProject.account = account.id;
-      accountProject.project = project.id;
-      accountProject.count = 0;
-    }
-    accountProject.count += 1;
-    accountProject.save();
-  }
 }
 
 /**
@@ -205,13 +140,35 @@ export function handleMint(event: Mint): void {
  * Mint event, while v3.2.9+ contracts emit this 3-param version.
  */
 export function handleMintWithTokenHash(event: MintWithTokenHash): void {
+  _handleMintEvent(
+    event.address,
+    event.params._tokenId,
+    event.params._to,
+    event.params._tokenHash,
+    event.block.timestamp,
+    event.transaction.hash
+  );
+}
+
+/**
+ * @dev Shared mint logic used by both the legacy Mint(address,uint256) handler
+ * and the v3.2.9+ Mint(address,uint256,bytes32) handler. The only difference
+ * between the two is how the token hash is resolved (RPC call vs. event
+ * parameter), which is handled by the caller before invoking this function.
+ */
+function _handleMintEvent(
+  contractAddress: Address,
+  tokenId: BigInt,
+  to: Address,
+  tokenHash: Bytes,
+  blockTimestamp: BigInt,
+  transactionHash: Bytes
+): void {
   let token = new Token(
-    generateContractSpecificId(event.address, event.params._tokenId)
+    generateContractSpecificId(contractAddress, tokenId)
   );
-  let projectIdNumber = generateProjectIdNumberFromTokenIdNumber(
-    event.params._tokenId
-  );
-  let projectId = generateContractSpecificId(event.address, projectIdNumber);
+  let projectIdNumber = generateProjectIdNumberFromTokenIdNumber(tokenId);
+  let projectId = generateContractSpecificId(contractAddress, projectIdNumber);
 
   let project = Project.load(projectId);
   if (project) {
@@ -220,17 +177,15 @@ export function handleMintWithTokenHash(event: MintWithTokenHash): void {
     // because many invocations often occur in a single block.
     let invocation = project.invocations;
 
-    token.tokenId = event.params._tokenId;
-    token.contract = event.address.toHexString();
+    token.tokenId = tokenId;
+    token.contract = contractAddress.toHexString();
     token.project = projectId;
-    token.owner = event.params._to.toHexString();
-    // Token hash is provided directly in the event (v3.2.9+), so no RPC
-    // call to `tokenIdToHash` is needed.
-    token.hash = event.params._tokenHash;
+    token.owner = to.toHexString();
+    token.hash = tokenHash;
     token.invocation = invocation;
-    token.createdAt = event.block.timestamp;
-    token.updatedAt = event.block.timestamp;
-    token.transactionHash = event.transaction.hash;
+    token.createdAt = blockTimestamp;
+    token.updatedAt = blockTimestamp;
+    token.transactionHash = transactionHash;
     token.nextSaleId = BigInt.fromI32(0);
 
     if (project.minterConfiguration) {
@@ -241,7 +196,7 @@ export function handleMintWithTokenHash(event: MintWithTokenHash): void {
       if (minterConfiguration) {
         const purchaseDetails = new PrimaryPurchase(token.id);
         purchaseDetails.token = token.id;
-        purchaseDetails.transactionHash = event.transaction.hash;
+        purchaseDetails.transactionHash = transactionHash;
         purchaseDetails.minterAddress = changetype<Bytes>(
           ByteArray.fromHexString(minterConfiguration.minter)
         );
@@ -261,8 +216,8 @@ export function handleMintWithTokenHash(event: MintWithTokenHash): void {
     project.invocations = invocation.plus(BigInt.fromI32(1));
     if (project.invocations == project.maxInvocations) {
       project.complete = true;
-      project.completedAt = event.block.timestamp;
-      project.updatedAt = event.block.timestamp;
+      project.completedAt = blockTimestamp;
+      project.updatedAt = blockTimestamp;
     }
     project.save();
 

--- a/src/mapping-v3-core.ts
+++ b/src/mapping-v3-core.ts
@@ -10,6 +10,7 @@ import {
 
 import {
   Mint,
+  Mint1 as MintWithTokenHash,
   ProjectUpdated,
   PlatformUpdated,
   MinterUpdated,
@@ -137,6 +138,95 @@ export function handleMint(event: Mint): void {
     // but this will need to be updated if we ever support async token hash
     // assignment.
     token.hash = contract.tokenIdToHash(event.params._tokenId);
+    token.invocation = invocation;
+    token.createdAt = event.block.timestamp;
+    token.updatedAt = event.block.timestamp;
+    token.transactionHash = event.transaction.hash;
+    token.nextSaleId = BigInt.fromI32(0);
+
+    if (project.minterConfiguration) {
+      const minterConfiguration = ProjectMinterConfiguration.load(
+        changetype<string>(project.minterConfiguration)
+      );
+
+      if (minterConfiguration) {
+        const purchaseDetails = new PrimaryPurchase(token.id);
+        purchaseDetails.token = token.id;
+        purchaseDetails.transactionHash = event.transaction.hash;
+        purchaseDetails.minterAddress = changetype<Bytes>(
+          ByteArray.fromHexString(minterConfiguration.minter)
+        );
+        purchaseDetails.currencyAddress = minterConfiguration.currencyAddress;
+        purchaseDetails.currencySymbol = minterConfiguration.currencySymbol;
+        purchaseDetails.save();
+        token.primaryPurchaseDetails = purchaseDetails.id;
+      } else {
+        log.warning("Minter configuration not found with id: {}", [
+          changetype<string>(project.minterConfiguration)
+        ]);
+      }
+    }
+
+    token.save();
+
+    project.invocations = invocation.plus(BigInt.fromI32(1));
+    if (project.invocations == project.maxInvocations) {
+      project.complete = true;
+      project.completedAt = event.block.timestamp;
+      project.updatedAt = event.block.timestamp;
+    }
+    project.save();
+
+    let account = new Account(token.owner);
+    account.save();
+
+    let accountProjectId = generateAccountProjectId(account.id, project.id);
+    let accountProject = AccountProject.load(accountProjectId);
+    if (!accountProject) {
+      accountProject = new AccountProject(accountProjectId);
+      accountProject.account = account.id;
+      accountProject.project = project.id;
+      accountProject.count = 0;
+    }
+    accountProject.count += 1;
+    accountProject.save();
+  }
+}
+
+/**
+ * @dev Added in v3.2.9 of the V3 core contract.
+ * This handler processes the new Mint event that includes the token hash
+ * directly in the event parameters: Mint(address,uint256,bytes32).
+ * Unlike the legacy Mint(address,uint256) handler above, this handler does
+ * NOT need to make an RPC call to `tokenIdToHash` because the token hash
+ * is emitted as part of the event itself. This improves indexing
+ * performance and reliability.
+ * Both handlers must remain active: legacy contracts emit the 2-param
+ * Mint event, while v3.2.9+ contracts emit this 3-param version.
+ */
+export function handleMintWithTokenHash(event: MintWithTokenHash): void {
+  let token = new Token(
+    generateContractSpecificId(event.address, event.params._tokenId)
+  );
+  let projectIdNumber = generateProjectIdNumberFromTokenIdNumber(
+    event.params._tokenId
+  );
+  let projectId = generateContractSpecificId(event.address, projectIdNumber);
+
+  let project = Project.load(projectId);
+  if (project) {
+    // @dev use invocations from entity in store. This will reflect the state
+    // at the time of the event, not the end of the block, which is required
+    // because many invocations often occur in a single block.
+    let invocation = project.invocations;
+
+    token.tokenId = event.params._tokenId;
+    token.contract = event.address.toHexString();
+    token.project = projectId;
+    token.owner = event.params._to.toHexString();
+    // Token hash is provided directly in the event (v3.2.9+), so no RPC
+    // call to `tokenIdToHash` is needed.
+    token.hash = event.params._tokenHash;
     token.invocation = invocation;
     token.createdAt = event.block.timestamp;
     token.updatedAt = event.block.timestamp;

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -152,6 +152,8 @@ dataSources:
       eventHandlers:
         - event: Mint(indexed address,indexed uint256)
           handler: handleMint
+        - event: Mint(indexed address,indexed uint256,bytes32)
+          handler: handleMintWithTokenHash
         - event: ProjectUpdated(indexed uint256,indexed bytes32)
           handler: handleProjectUpdated
         - event: PlatformUpdated(indexed bytes32)
@@ -2513,6 +2515,8 @@ templates:
       eventHandlers:
         - event: Mint(indexed address,indexed uint256)
           handler: handleMint
+        - event: Mint(indexed address,indexed uint256,bytes32)
+          handler: handleMintWithTokenHash
         - event: ProjectUpdated(indexed uint256,indexed bytes32)
           handler: handleProjectUpdated
         - event: PlatformUpdated(indexed bytes32)

--- a/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
+++ b/tests/subgraph/mapping-v3-core/mapping-v3-core.test.ts
@@ -55,6 +55,7 @@ import {
 import { Project } from "../../../generated/schema";
 import {
   Mint,
+  Mint1 as MintWithTokenHash,
   ProjectUpdated,
   PlatformUpdated
 } from "../../../generated/IGenArt721CoreV3_Base/IGenArt721CoreContractV3_Base";
@@ -81,6 +82,7 @@ import {
   FIELD_PROJECT_WEBSITE,
   handleIAdminACLV0SuperAdminTransferred,
   handleMint,
+  handleMintWithTokenHash,
   handleTransfer,
   handlePlatformUpdated,
   handleOwnershipTransferred,
@@ -249,6 +251,190 @@ test(`${coreType}: Can handle Mint without purchase details`, () => {
     fullTokenId,
     "owner",
     toAddress.toHexString()
+  );
+
+  assert.notInStore(PRIMARY_PURCHASE_ENTITY_TYPE, fullTokenId);
+});
+
+// Tests for the v3.2.9+ Mint(address,uint256,bytes32) event, which includes
+// the token hash directly in the event. The handler should NOT make any RPC
+// calls to `tokenIdToHash`; notably, we do NOT mock `tokenIdToHash` here,
+// so the test will fail if the handler attempts that call.
+test(`${coreType}: Can handle MintWithTokenHash with purchase details`, () => {
+  clearStore();
+  const projectId = BigInt.fromI32(1);
+  const tokenId = BigInt.fromI32(1000001);
+  addTestContractToStore(projectId);
+  // Intentionally NOT mocking tokenIdToHash — the handler must not call it.
+  mockCoreType(TEST_CONTRACT_ADDRESS, `${coreType}`);
+
+  const fullProjectId = generateContractSpecificId(
+    TEST_CONTRACT_ADDRESS,
+    projectId
+  );
+  const artistAddress = randomAddressGenerator.generateRandomAddress();
+  const projectName = "Test Project";
+  const pricePerTokenInWei = BigInt.fromI64(i64(1e18));
+
+  const project = addNewProjectToStore(
+    TEST_CONTRACT_ADDRESS,
+    projectId,
+    projectName,
+    artistAddress,
+    pricePerTokenInWei,
+    CURRENT_BLOCK_TIMESTAMP
+  );
+
+  const minterAddress = randomAddressGenerator.generateRandomAddress();
+  const currencyAddress = randomAddressGenerator.generateRandomAddress();
+  const currencySymbol = "TEST";
+  const projectMinterConfig = addNewLegacyProjectMinterConfigToStore(
+    fullProjectId,
+    minterAddress
+  );
+  projectMinterConfig.currencyAddress = currencyAddress;
+  projectMinterConfig.currencySymbol = currencySymbol;
+  projectMinterConfig.save();
+
+  project.minterConfiguration = projectMinterConfig.id;
+  project.save();
+
+  const fullTokenId = generateContractSpecificId(
+    TEST_CONTRACT_ADDRESS,
+    tokenId
+  );
+
+  const toAddress = randomAddressGenerator.generateRandomAddress();
+
+  const event: MintWithTokenHash = changetype<MintWithTokenHash>(
+    newMockEvent()
+  );
+  event.address = TEST_CONTRACT_ADDRESS;
+  event.transaction.hash = TEST_TX_HASH;
+  event.logIndex = BigInt.fromI32(0);
+  event.parameters = [
+    new ethereum.EventParam("_to", ethereum.Value.fromAddress(toAddress)),
+    new ethereum.EventParam(
+      "_tokenId",
+      ethereum.Value.fromUnsignedBigInt(tokenId)
+    ),
+    new ethereum.EventParam(
+      "_tokenHash",
+      ethereum.Value.fromFixedBytes(TEST_TOKEN_HASH)
+    )
+  ];
+
+  handleMintWithTokenHash(event);
+
+  assert.fieldEquals(
+    TOKEN_ENTITY_TYPE,
+    fullTokenId,
+    "owner",
+    toAddress.toHexString()
+  );
+
+  // Verify token hash was sourced from the event, not an RPC call
+  assert.fieldEquals(
+    TOKEN_ENTITY_TYPE,
+    fullTokenId,
+    "hash",
+    TEST_TOKEN_HASH.toHexString()
+  );
+
+  assert.fieldEquals(
+    PRIMARY_PURCHASE_ENTITY_TYPE,
+    fullTokenId,
+    "token",
+    fullTokenId
+  );
+
+  assert.fieldEquals(
+    PRIMARY_PURCHASE_ENTITY_TYPE,
+    fullTokenId,
+    "minterAddress",
+    minterAddress.toHexString()
+  );
+
+  assert.fieldEquals(
+    PRIMARY_PURCHASE_ENTITY_TYPE,
+    fullTokenId,
+    "currencyAddress",
+    currencyAddress.toHexString()
+  );
+
+  assert.fieldEquals(
+    PRIMARY_PURCHASE_ENTITY_TYPE,
+    fullTokenId,
+    "currencySymbol",
+    currencySymbol
+  );
+});
+
+test(`${coreType}: Can handle MintWithTokenHash without purchase details`, () => {
+  clearStore();
+  const projectId = BigInt.fromI32(1);
+  const tokenId = BigInt.fromI32(1000001);
+  addTestContractToStore(projectId);
+  // Intentionally NOT mocking tokenIdToHash — the handler must not call it.
+  mockCoreType(TEST_CONTRACT_ADDRESS, `${coreType}`);
+
+  const fullProjectId = generateContractSpecificId(
+    TEST_CONTRACT_ADDRESS,
+    projectId
+  );
+  const artistAddress = randomAddressGenerator.generateRandomAddress();
+  const projectName = "Test Project";
+  const pricePerTokenInWei = BigInt.fromI64(i64(1e18));
+
+  addNewProjectToStore(
+    TEST_CONTRACT_ADDRESS,
+    projectId,
+    projectName,
+    artistAddress,
+    pricePerTokenInWei,
+    CURRENT_BLOCK_TIMESTAMP
+  );
+
+  const fullTokenId = generateContractSpecificId(
+    TEST_CONTRACT_ADDRESS,
+    tokenId
+  );
+
+  const toAddress = randomAddressGenerator.generateRandomAddress();
+
+  const event: MintWithTokenHash = changetype<MintWithTokenHash>(
+    newMockEvent()
+  );
+  event.address = TEST_CONTRACT_ADDRESS;
+  event.transaction.hash = TEST_TX_HASH;
+  event.logIndex = BigInt.fromI32(0);
+  event.parameters = [
+    new ethereum.EventParam("_to", ethereum.Value.fromAddress(toAddress)),
+    new ethereum.EventParam(
+      "_tokenId",
+      ethereum.Value.fromUnsignedBigInt(tokenId)
+    ),
+    new ethereum.EventParam(
+      "_tokenHash",
+      ethereum.Value.fromFixedBytes(TEST_TOKEN_HASH)
+    )
+  ];
+
+  handleMintWithTokenHash(event);
+
+  assert.fieldEquals(
+    TOKEN_ENTITY_TYPE,
+    fullTokenId,
+    "owner",
+    toAddress.toHexString()
+  );
+
+  // Verify token hash was sourced from the event, not an RPC call
+  assert.fieldEquals(
+    TOKEN_ENTITY_TYPE,
+    fullTokenId,
+    "hash",
+    TEST_TOKEN_HASH.toHexString()
   );
 
   assert.notInStore(PRIMARY_PURCHASE_ENTITY_TYPE, fullTokenId);


### PR DESCRIPTION
## Description of the change

Update subgraph with new mint event handling.

The new mint event may be emitted from V3 core contracts, and includes token hash. this eliminates an rpc call in the subgraph handler, speeding up indexing of rapid mints.

Legacy testing is added, for consistency with our existing Mint event testing.

ref: https://github.com/ArtBlocks/artblocks-contracts/pull/1956